### PR TITLE
SUREFIRE-879 maven-surefire-report-plugin fails some times with Concurre...

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -206,7 +206,10 @@ public class TestSetRunListener
     public String getAsString( List<ByteBuffer> byteBufferList )
     {
         StringBuilder stringBuffer = new StringBuilder();
-        for ( ByteBuffer byteBuffer : byteBufferList )
+        // To avoid getting a java.util.ConcurrentModificationException while iterating (see SUREFIRE-879) we need to
+        // iterate over a copy or the elements array. Since the passed in byteBufferList is always wrapped with
+        // Collections.synchronizedList( ) we are guaranteed toArray() is going to be atomic, so we are safe.
+        for ( Object byteBuffer : byteBufferList.toArray() )
         {
             stringBuffer.append( byteBuffer.toString() );
         }


### PR DESCRIPTION
...ntModificationException when running parallel TestNG

The issue is easily fixed by atomically getting the array of elements and iterating over it rather than the list of buffers.
toArray() is atomic in this case because the passed in List happens to always be wrapped by Collections.synchronizedList() (in all trackable usages).

See Jira issue: http://jira.codehaus.org/browse/SUREFIRE-879
