### PR TITLE
a way to force the junit runner to stop when there is a test failure

### DIFF
--- a/surefire-providers/common-junit4/src/main/java/org/apache/maven/surefire/common/junit4/JUnit4RunListener.java
+++ b/surefire-providers/common-junit4/src/main/java/org/apache/maven/surefire/common/junit4/JUnit4RunListener.java
@@ -27,6 +27,7 @@ import org.apache.maven.surefire.testset.TestSetFailedException;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -50,6 +51,8 @@ public class JUnit4RunListener
 
     private final JUnit4Reflector jUnit4Reflector = new JUnit4Reflector();
 
+    private RunNotifier runNotifier;
+
     /**
      * Constructor.
      *
@@ -58,6 +61,11 @@ public class JUnit4RunListener
     public JUnit4RunListener( RunListener reporter )
     {
         this.reporter = reporter;
+    }
+
+    public void setNotifier( RunNotifier notifer )
+    {
+        this.runNotifier = notifer;
     }
 
     // Testrun methods are not invoked when using the runner
@@ -114,6 +122,11 @@ public class JUnit4RunListener
             this.reporter.testError( report );
         }
         failureFlag.set( Boolean.TRUE );
+
+        if ( this.runNotifier != null )
+        {
+            this.runNotifier.pleaseStop();
+        }
     }
 
     protected StackTraceWriter createStackTraceWriter( Failure failure )


### PR DESCRIPTION
I'm not sure if this is an acceptable solution, and I _didn't_ add any test cases for this, but it's at least some progress on a **3 year old** request. http://jira.codehaus.org/browse/SUREFIRE-580
- uses pleaseStop() from the RunNotifier, along with a config property in the pom
- doesn't work with Scalatest <=2.1.5 (it works, it's just not very graceful - there is an open issue with Scalatest that is being resolved)
- I'm not sure if TestNG has an equivalent, but it would probably be a similar modification to the Provider
