### PR TITLE
[SUREFIRE-839] Tests not matching categories would fail build

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire839TestWithoutCategoriesIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire839TestWithoutCategoriesIT.java
@@ -30,4 +30,10 @@ public class Surefire839TestWithoutCategoriesIT
     {
         unpack( "junit48-categories" ).setJUnitVersion( "4.11" ).executeTest().verifyErrorFree( 2 );
     }
+
+    @Test
+    public void classWithoutCategoryForked()
+    {
+        unpack( "junit48-categories" ).setJUnitVersion( "4.11" ).forkOncePerThread().threadCount(2).executeTest().verifyErrorFree( 2 );
+    }
 }

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreWrapper.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreWrapper.java
@@ -19,6 +19,7 @@ package org.apache.maven.surefire.junitcore;
  * under the License.
  */
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.apache.maven.surefire.common.junit4.JUnit4RunListener;
@@ -53,14 +54,19 @@ class JUnitCoreWrapper
 
         try
         {
-            Request req = Request.classes( computer, testsToRun.getLocatedClasses() );
-            if ( filter != null )
+            // in order to support LazyTestsToRun, the iterator must be used
+            Iterator classIter = testsToRun.iterator();
+            while (classIter.hasNext()) 
             {
-                req = req.filterWith( filter );
-            }
+                Request req = Request.classes( computer, new Class[]{ (Class) classIter.next() });
+                if ( filter != null )
+                {
+                    req = req.filterWith( filter );
+                }
 
-            final Result run = junitCore.run( req );
-            JUnit4RunListener.rethrowAnyTestMechanismFailures( run );
+                final Result run = junitCore.run( req );
+                JUnit4RunListener.rethrowAnyTestMechanismFailures( run );
+            }
         }
         finally
         {


### PR DESCRIPTION
Fixed in a way that does not break forkMode=onceperthread (enhanced the IT for that), refined the logic of JUnitCoreProvider.canRunClass (to also detect the BasicTest class from the IT)
