### PR TITLE
[SUREFIRE-927] Added support for TestNG configuration configFailurePolicy

### DIFF
--- a/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/conf/TestNGMapConfigurator.java
+++ b/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/conf/TestNGMapConfigurator.java
@@ -89,6 +89,10 @@ public class TestNGMapConfigurator
             {
                 val = convert( val, Boolean.class );
             }
+			else if ( "configfailurepolicy".equals( key ) )
+            {
+                val = convert( val, String.class );
+            }
             else if ( "group-by-instances".equals( key ) )
             {
                 val = convert( val, Boolean.class );


### PR DESCRIPTION
configFailurePolicy - Whether TestNG should continue to execute the remaining tests in the suite or skip them if an @Before\* method fails.
