### PR TITLE
Fix typos and grammatical errors

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkConfiguration.java
@@ -210,7 +210,7 @@ public class ForkConfiguration
 
     /**
      * Replaces expressions <pre>@{property-name}</pre> with the corresponding properties
-     * from the model. This allows late evaluation of property values when the plugin is exexcuted (as compared
+     * from the model. This allows late evaluation of property values when the plugin is executed (as compared
      * to evaluation when the pom is parsed as is done with <pre>${property-name}</pre> expressions).
      *
      * This allows other plugins to modify or set properties with the changes getting picked up by surefire.

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
@@ -483,8 +483,8 @@ public class ForkStarter
                 {
                     // noinspection ThrowFromFinallyBlock
                     throw new RuntimeException(
-                        "The forked VM terminated without saying properly goodbye. VM crash or System.exit called ?"
-                            + "\nCommand was" + cli.toString() );
+                        "The forked VM terminated without properly saying goodbye. VM crash or System.exit called?"
+                            + "\nCommand was " + cli.toString() );
                 }
 
             }

--- a/maven-surefire-plugin/src/site/fml/faq.fml
+++ b/maven-surefire-plugin/src/site/fml/faq.fml
@@ -51,7 +51,7 @@ under the License.
       </answer>
     </faq>
     <faq id="vm-termination">
-      <question>Surefire fails with the message "The forked VM terminated without saying properly goodbye"</question>
+      <question>Surefire fails with the message "The forked VM terminated without properly saying  goodbye"</question>
       <answer>
         <p>
         Surefire does not support tests or any referenced libraries calling System.exit() at any time. If

--- a/surefire-api/src/main/java/org/apache/maven/surefire/booter/ForkingRunListener.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/booter/ForkingRunListener.java
@@ -173,7 +173,7 @@ public class ForkingRunListener
         int i = StringUtils.escapeBytesToPrintable( content, 0, buf, off, len );
         content[i++] = (byte) '\n';
 
-        synchronized ( target ) // See notes about synhronization/thread safety in class javadoc
+        synchronized ( target ) // See notes about synchronization/thread safety in class javadoc
         {
             target.write( header, 0, header.length );
             target.write( content, 0, i );

--- a/surefire-api/src/main/java/org/apache/maven/surefire/providerapi/ProviderParameters.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/providerapi/ProviderParameters.java
@@ -76,7 +76,7 @@ public interface ProviderParameters
     /**
      * Gets a logger intended for console output.
      * <p/>
-     * This output is inteded for provider-oriented messages that are not attached to a single test-set
+     * This output is intended for provider-oriented messages that are not attached to a single test-set
      * and will normally be written to something console-like immediately.
      *
      * @return A console logger

--- a/surefire-api/src/main/java/org/apache/maven/surefire/report/ConsoleOutputCapture.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/report/ConsoleOutputCapture.java
@@ -84,7 +84,7 @@ public class ConsoleOutputCapture
         {
             if ( s == null )
             {
-                s = "null"; // Shamelessy taken from super.print
+                s = "null"; // Shamelessly taken from super.print
             }
             final byte[] bytes = s.getBytes();
             final byte[] join = ByteBuffer.join( bytes, 0, bytes.length, newline, 0, 1 );

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProviderFactory.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProviderFactory.java
@@ -69,7 +69,7 @@ public class ProviderFactory
     {
         final PrintStream orgSystemOut = System.out;
         final PrintStream orgSystemErr = System.err;
-        // Note that System.out/System.err are also read in the "ReporterConfiguration" instatiation
+        // Note that System.out/System.err are also read in the "ReporterConfiguration" instantiation
         // in createProvider below. These are the same values as here.
 
         ProviderFactory providerFactory =

--- a/surefire-integration-tests/src/test/resources/fork-mode-testng/pom.xml
+++ b/surefire-integration-tests/src/test/resources/fork-mode-testng/pom.xml
@@ -41,7 +41,7 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <!-- NOTE: Deliberaty excluding junit to enforce TestNG only tests, cf. SUREFIRE-642 -->
+          <!-- NOTE: Deliberately excluding junit to enforce TestNG only tests, cf. SUREFIRE-642 -->
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
         </exclusion>

--- a/surefire-integration-tests/src/test/resources/testng-junit-together/src/test/java/JunitTest.java
+++ b/surefire-integration-tests/src/test/resources/testng-junit-together/src/test/java/JunitTest.java
@@ -29,7 +29,7 @@ public class JunitTest extends TestCase {
 	Object testObject;
 	
 	/**
-	 * Creats an object instance
+	 * Creates an object instance
 	 */
 	public void setUp()
 	{

--- a/surefire-integration-tests/src/test/resources/testng-junit4-together/src/test/java/Junit4NoRunWithTest.java
+++ b/surefire-integration-tests/src/test/resources/testng-junit4-together/src/test/java/Junit4NoRunWithTest.java
@@ -33,7 +33,7 @@ public class Junit4NoRunWithTest {
 	Object testObject;
 
 	/**
-	 * Creats an object instance
+	 * Creates an object instance
 	 */
 	@Before
 	public void setUp()

--- a/surefire-integration-tests/src/test/resources/testng-junit4-together/src/test/java/Junit4SimpleRunWithTest.java
+++ b/surefire-integration-tests/src/test/resources/testng-junit4-together/src/test/java/Junit4SimpleRunWithTest.java
@@ -36,7 +36,7 @@ public class Junit4SimpleRunWithTest {
 	Object testObject;
 
 	/**
-	 * Creats an object instance
+	 * Creates an object instance
 	 */
 	@Before
 	public void setUp()

--- a/surefire-shadefire/pom.xml
+++ b/surefire-shadefire/pom.xml
@@ -31,7 +31,7 @@
 
   <name>ShadeFire JUnit3 Provider</name>
   <description>A super-shaded junit3 provider that is used by surefire to build itself,
-    that basically has ALL classes relocated to facilitate no API-conflict whatsover with ourself.
+    that basically has ALL classes relocated to facilitate no API-conflict whatsoever with ourself.
     The only remaining point of conflict is around the booter properties file format
   </description>
   <licenses>


### PR DESCRIPTION
I've been having some issues with my JDK and encountered the following message while building:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.14.1:test (default-test) on project logback-core: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.14.1:test failed: The forked VM terminated without saying properly goodbye. VM crash or System.exit called ?
[ERROR] Command was/bin/sh -c cd /usr/home/ecd/repos/misc/logback/logback-core && /usr/local/linux-sun-jdk1.7.0/jre/bin/java -jar /usr/home/ecd/repos/misc/logback/logback-core/target/surefire/surefirebooter6720085623583714622.jar /usr/home/ecd/repos/misc/logback/logback-core/target/surefire/surefire846998716577511588tmp /usr/home/ecd/repos/misc/logback/logback-core/target/surefire/surefire_08386594812885878010tmp
[ERROR] -> [Help 1]
```

The `without saying properly goodbye` and the `Command was/bin/sh` caught my attention. This pull requests fixes those plus some other typos.
