### PR TITLE
[SUREFIRE-876] avoid using Description.getTestClass()

### DIFF
--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreRunListener.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreRunListener.java
@@ -66,15 +66,15 @@ public class JUnitCoreRunListener
         final ArrayList<Description> children = description.getChildren();
 
         TestSet testSet = new TestSet( description );
-        Class<?> itemTestClass = null;
+        String itemTestClassName = null;
         for ( Description item : children )
         {
             if ( item.isTest() && item.getMethodName() != null )
             {
                 testSet.incrementTestMethodCount();
-                if ( itemTestClass == null )
+                if ( itemTestClassName == null )
                 {
-                    itemTestClass = item.getTestClass();
+                    itemTestClassName = item.getClassName();
                 }
             }
             else if ( item.getChildren().size() > 0 )
@@ -86,9 +86,9 @@ public class JUnitCoreRunListener
                 classMethodCounts.put( item.getClassName(), testSet );
             }
         }
-        if ( itemTestClass != null )
+        if ( itemTestClassName != null )
         {
-            classMethodCounts.put( itemTestClass.getName(), testSet );
+            classMethodCounts.put( itemTestClassName, testSet );
         }
     }
 


### PR DESCRIPTION
Description.getTestClass() uses Class.forName() which
breaks classloader isolation [1,2].
Refactor JUnitCoreRunListener where we only
need the class name anyway to avoid calling
Description.getTestClass().

[1] https://github.com/KentBeck/junit/issues/364
[2] https://bugs.eclipse.org/bugs/show_bug.cgi?id=318299#c8
