### PR TITLE
Fixed tiny doc bug

### DIFF
--- a/maven-surefire-plugin/src/site/apt/examples/testng.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/testng.apt.vm
@@ -53,7 +53,7 @@ Using TestNG
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.3.1</version>
+      <version>5.11</version>
       <scope>test</scope>
       <classifier>jdk15</classifier>
     </dependency>


### PR DESCRIPTION
- Example for TestNG <= 5.11 was using version 6.3.1.
  *\* Fixed to use 5.11
