### PR TITLE
Avoid invalid link ids in surefire-report

### DIFF
--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
@@ -31,6 +31,7 @@ import org.apache.maven.doxia.markup.HtmlMarkup;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributeSet;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
+import org.apache.maven.doxia.util.DoxiaUtils;
 import org.apache.maven.reporting.MavenReportException;
 
 /**
@@ -425,7 +426,7 @@ public class SurefireReportGenerator
 
                             if ( failure != null )
                             {
-                                sink.link( "#" + testCase.getFullName() );
+                                sink.link( "#" + toHtmlId( testCase.getFullName() ) );
 
                                 sinkIcon( (String) failure.get( "type" ), sink );
 
@@ -442,7 +443,7 @@ public class SurefireReportGenerator
                             {
                                 sink.tableCell();
 
-                                sinkLink( sink, testCase.getName(), "#" + testCase.getFullName() );
+                                sinkLink( sink, testCase.getName(), "#" + toHtmlId( testCase.getFullName() ) );
 
                                 SinkEventAttributeSet atts = new SinkEventAttributeSet();
                                 atts.addAttribute( SinkEventAttributes.CLASS, "detailToggle" );
@@ -540,7 +541,14 @@ public class SurefireReportGenerator
 
     private String toHtmlId( String id )
     {
-        return id.replace( ".", "_" );
+        if ( DoxiaUtils.isValidId(id) )
+        {
+            return id;
+        }
+        else
+        {
+            return DoxiaUtils.encodeId( id, true );
+        }
     }
 
     private void constructFailureDetails( Sink sink, ResourceBundle bundle, List<ReportTestCase> failureList )
@@ -579,7 +587,7 @@ public class SurefireReportGenerator
 
                 sink.tableCell_();
 
-                sinkCellAnchor( sink, tCase.getName(), tCase.getFullName() );
+                sinkCellAnchor( sink, tCase.getName(), toHtmlId( tCase.getFullName() ) );
 
                 sink.tableRow_();
 


### PR DESCRIPTION
If you are using the Maven Surefire Report Plugin to view your jasmine test results (generated with Jasmine Maven Plugin) as HTML. The generated HTML-Pages look quite good in different browsers but the links on failed tests don't work at all.

The XML containing the jasmine results has whitespace and special chars in the names of the testcases. Theses names are not allowed for HTML-Ids, so the names have to be modified before using them as ids/targets for anchors/links in the generated HTML.

This is only done halfway in the current version of Maven Surefire Report Plugin. The anchors have a modified id. Because the SurefireReportGenerator.java uses sink.anchor() to generate the anchor tags. That function uses DoxiaUtils.encodeId() to encode any illegal character. But the link targets are wrong. SurefireReportGenerator.java uses it's own function toHtmlId() which does not implement the same logic as DoxiaUtils.encodeId().

Fixes included in this commit:
- Call toHtmlId() everytime before using testCase.getFullName() as anchor id or link target.
- Use DoxiaUtils.encodeId() in toHtmlId(), to avoid problems with any illegal char.

Regards,
kermit-the-frog
