### PR TITLE
[SUREFIRE-933] Fix forkMode onceperthread after SUREFIRE-839

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire839TestWithoutCategoriesIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire839TestWithoutCategoriesIT.java
@@ -28,12 +28,12 @@ public class Surefire839TestWithoutCategoriesIT
     @Test
     public void classWithoutCategory()
     {
-        unpack( "junit48-categories" ).setJUnitVersion( "4.11" ).executeTest().verifyErrorFree( 2 );
+        unpack( "junit48-categories" ).setJUnitVersion( "4.11" ).executeTest().verifyErrorFree( 3 );
     }
 
     @Test
     public void classWithoutCategoryForked()
     {
-        unpack( "junit48-categories" ).setJUnitVersion( "4.11" ).forkOncePerThread().threadCount(2).executeTest().verifyErrorFree( 2 );
+        unpack( "junit48-categories" ).setJUnitVersion( "4.11" ).forkOncePerThread().threadCount( 2 ).executeTest().verifyErrorFree( 3 );
     }
 }

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreProvider.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreProvider.java
@@ -99,7 +99,7 @@ public class JUnitCoreProvider
     public Iterator getSuites()
     {
         final Filter filter = jUnit48Reflector.isJUnit48Available() ? createJUnit48Filter() : null;
-        testsToRun = getSuitesAsList( filter );
+        testsToRun = scanClassPath();
         return testsToRun.iterator();
     }
 
@@ -127,7 +127,7 @@ public class JUnitCoreProvider
             }
             else
             {
-                testsToRun = getSuitesAsList( filter );
+                testsToRun = scanClassPath();
             }
         }
 
@@ -146,48 +146,6 @@ public class JUnitCoreProvider
 
         JUnitCoreWrapper.execute( testsToRun, jUnitCoreParameters, customRunListeners, filter );
         return reporterFactory.close();
-    }
-
-    @SuppressWarnings( "unchecked" )
-    private TestsToRun getSuitesAsList( Filter filter )
-    {
-        List<Class<?>> res = new ArrayList<Class<?>>( 500 );
-        TestsToRun max = scanClassPath();
-        if ( filter == null )
-        {
-            return max;
-        }
-
-        Iterator<Class<?>> it = max.iterator();
-        while ( it.hasNext() )
-        {
-            Class<?> clazz = it.next();
-            if ( canRunClass( filter, clazz ) )
-            {
-                res.add( clazz );
-            }
-        }
-        return new TestsToRun( res );
-    }
-
-    private boolean canRunClass( Filter filter, Class<?> clazz )
-    {
-        final Description d = Description.createSuiteDescription( clazz );
-        if ( filter.shouldRun( d ) )
-        {
-            // if the class-level check passes, we need to check if any methods are left to run
-            for ( Method method : clazz.getMethods() )
-            {
-                final Description testDescription =
-                    Description.createTestDescription( clazz, method.getName(), method.getAnnotations() );
-                if ( filter.shouldRun( testDescription ) )
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     private Filter createJUnit48Filter()


### PR DESCRIPTION
Changed the fix for [SUREFIRE-839] in a way that does not break forkMode=onceperthread (enhanced the IT for that). Tests are now filtered right before handing them over to JUnit. In case of a NoTestsRemainException while filtering the test request, nothing will be handed over to JUnit.

Please note: I have changed the expected number of error free tests in Surefire839TestWithoutCategoriesIT from 2 to 3. 
