### PR TITLE
Fix formatting and spelling mistakes in the documentation

### DIFF
--- a/maven-surefire-plugin/src/site/apt/api.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/api.apt.vm
@@ -29,35 +29,37 @@
 
 Maven Surefire Provider API
 
-  As of version 2.7 of surefire, there is a proposed public api available for
-  external providers to use surefire features.
+  As of version 2.7 of Surefire, there is a proposed public API available for
+  external providers to use Surefire features.
 
-  The key features of surefire are forking, reporting and directory/classpath scanning.
+  The key features of Surefire are forking, reporting and directory/classpath scanning.
   The remaining features are implemented in the providers.
 
-  Please note that this API is still subject to change until otherwise declared, even in minor revisions. This would
-  mostly happen to facilitate needs in new providers.
+  Please note that this API is still subject to change until otherwise declared, even in minor revisions.
+  Such changes will mostly happen to facilitate needs of new providers.
 
-* Requirements for a provider
+* Requirements for a Provider
 
   There are three things any provider must fulfill:
 
   * A provider must implement the <<<org.apache.maven.surefire.providerapi.SurefireProvider>>> interface.
 
   * A provider contains a <<<META-INF/services>>> file entry named <<<org.apache.maven.surefire.providerapi.SurefireProvider>>>
-  ( as per {{{http://download.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html}ServiceLoader}}). This file
-  contains the name of the actual provider class.
+  (as per {{{http://download.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html}ServiceLoader}}). This file
+  contains the fully qualified name of the actual provider class.
 
   * The actual provider class contains a one-arg constructor that accepts an instance of
-  <<<org.apache.maven.surefire.providerapi.ProviderParameters>>>. This interface delivers all the surefire feature
-  to the provider implementation, please see the javadoc of this interface for options.
+  <<<org.apache.maven.surefire.providerapi.ProviderParameters>>>. This interface delivers all Surefire features
+  to the provider implementation. Please see the javadoc of this interface for options.
 
-  There are 4 well-known providers within surefire that are also implemented this way, so
-  examples can be found by looking at the surefire source code itself. surefire-junit47 is
+  []
+
+  There are four well-known providers within Surefire that are also implemented this way, so
+  examples can be found by looking at the Surefire source code itself. <<<surefire-junit47>>> is
   the showcase implementation.
 
   The javadoc on the intefaces mentioned in this article should otherwise be sufficient to write a provider.
-  Providers are added as dependencies to the surefire/failsafe plugins.
+  Providers are added as dependencies to the Surefire and Failsafe plugins.
 
 ** API Changes for 2.11
 
@@ -83,8 +85,8 @@ Maven Surefire Provider API
     final TestsToRun scanResult = directoryScanner.locateTestClasses( testClassLoader, testChecker );
 +---+
 
-   from this version ProviderParameters#getDirectoryScanner has been deprecated, and *will* be removed
-   for the next major version.
+   In this version <<<ProviderParameters#getDirectoryScanner>>> has been deprecated, and it *will* be removed
+   for the next major version. Instead, use
 
 +---+
     scanResult = booterParameters.getScanResult();

--- a/maven-surefire-plugin/src/site/apt/developing.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/developing.apt.vm
@@ -1,5 +1,5 @@
   ------
-  Developing surefire
+  Developing Surefire
   ------
   Kristian Rosenvold
   ------
@@ -28,23 +28,23 @@
 
 Developer Center
 
-  When working with surefire, it is necessary to understand a few things:
+  When working with Surefire, it is necessary to understand a few things:
 
-* Multi-Module project
+* Multi-module Project
 
   The plugin is built as part of a multi-module plugin. The generated
-  'project information' will suggest that you check out (e.g.) 
-  http://svn.apache.org/repos/asf/maven/surefire/trunk/${project.artifactId}.
+  "project information" will suggest that you check out (e.g.)
+  {{http://svn.apache.org/repos/asf/maven/surefire/trunk/${project.artifactId}}}.
   In fact, you need to check out (e.g.)
-  http://svn.apache.org/repos/asf/maven/surefire/trunk and
+  {{http://svn.apache.org/repos/asf/maven/surefire/trunk}} and
   build from there.
 
-* Making testcases for demonstrating problems
+* Making Test Cases for Demonstrating Problems
 
   When reporting an issue, it is immensely useful to create a small sample project
   that demonstrates the problem. Surefire already contains a large number of such
   projects, and they can be found at
-  https://svn.apache.org/repos/asf/maven/surefire/trunk/surefire-integration-tests/src/test/resources/
+  {{https://svn.apache.org/repos/asf/maven/surefire/trunk/surefire-integration-tests/src/test/resources/}}.
   Typically you can check out one of the pre-existing projects and run it like this:
 
 +---+
@@ -53,59 +53,58 @@ cd failsafe-buildfail
 mvn -Dsurefire.version=2.12 verify
 +---+
 
-* Attaching a debugger
+* Attaching a Debugger
 
-  Sometimes it's appropriate to attach a remote debugger to the surefire fork to try to determine what
-  is /really/ going on. If you checkout & build trunk, you'd usually do something like this:
+  Sometimes it's appropriate to attach a remote debugger to the Surefire fork to try to determine what
+  is <really> going on. If you checkout and build trunk, you'd usually do something like this:
 
 +---+
   mvn -Dmaven.surefire.debug=true install
 +---+
 
-  Load the source in your IDE, set a breakpoint at the start of ForkedBooter#main and attach
+  Load the source in your IDE, set a breakpoint at the start of <<<ForkedBooter#main>>> and attach
   a debugger to port 5005.
 
-* Tracing forked execution
+* Tracing a Forked Execution
 
-The forked surefire process uses stdio to communicate back to the source. Sometimes when tracking troubles
-it can be helpful to look at just the output of the fork.
+  The forked Surefire process uses standard input and output to communicate back to the source. Sometimes when tracking troubles
+  it can be helpful to look at just the output of the fork.
 
-Ths can be done by running:
+  This can be done by running:
 
 +---+
 mvn -e -X install | grep Forking
 +---+
 
-If you copy the command part of the output, you should be able to re-run the command by just pasting it on
-the command line (you might have to do only the bits after &&).
+  If you copy the command part of the output, you should be able to re-run the command by just pasting it on
+  the command line (you might have to do only the bits after <<<&&>>>).
 
-You can now paste this command on the command line and capture the output of the fork. This may help you
-determine if the problem is in the forked end or the receiving end.
+  You can now paste this command on the command line and capture the output of the fork. This may help you
+  determine if the problem is in the forked end or the receiving end.
 
-If investigating a particular class, you probably want to grep the output of this for the classname.
-Additionally the booter codes (first field) can be seen at
-https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=blob;f=surefire-api/src/main/java/org/apache/maven/surefire/booter/ForkingRunListener.java
+  When investigating a particular class, you probably want to <<<grep>>> the output for the class name.
+  Additionally the booter code (first field) can be seen at
+  {{https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=blob;f=surefire-api/src/main/java/org/apache/maven/surefire/booter/ForkingRunListener.java}}
 
-The second field in the output (after booter code) is the logical channel number, where differnt threads in the fork
-should come in different channels.
+  The second field in the output (after the booter code) is the logical channel number, where different threads in the fork
+  should come in different channels.
 
-* TestCases
+* Test Cases
 
-  All patches to surefire must contain test coverage, either as an integration test
+  All patches to Surefire must contain test coverage, either as an integration test
   or a unit test. All new features (changed/added plugin options) must be covered by
-  and end-to-end integration test.
+  an end-to-end integration test.
 
   There are
-  numerous other integration tests that all operate upon small sample projects in
-  surefire-integration-tests/src/test/resources
+  numerous other integration tests that all operate on small sample projects in
+  <<<surefire-integration-tests/src/test/resources>>>.
 
-  Example integration tests are Surefire141PluggableProvidersIT and the corresponding
-  surefire-integration-tests/src/test/resources/surefire-141-pluggableproviders.
+  Example integration tests are <<<Surefire141PluggableProvidersIT>>> and the corresponding
+  <<<surefire-integration-tests/src/test/resources/surefire-141-pluggableproviders>>>.
 
+* Essential Source Code Reading List
 
-* Essential source code reading list
-
-  Some methods/classes reveal more about the basic working of a piece of code than others. The enclosed classes/methods
+  Some methods/classes reveal more about the basic working of a piece of code than others. The following classes/methods
   are a "reading list" for getting quickly acquainted with the code:
 
 +---+
@@ -117,35 +116,34 @@ ForkedBooter#main
 * JDK Versions
 
   The surefire booter is capable of booting all the way back to jdk1.3. Specifically
-  this means surefire-api, surefire-booter, common-junit3 and surefire-junit3 are
+  this means <<<surefire-api>>>, <<<surefire-booter>>>, <<<common-junit3>>> and <<<surefire-junit3>>> are
   source/target 1.3. The plugin and several providers are 1.5.
-
 
 * Provider Isolation
 
-  Classes in the SUT (Subject Under Test), override any classes within the
-  surefire providers. This means providers using any
-  third party dependencies (other than the test framework itself), should
+  Classes in the SUT (<Subject Under Test>) override any classes within the
+  Surefire providers. This means providers using any
+  third party dependencies (other than the test framework itself) should
   shade these classes to a different package.
 
-* Common provider modules
+* Common Provider Modules
 
-  The surefire-providers module contains common-junitXX modules. These modules
-  depend on the XX version of JUnit and can access the JUnit API's at the correct
+  The <<<surefire-providers>>> module contains <<<common-junitXX>>> modules. These modules
+  depend on the <<<XX>>> version of JUnit and can access the JUnit APIs at the correct
   JUnit version level. Unit tests can also be written that will run with the
   correct JUnit version. At build time, all of the relevant parts of these "common"
-  modules are just shaded into the providers jar files.
+  modules are just shaded into the provider jar files.
 
 * Shadefire
 
   "Shadefire" is the first module to be run in the
-  surefire build. This creates as shaded version of the JUnit provider, and this provider
-  is thereafter used to build surefire itself (As of any release after 2.8). This is
-  because the SUT overrides the provider, and the shadefire provider has been
-  relocated to avoid this overriding when surefire is building itself.
+  Surefire build. This creates as shaded version of the JUnit provider, and this provider
+  is thereafter used to build Surefire itself (as of Surefire 2.8). This is
+  because the SUT overrides the provider, and the Shadefire provider has been
+  relocated to avoid this overriding when Surefire is building itself.
 
-* Deploying/releasing surefire
+* Deploying and Releasing Surefire
 
   Surefire depends on a previous version of itself, which
-  is too advanced for maven 2.2.x dependency resolution, and maven 3.x is
-  required to build surefire
+  is too advanced for the Maven 2.2.x dependency resolution. Thus Maven 3.x is
+  required to build Surefire.

--- a/maven-surefire-plugin/src/site/apt/examples/class-loading.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/class-loading.apt.vm
@@ -1,5 +1,5 @@
   ------
-  Classloading and Forking
+  Class Loading and Forking
   ------
   Dan Fabulich
   ------
@@ -26,16 +26,16 @@
  ~~ NOTE: For help with the syntax of this file, see:
  ~~ http://maven.apache.org/doxia/references/apt-format.html
 
-Classloading and Forking in Maven Surefire
+Class Loading and Forking in Maven Surefire
 
- This page discusses classloading and forking under Maven Surefire which is a shared component used by both
+ This page discusses class loading and forking under Maven Surefire which is a shared component used by both
  the Surefire and Failsafe Maven plugins, with an eye towards troubleshooting problems.
 
 * Executive Summary
 
  If you're having problems, you'll probably want to tinker with these three settings: <<<forkCount>>>, <<<useSystemClassLoader>>>, and <<<useManifestOnlyJar>>>.
 
-* What problem does the Maven Surefire project solve?
+* What Problem does the Maven Surefire Project Solve?
 
  Initially, the problem seems simple enough. Just launch Java with a classpath, like this:
  
@@ -54,64 +54,64 @@ java -classpath foo.jar:bar.jar MyApp
  practical length limitations, as documented in {{{http://jira.codehaus.org/browse/SUREFIRE-727}SUREFIRE-727}}.
  This means most of the length-related problems in this article may be outdated.
 
-* How do people solve this problem in general?
+* Generic Solutions
 
  There are two "tricks" you can use to workaround this problem; both of them can cause other problems in some cases.
 
- 1. <<Isolated Classloader>>: One workaround is to use an isolated classloader.
- Instead of launching MyApp directly, we can launch some other app (a "booter")
+ 1. <<Isolated Class Loader>>: One workaround is to use an isolated class loader.
+ Instead of launching <MyApp> directly, we can launch some other application (a "booter")
  with a much shorter classpath. We can then create a new java.lang.ClassLoader
- (usually a java.net.URLClassLoader) with your classpath configured. The booter
- can then load up MyApp from the classloader; when MyApp refers to other classes,
- they will be automatically loaded from our isolated classloader.
+ (usually a <<<java.net.URLClassLoader>>>) with the desired classpath configured. The booter
+ can then load up <MyApp> from the class loader; when <MyApp> refers to other classes,
+ they will be automatically loaded from our isolated class loader.
  
- The problem with using an isolated classloader is that your classpath isn't
- <really> correct, and some apps can detect this and object. For example, the
- system property <<<java.class.path>>> won't include your jars; if your app notices
+ The problem with using an isolated class loader is that your classpath isn't
+ <really> correct, and some applications can detect this and object. For example, the
+ system property <<<java.class.path>>> won't include your jars; if your application notices
  this, it could cause a problem.
  
- There's another similar problem with using an isolated classloader: any class
+ There's another similar problem with using an isolated class loader: any class
  may call the static method <<<ClassLoader.getSystemClassLoader()>>> and attempt to
- load classes out of that classloader, instead of using the default classloader.
- Classes often do this if they need to create classloaders of their own.
+ load classes out of that class loader, instead of using the default class loader.
+ Classes often do this if they need to create class loaders of their own.
  Unfortunately, Java-based web application servers like Jetty, Tomcat, BEA
  WebLogic and IBM WebSphere are very likely to try to escape the confines of an
- isolated classloader.
+ isolated class loader.
  
- 2. <<Manifest-Only JAR>>: Another workaround is to use a "manifest-only jar." In
- this case, you create a temporary jar that's almost completely empty, except for
- a META-INF/MANIFEST.MF file. Java manifests can contain attributes that the Java
- VM will honor as directives; for example, you can have a "Class-Path" attribute,
- which contains a list of other jars to add to the classpath. So then you can run
+ 2. <<Manifest-Only JAR>>: Another workaround is to use a "manifest-only JAR." In
+ this case, you create a temporary JAR that's almost completely empty, except for
+ a <<<META-INF/MANIFEST.MF>>> file. Java manifests can contain attributes that the Java
+ virtual machine will honor as directives. For example, you can have a <<<Class-Path>>> attribute,
+ which specifies a list of other JARs to add to the classpath. So then you can run
  your code like this:
  
 +---+
 java -classpath booter.jar MyApp
 +---+
   
- This is a bit more realistic, because in this case the system classloader, the
- thread context classloader and the default classloader are all the same; there's
- no possibility of "escaping" the classloader. But this is still a weird
+ This is a bit more realistic, because in this case the system class loader, the
+ thread context class loader and the default class loader are all the same; there's
+ no possibility of "escaping" the class loader. But this is still a weird
  simulation of a "normal" classpath, and it's still possible for apps to notice
  this. Again, <<<java.class.path>>> may not be what you'd expect ("why does it contain
- only one jar?"). Additionally, it's possible to query the system classloader to
- get the list of jars back out of it; your app may be confused if it finds only
+ only one jar?"). Additionally, it's possible to query the system class loader to
+ get the list of jars back out of it; your application may be confused if it finds only
  our <<<booter.jar>>> there!
 
-* Advantages/Disadvantages of each solution
+* Advantages/Disadvantages of each Solution
 
- If your app tries to interrogate its own classloader for a list of jars, it may
- work better under an isolated classloader than it would with a manifest-only
- jar.  However, if your app tries to escape its default classloader, it may not
- work under an isolated classloader at all.
+ If your application tries to interrogate its own class loader for a list of JARs, it may
+ work better under an isolated class loader than it would with a manifest-only
+ JAR.  However, if your application tries to escape its default class loader, it may not
+ work under an isolated class loader at all.
 
- One advantage of using an isolated classloader is that it's the only way to use
- an isolated classloader without forking a separate process, running all of the
+ One advantage of using an isolated class loader is that it's the only way to use
+ an isolated class loader without forking a separate process, running all of the
  tests in the same process as Maven itself.  But that itself can be pretty risky,
  especially if Maven is running embedded in your IDE!
  
  Finally, of course, you could just try to wire up a plain old Java classpath and hope
- it's short enough.  The worst case there is that your classpath might work
+ it's short enough.  In the worst case your classpath might work
  on some machines and not others.  Windows boxes would behave differently from
  Linux boxes; users with short user names might have more success than users
  with long user names, etc.  For this reason, we chose not to make the basic
@@ -123,19 +123,19 @@ java -classpath booter.jar MyApp
  Surefire provides a mechanism for using multiple strategies.  The main parameter that
  determines this is called <<<useSystemClassLoader>>>.  If <<<useSystemClassLoader>>> is
  <<<true>>>, then we use a manifest-only JAR; otherwise, we use an isolated
- classloader.  If you want to use a basic plain old Java classpath, you can set
+ class loader.  If you want to use a basic plain old Java classpath, you can set
  <<<useManifestOnlyJar=false>>> which only has an effect when <<<useSystemClassLoader=true>>>.
 
  The default value for <<<useSystemClassLoader>>> changed between Surefire 2.3 and
  Surefire 2.4, which was a pretty significant change.  In Surefire 2.3,
- <<<useSystemClassLoader>>> was <<<false>>> by default, and we used an isolated classloader.
+ <<<useSystemClassLoader>>> was <<<false>>> by default, and we used an isolated class loader.
  In Surefire 2.4, <<<useSystemClassLoader>>> is <<<true>>> by default.  No value works for
  everyone, but we think this default is an improvement; a bunch of
  hard-to-diagnose bugs get better when we <<<useSystemClassLoader=true>>>.
 
- Unfortunately, if <<<useSystemClassLoader>>> is set incorrectly for your app, you're going to
+ Unfortunately, if <<<useSystemClassLoader>>> is set incorrectly for your application, you're going to
  have a problem on your hands that can be quite difficult to diagnose.  You might
- even be forced to read a long doc page like this one.  ;-)
+ even be forced to read a long documentation page like this one.  ;-)
 
  If you're having problems loading classes, try setting <<<useSystemClassLoader=false>>>
  to see if that helps.  You can do that with the POM snippet below, or by setting
@@ -163,12 +163,12 @@ java -classpath booter.jar MyApp
 
 * Debugging Classpath Problems
 
- If you've read this far, you're probably fully equipped to diagnose problems that may occur during classloading.  Here's some general tips to try:
+ If you've read this far, you're probably fully equipped to diagnose problems that may occur during class loading.  Here's some general tips to try:
 
- * Run mvn with --debug (aka -X) to get more detailed output
+ * Run Maven with <<<--debug>>> (or equivalently, <<<-X>>>) to get more detailed output
 
- * Check your <<<forkCount>>>.  If <<<forkCount=0>>> (or <<<forkMode=never>>>, the deprecated version of that), it's impossible to use the system classloader or a plain old Java classpath; we have to use an isolated classloader.
+ * Check your <<<forkCount>>>.  If <<<forkCount=0>>> (or <<<forkMode=never>>>, the deprecated version of that), it's impossible to use the system class loader or a plain old Java classpath; we have to use an isolated class loader.
 
  * If you're using the defaults, <<<useSystemClassLoader=true>>> and <<<useManifestOnlyJar=false>>>.  In that case, look at the generated manifest-only Surefire booter JAR.  Open it up (it's just a zip) and read its manifest.
 
- * Run mvn with -Dmaven.${thisPlugin.toLowerCase()}.debug, and attach to the running process with a debugger.
+ * Run Maven with <<<-Dmaven.${thisPlugin.toLowerCase()}.debug>>>, and attach to the running process with a debugger.

--- a/maven-surefire-plugin/src/site/apt/examples/configuring-classpath.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/configuring-classpath.apt.vm
@@ -28,7 +28,7 @@
 
 The Default Classpath
 
-  The surefire plugin builds the test classpath in the following order:
+  The Surefire plugin builds the test classpath in the following order:
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
   [[1]] The {{{../test-mojo.html#testClassesDirectory}test-classes}} directory
@@ -48,10 +48,10 @@ The Default Classpath
 Additional Classpath Elements
 
   If you need to put more stuff in your classpath when ${thisPlugin} executes (e.g some funky resources or a container specific JAR),
-  we normally recommend you add it to your classpath as a dependency.  Consider deploying shared jars to a private remote repository for your
+  we normally recommend you add it to your classpath as a dependency.  Consider deploying shared JARs to a private remote repository for your
   organization.
 
-  But, if you must, you can use the <<<additionalClasspathElements>>> element to add custom resources/jars to your classpath.
+  But, if you must, you can use the <<<additionalClasspathElements>>> element to add custom resources/JARs to your classpath.
   This will be treated as an absolute file system path, so you may want use $\{basedir\} or another property combined with a relative path.
   Note that additional classpath elements are added to the end of the classpath, so you cannot use these to
   override project dependencies or resources.
@@ -82,7 +82,7 @@ Removing Dependency Classpath Elements
 
   Dependencies can be removed from the test classpath using the parameters <<<classpathDependencyExcludes>>> and
   <<<classpathDependencyScopeExclude>>>.  A list of specific dependencies can be removed from the
-  classpath by specifying the groupId:artifactId to be removed.
+  classpath by specifying the <<<groupId:artifactId>>> to be removed.
 
 +---+
 <project>

--- a/maven-surefire-plugin/src/site/apt/examples/debugging.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/debugging.apt.vm
@@ -64,7 +64,7 @@ mvn -Dmaven.${thisPlugin.toLowerCase()}.debug="-Xdebug -Xrunjdwp:transport=dt_so
 
 Non-forked Tests
 
-  You can force Maven not to fork tests by setting the configuration parameter <<<forkCount>>> to <0>.
+  You can force Maven not to fork tests by setting the configuration parameter <<<forkCount>>> to 0.
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
 +---+
@@ -76,7 +76,7 @@ mvn -DforkCount=0 verify
 +---+
 #{end}
 
-  Then all you need to do is debug Maven itself.  Since Maven 2.0.8, Maven has shipped with a "mvnDebug" shell script that you can
+  Then all you need to do is debug Maven itself.  Since Maven 2.0.8, Maven ships with a <<<mvnDebug>>> shell script that you can
   use to launch Maven with convenient debugging options:
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")

--- a/maven-surefire-plugin/src/site/apt/examples/fork-options-and-parallel-execution.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/fork-options-and-parallel-execution.apt.vm
@@ -46,30 +46,30 @@ Fork Options and Parallel Test Execution
   The most obvious one is by using the <<<parallel>>> parameter. The possible
   values depend on the test provider used. For JUnit 4.7 and onwards, this may
   be <<<methods>>>, <<<classes>>>, <<<both>>>, <<<suites>>>,
-  <<<suitesAndClasses>>>, <<<suitesAndMethods>>>, <<<classesAndMethods>>>,
+  <<<suitesAndClasses>>>, <<<suitesAndMethods>>>, <<<classesAndMethods>>> or
   <<<all>>>.
-  As of surefire 2.16, the value "both" is deprecated but it still can be
+  As of Surefire 2.16, the value "<<<both>>>" is deprecated but it still can be
   used and behaves same as <<<classesAndMethods>>>.
 
   See the example pages for {{{./junit.html#Running_tests_in_parallel}JUnit}}
   and {{{./testng.html#Running_tests_in_parallel}TestNG}} for details.
 
   The <extent> of the parallelism is configured using the following parameters.
-  The parameter <<<useUnlimitedThreads>>> declares the unlimited number of
-  threads. Unless <<<useUnlimitedThreads>>> is set to "true", the parameter
+  The parameter <<<useUnlimitedThreads>>> allows for an unlimited number of
+  threads. Unless <<<useUnlimitedThreads>>> is set to "<<<true>>>", the parameter
   <<<threadCount>>> can be used with the optional parameter
   <<<perCoreThreadCount>>>.
-  The parameters <<<useUnlimitedThreads>>>, <<<threadCount>>> make sense with
-  thereinbefore value specified in the parameter <<<parallel>>>.
+  The parameters <<<useUnlimitedThreads>>> and <<<threadCount>>> are to be interpreted
+  in the context of the value specified for the <<<parallel>>> parameter.
   
-  You can impose thread-count limitations on suites, classes or methods if you
-  configure some of the parameters <<<threadCountSuites>>>,
-  <<<threadCountClasses>>> or <<<threadCountMethods>>>.
-  If the only <<<threadCount>>> is specified, the surefire attempts to estimate
-  thread-counts for suites, classes and methods and reuse the threads in favor
+  One can impose thread-count limitations on suites, classes or methods
+  using one or more of the parameters <<<threadCountSuites>>>,
+  <<<threadCountClasses>>> and <<<threadCountMethods>>>.
+  If only <<<threadCount>>> is specified, Surefire attempts to estimate the
+  thread counts for suites, classes and methods and reuses the threads in favor
   of a leaf, e.g. parallel methods (possibly increasing concurrent methods).
   
-  As an example with unlimited number of threads, there is maximum of three
+  As an example with an unlimited number of threads, there is maximum of three
   concurrent threads to execute suites:
   parallel = all, useUnlimitedThreads = true, threadCountSuites = 3.
   

--- a/maven-surefire-plugin/src/site/apt/examples/inclusion-exclusion.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/inclusion-exclusion.apt.vm
@@ -34,30 +34,30 @@ Inclusions and Exclusions of Tests
   with the following wildcard patterns:
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
-   * <<<"**/Test*.java">>> - includes all of its subdirectories and all java
+   * <<<"**/Test*.java">>> - includes all of its subdirectories and all Java
    filenames that start with "Test".
 
-   * <<<"**/*Test.java">>> - includes all of its subdirectories and all java
+   * <<<"**/*Test.java">>> - includes all of its subdirectories and all Java
    filenames that end with "Test".
 
-   * <<<"**/*TestCase.java">>> - includes all of its subdirectories and all java
+   * <<<"**/*TestCase.java">>> - includes all of its subdirectories and all Java
    filenames that end with "TestCase".
 
 #{else}
-   * <<<"**/IT*.java">>> - includes all of its subdirectories and all java
+   * <<<"**/IT*.java">>> - includes all of its subdirectories and all Java
    filenames that start with "IT".
 
-   * <<<"**/*IT.java">>> - includes all of its subdirectories and all java
+   * <<<"**/*IT.java">>> - includes all of its subdirectories and all Java
    filenames that end with "IT".
 
-   * <<<"**/*ITCase.java">>> - includes all of its subdirectories and all java
+   * <<<"**/*ITCase.java">>> - includes all of its subdirectories and all Java
    filenames that end with "ITCase".
 
 #{end}
 
    []
 
-  If the test classes does not go with the naming convention, then configure
+  If the test classes do not follow any of these naming conventions, then configure
   ${thisPlugin} Plugin and specify the tests you want to include.
 
 +---+
@@ -85,7 +85,7 @@ Inclusions and Exclusions of Tests
 
   There are certain times when some tests are causing the build to fail.
   Excluding them is one of the best workarounds to continue the build.
-  Exclusions can be done by configuring the <<excludes>> property of the
+  Exclusions can be done by configuring the <<<excludes>>> property of the
   plugin.
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
@@ -134,7 +134,7 @@ Inclusions and Exclusions of Tests
 +---+
 #{end}
 
-* Regular expression support
+* Regular Expression Support
 
   An include/exclude pattern can be an ant-style path expression, but
   regular expressions are also supported through this syntax:
@@ -160,5 +160,5 @@ Inclusions and Exclusions of Tests
 </project>
 +---+
 
-  Note the syntax %regex[expr], where expr is the actual expression and the rest is just wrapping. Also
-  note that regex matches are done over .class files and not .java files.
+  Note the syntax <<<%regex[expr]>>>, where <<<expr>>> is the actual expression and the rest is just wrapping. Also
+  note that regex matches are done over <<<*.class>>> files and not <<<*.java>>> files.

--- a/maven-surefire-plugin/src/site/apt/examples/junit.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/junit.apt.vm
@@ -38,7 +38,7 @@ Using JUnit
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.1</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
   [...]
@@ -47,28 +47,28 @@ Using JUnit
 
 
   This is the only step that is required to get started - you can now create tests in your test source directory
-  (eg, <<<src/test/java>>>).
+  (e.g., <<<src/test/java>>>).
 
 * Different Generations of JUnit support
 
   Surefire supports three different generations of JUnit: JUnit 3.8.x, JUnit 4.x (serial provider) and JUnit 4.7 (junit-core provider
   with parallel support). The provider is selected based on the JUnit version in your project and the configuration parameters (for parallel).
 
-* Upgrade check for JUnit 4.x
+* Upgrade Check for JUnit 4.x
 
   As of Surefire version 2.7, the algorithm for choosing which tests to run
   has changed. From 2.7 and on, only valid JUnit tests are run for all versions of JUnit, where older versions
   of the plugin would also run invalid tests that satisfied the naming convention.
 
   When upgrading from a Surefire version prior to 2.7, the build can be run with
-  the flag -Dsurefire.junit4.upgradecheck. This will perform a check and notify you of any invalid tests that
+  the flag <<<-Dsurefire.junit4.upgradecheck>>>. This will perform a check and notify you of any invalid tests that
   will not be run with this version of Surefire (and the build fails). This is only meant to be used as a tool
   when upgrading to check that all expected tests will be run. It is a transitional
   feature that will be removed in a future version of surefire.
 
-* How is the provider chosen ?
+* Provider Selection
 
-   If nothing is configured, surefire detects which junit version to use by the following algorithm:
+   If nothing is configured, Surefire detects which JUnit version to use by the following algorithm:
 
 +---+
 if the JUnit version in the project >= 4.7 and the parallel attribute has ANY value
@@ -81,13 +81,13 @@ else
 
     Please note that the "else" part of this algorithm is also a FAQ response:
 
-    You depend on the appropriate version of JUnit being present in the project dependencies, or surefire may choose the wrong
+    You depend on the appropriate version of JUnit being present in the project dependencies, or Surefire may choose the wrong
     provider. If, for instance, one of your dependencies pulls in JUnit 3.8.1 you risk that surefire chooses the
     3.8.1 provider, which will not support annotations or any of the 4.x features.
 
-    Use mvn dependency:tree, pom dependency ordering and/or and exclusion of transitive dependencies to fix this problem.
+    Use <<<mvn dependency:tree>>>, POM dependency ordering and/or exclusion of transitive dependencies to fix this problem.
 
-** Manually specifying a provider
+** Manually Specifying a Provider
 
    You can also manually force a specific provider by adding it as a dependency to ${thisPlugin} itself:
 
@@ -113,9 +113,9 @@ else
   When using this technique there  is no check that the proper test-frameworks are present on your project's
   classpath. Failing to add the proper test-frameworks will result in a build failure.
 
-* Running tests in parallel
+* Running Tests in Parallel
 
-  From JUnit 4.7 and onwards you can run your tests in parallel. To do this, you must set the
+  From JUnit 4.7 onwards you can run your tests in parallel. To do this, you must set the
   <<<parallel>>> parameter, and may change the <<<threadCount>>> or <<<useUnlimitedThreads>>> attribute.
   For example:
 
@@ -136,22 +136,22 @@ else
 +---+
 
 
-  If your tests specify any value for the "parallel" attribute and your project uses JUnit 4.7+, your request will be routed to
-  the concurrent JUnit provider, which uses the JUnit JUnitCore testrunner.
+  If your tests specify any value for the <<<parallel>>> attribute and your project uses JUnit 4.7+, your request will be routed to
+  the concurrent JUnit provider, which uses the JUnit JUnitCore test runner.
 
   This is particularly useful for slow tests that can have high concurrency.
 
-  As of surefire 2.7, no additional dependencies are needed to use the full set of options with parallel.
-  As of surefire 2.16, new thread-count attributes are introduced, namely <<<threadCountSuites>>>, <<<threadCountClasses>>> and
-  <<<threadCountMethods>>>. Additionally new attributes, <<<parallelTestsTimeoutInSeconds>>> and
-  <<<parallelTestsTimeoutForcedInSeconds>>>, are used to shutdown the parallel execution after an elapsed timeout, and 
-  the attribute "parallel" specifies new values.
+  As of Surefire 2.7, no additional dependencies are needed to use the full set of options with parallel.
+  As of Surefire 2.16, new thread-count attributes are introduced, namely <<<threadCountSuites>>>, <<<threadCountClasses>>> and
+  <<<threadCountMethods>>>. Additionally, the new attributes <<<parallelTestsTimeoutInSeconds>>> and
+  <<<parallelTestsTimeoutForcedInSeconds>>> are used to shut down the parallel execution after an elapsed timeout, and
+  the attribute <<<parallel>>> specifies new values.
   
   See also {{{./fork-options-and-parallel-execution.html}Fork Options and Parallel Test Execution}}.
 
-* Using custom listeners and reporters
+* Using Custom Listeners and Reporters
 
-  JUnit4/4.7 provider provides support for attaching custom RunListeners to your tests.
+  The junit4 and junit47 providers provide support for attaching custom <<<RunListeners>>> to your tests.
 
   You can configure multiple custom listeners like this:
 
@@ -174,13 +174,14 @@ else
 </plugins>
 +---+
 
-* Using a security manager (JUnit3 only)
+* Using a Security Manager (JUnit3 only)
 
-   As long as forkCount!=0 and you use JUnit3, you can run your tests with a java security manager active.
-   The classname of the security manager must be sent as a system property variable to the JUnit3 provider.
+   As long as <<<forkCount>>> is not 0 and you use JUnit3, you can run your tests with a Java security manager enabled.
+   The class name of the security manager must be sent as a system property variable to the JUnit3 provider.
 
-   JUnit4 uses mechanisms internally that are not compatible with the tested security managers and is not supported
-   by surefire.
+   JUnit4 uses mechanisms internally that are not compatible with the tested
+   security managers and thus this means of configuring a security manager with JUnit4 is not supported
+   by Surefire.
 
 +---+
 <plugins>
@@ -199,10 +200,10 @@ else
 </plugins>
 +---+
 
-* Using a security manager (All providers)
+* Using a Security Manager (All providers)
 
-    Alternatively you can define a policy file that allows all providers to run with surefire
-    and send them using the argLine parameter and two system properties;
+    Alternatively you can define a policy file that allows all providers to run with Surefire
+    and configure it using the <<<argLine>>> parameter and two system properties:
 
 +---+
 <plugins>
@@ -225,7 +226,7 @@ else
 * Using JUnit Categories
 
     JUnit 4.8 introduced the notion of Categories. You can use JUnit categories by using the <<<groups>>> parameter. As long as 
-    the JUnit version in the project is 4.8 or higher, the presence of the "groups" parameter will automatically make surefire select 
+    the JUnit version in the project is 4.8 or higher, the presence of the "groups" parameter will automatically make Surefire select
     the junit47 provider, which supports groups.
 
 +---+
@@ -272,6 +273,6 @@ else
     }
 +---+
 
-  The @Category annotation can also be applied at class-level.
+  The <<<@Category>>> annotation can also be applied at class-level.
 	
   For more information on JUnit, see the {{{http://www.junit.org}JUnit web site}}.

--- a/maven-surefire-plugin/src/site/apt/examples/pojo-test.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/pojo-test.apt.vm
@@ -1,5 +1,5 @@
-   ------
-  Using POJO tests
+  ------
+  Using POJO Tests
   ------
   Christian Gruber
   ------
@@ -26,19 +26,19 @@
  ~~ NOTE: For help with the syntax of this file, see:
  ~~ http://maven.apache.org/doxia/references/apt-format.html  
 
-Defining a POJO Test
+Using POJO Tests
 
   POJO tests look very much like JUnit or TestNG tests, though they do not
   require dependencies on these artifacts.  A test class should be named
   <<<**/*Test>>> and should contain <<<test*>>> methods which will each be 
-  executed by surefire.  
+  executed by Surefire.
   
   Validating assertions can be done using the JDK 1.4 <<<assert>>> keyword.
   Simultaneous test execution is not possible with POJO tests.
   
-  Fixture can be setup before and after each <<<test*>>> method by implementing
-  a set-up and a tear-down method.  These methods must match these signatures 
-  to be recognized and executed before and after each test method.
+  Fixtures can be setup before and after each <<<test*>>> method by implementing
+  a set-up and a tear-down methods.  These methods must match the following signatures
+  to be recognized and executed before and after each test method:
      
 +---+
 public void setUp();
@@ -47,4 +47,3 @@ public void tearDown();
 
   These fixture methods can also throw any exception and will still be valid.
 
-  

--- a/maven-surefire-plugin/src/site/apt/examples/providers.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/providers.apt.vm
@@ -1,5 +1,5 @@
  ------
- Selecting providers
+ Selecting Providers
  ------
  Kristian Rosenvold <krosenvold@apache.org>
  ------
@@ -26,16 +26,16 @@
  ~~ NOTE: For help with the syntax of this file, see:
  ~~ http://maven.apache.org/doxia/references/apt-format.html 
 
-Selecting providers
+Selecting Providers
 
-* Selecting a provider
+* Selecting a Provider
 
   Surefire normally automatically selects which test-framework provider to use based on the version of
   TestNG/JUnit present in your project's classpath. In some cases it may be desirable to manually
   override such a selection. This can be done by adding the required provider as a dependency to
   the surefire-plugin.
 
-  The following example shows how to force the junit 4.7 provider:
+  The following example shows how to force usage of the Junit 4.7 provider:
 
 +---+
 <plugins>
@@ -56,9 +56,9 @@ Selecting providers
 </plugins>
 +---+
 
-  The providers supplied with surefire are surefire-junit3, surefire-junit4, surefire-junit47 and surefire-testng.
+  The providers supplied with Surefire are <<<surefire-junit3>>>, <<<surefire-junit4>>>, <<<surefire-junit47>>> and <<<surefire-testng>>>.
   Please note that forcing a provider still requires that the test framework is properly set up on your project classpath.
 
   You can also specify multiple providers as dependencies, and they will all be run and produce a common report.
-  This may be especially handy with external providers, since there are few use-cases for combining the included providers.
+  This may be especially handy with external providers, since there are few use cases for combining the included providers.
 

--- a/maven-surefire-plugin/src/site/apt/examples/single-test.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/single-test.apt.vm
@@ -73,13 +73,13 @@ mvn -Dit.test=ITSquare,ITCi*le verify
 +---+
 #{end}
 
-Running a set of methods in a Single Test Class
+Running a Set of Methods in a Single Test Class
 
-  With version 2.7.3, you can run only n tests in a single Test Class.
+  As of Surefire 2.7.3, you can also run only a subset of the tests in a test class.
   
-  << NOTE : it's supported for junit 4.x and TestNG. >>
+  << NOTE : This feature is supported only for Junit 4.x and TestNG. >>
   
-  You must use the following syntax
+  You must use the following syntax:
   
 #{if}(${project.artifactId}=="maven-surefire-plugin")
 +---+
@@ -103,7 +103,7 @@ mvn -Dit.test=ITCircle#test* verify
 +---+
 #{end}
 
-  As of surefire 2.12.1, you can select multiple methods (JUnit4X only at this time, patches welcome)
+  As of Surefire 2.12.1, you can select multiple methods (JUnit 4.x only at this time; patches welcome!):
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
 +---+

--- a/maven-surefire-plugin/src/site/apt/examples/skipping-test.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/skipping-test.apt.vm
@@ -1,5 +1,5 @@
   ------
-  Skipping Test
+  Skipping Tests
   ------
   Johnny Ruiz
   Brett Porter
@@ -52,16 +52,16 @@ Skipping Tests
 </project>
 +---+
 
- You can also skip the tests via command line by executing the following command:
+ You can also skip the tests via the command line by executing the following command:
 
 +---+
 mvn install -DskipTests
 +---+
 
 #{if}(${project.artifactId}=="maven-failsafe-plugin")
- Since <<<skipTests>>> is also followed by the ${thatPlugin} Plugin, this will have the effect
+ Since <<<skipTests>>> is also supported by the ${thatPlugin} Plugin, this will have the effect
  of not running any tests.  If, instead, you want to skip only the integration tests
- being run by the ${thisPlugin} Plugin, you would use the <<<skipITs>>> property
+ being run by the ${thisPlugin} Plugin, you would use the <<<skipITs>>> property instead:
 
 +---+
 mvn install -DskipITs
@@ -75,7 +75,7 @@ mvn install -DskipITs
 mvn install -Dmaven.test.skip=true
 +---+
 
-Skipping by default
+Skipping by Default
 
    If you want to skip tests by default but want the ability to re-enable tests from the
    command line, you need to go via a properties section in the pom:
@@ -109,4 +109,4 @@ Skipping by default
 mvn install -DskipTests=false
 +---+
 
-   The same can be done with the "skip" parameter and other booleans on the plugin.
+   The same can be done with the <<<skip>>> parameter and other boolean properties of the plugin.

--- a/maven-surefire-plugin/src/site/apt/examples/system-properties.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/system-properties.apt.vm
@@ -34,7 +34,7 @@ Using System Properties
 * systemPropertyVariables
 
   This configuration is the replacement of the deprecated <<<systemProperties>>>.  It can accept any value
-  from Maven's properties that can be converted <<to String value>>.
+  from Maven's properties that can be converted <<to a String value>>.
 
 +---+
 <project>
@@ -60,7 +60,7 @@ Using System Properties
 +---+
 
 
-* systemProperties ( deprecated )
+* systemProperties ( Deprecated )
 
 +---+
 <project>
@@ -87,10 +87,10 @@ Using System Properties
 </project>
 +---+
 
-  Take note that only <<String valued>> properties can be passed as system
-  properties. Any attempt to pass any other Maven variable type (i.e. <<<List>>>
+  Take note that only <<String typed>> properties can be passed as system
+  properties. Any attempt to pass any other Maven variable type (e.g. a <<<List>>>
   or a <<<URL>>> variable) will cause the variable expression to be passed
-  literally (unevaluated). So having the example below:
+  literally (unevaluated). So given the example below:
 
 +---+
 <project>
@@ -116,11 +116,11 @@ Using System Properties
 </project>
 +---+
 
-  will literally pass <<$\{project.build.outputDirectory\}>> because the value
+  The string <<$\{project.build.outputDirectory\}>> will be passed on literally because the type
   of that expression is a <<<File>>>, not a <<<String>>>.
 
-  To inherit the "systemProperties" collection from the parent configuration,
-  you will need to specify combine.children="append" on the systemProperties node in the child pom:
+  To inherit the <<<systemProperties>>> collection from the parent configuration,
+  you will need to specify <<<combine.children="append">>> on the <<<systemProperties>>> node in the child pom:
 
 +---+
   <systemProperties combine.children="append">
@@ -130,10 +130,10 @@ Using System Properties
    </systemProperties>
 +---+
 
-Special VM properties
+Special VM Properties
 
   Some system properties must be set on the command line of the forked VM, and cannot be set after the
-  VM has been started. These properties must be added to the argLine parameter of the surefire plugin.
+  VM has been started. These properties must be added to the <<<argLine>>> parameter of the Surefire plugin. E.g.,
 
 +---+
   <argLine>-Djava.endorsed.dirs=...</argLine>

--- a/maven-surefire-plugin/src/site/apt/examples/testng.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/testng.apt.vm
@@ -38,7 +38,7 @@ Using TestNG
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.3.1</version>
+      <version>6.8.8</version>
       <scope>test</scope>
     </dependency>
   [...]
@@ -65,11 +65,11 @@ Using TestNG
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
   This is the only step that is required to get started - you can now create tests in your test source directory
-  (eg, <<<src/test/java>>>. As long as they are named using the defaults such as <<<*Test.java>>> they will be run
+  (e.g., <<<src/test/java>>>). As long as they are named in accordance with the defaults such as <<<*Test.java>>> they will be run
   by ${thisPlugin} as TestNG tests.
 #{else}
   This is the only step that is required to get started - you can now create tests in your test source directory
-  (eg, <<<src/test/java>>>. As long as they are named using the defaults such as <<<*IT.java>>> they will be run
+  (e,g., <<<src/test/java>>>). As long as they are named in accordance with the defaults such as <<<*IT.java>>> they will be run
   by ${thisPlugin} as TestNG tests.
 #{end}
 
@@ -102,7 +102,7 @@ Using TestNG
 
 * Specifying Test Parameters
 
-  Your TestNG test can accept parameters with the @Parameters annotation.  You can also pass parameters from Maven
+  Your TestNG test can accept parameters with the <<<@Parameters>>> annotation.  You can also pass parameters from Maven
   into your TestNG test, by specifying them as system properties, like this:
 
 +---+
@@ -146,7 +146,7 @@ Using TestNG
 
   Likewise, the <<<excludedGroups>>> parameter can be used to run all but a certain set of groups.
 
-* Running tests in parallel
+* Running Tests in Parallel
 
   TestNG allows you to run your tests in parallel, including JUnit tests. To do this, you must set the
   <<<parallel>>> parameter, and may change the <<<threadCount>>> parameter if the default of 5 is not sufficient.
@@ -168,12 +168,12 @@ Using TestNG
 </plugins>
 +---+
 
-  This is particularly useful for slow tests that can have high concurrency, or to quickly and roughly assess the independance
+  This is particularly useful for slow tests that can have high concurrency, or to quickly and roughly assess the independence
   and thread safety of your tests and code.
 
   See also {{{./fork-options-and-parallel-execution.html}Fork Options and Parallel Test Execution}}.
 
-* Using custom listeners and reporters
+* Using Custom Listeners and Reporters
 
   TestNG provides support for attaching custom listeners, reporters, annotation transformers and method interceptors to your tests.
   By default, TestNG attaches a few basic listeners to generate HTML and XML reports.

--- a/maven-surefire-plugin/src/site/apt/featurematrix.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/featurematrix.apt.vm
@@ -1,3 +1,7 @@
+  ------
+  Feature Matrix
+  ------
+
 ~~ Licensed to the Apache Software Foundation (ASF) under one
 ~~ or more contributor license agreements.  See the NOTICE file
 ~~ distributed with this work for additional information
@@ -18,13 +22,13 @@
 ~~ NOTE: For help with the syntax of this file, see:
 ~~ http://maven.apache.org/doxia/references/apt-format.html
 
-Feature matrix
+Feature Matrix
 
     Not all features are supported for all test frameworks, and the following table gives a brief overview
     of support status:
 
 *---------------------------------------------+-----------+-----------+------------+-----------+----------+
-|| <<Feature>>                                ||<<JUnit3>>||<<JUnit4>>||<<Junit47>>||<<TestNG>>||<<Pojo>> |
+|| <<Feature>>                                ||<<JUnit3>>||<<JUnit4>>||<<Junit47>>||<<TestNG>>||<<POJO>> |
 *---------------------------------------------+------------+----------+------------+-----------+----------+
 | groups/category support                     |     N      |    N     |      Y     |    Y      |  N       |
 *---------------------------------------------+------------+----------+------------+-----------+----------+
@@ -38,9 +42,9 @@ Feature matrix
 *---------------------------------------------+------------+----------+------------+-----------+----------+
 
 
-    Legend: Y means supported, N means not supported. ? means not tested.
+    Legend: "Y" means supported, "N" means not supported. "?" means not tested.
 
     If you would like to implement support for
-    a given provider with an N or a ? (or create tests for it), you should create a patch and mark the issue is an
-    improvement. If there is something wrong with an implementation marked with "Y" it's a bug.
+    a given provider with an "N" or a "?" (or create tests for it), you should create a patch and mark the issue as an
+    improvement. If there is something wrong with an implementation marked with "Y" that is considered a bug.
 

--- a/maven-surefire-plugin/src/site/apt/index.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/index.apt.vm
@@ -33,9 +33,9 @@ Maven ${thisPlugin} Plugin
 #{if}(${project.artifactId}=="maven-surefire-plugin")
   The Surefire Plugin is used during the <<<test>>> phase of the build
   lifecycle to execute the unit tests of an application. It generates reports
-  in 2 different file formats:
+  in two different file formats:
 #{else}
-  The Failsafe Plugin is designed to run integration tests while the Surefire Plugins is designed to run unit tests.
+  The Failsafe Plugin is designed to run integration tests while the Surefire Plugin is designed to run unit tests.
   The name (failsafe) was chosen both because it is a synonym of surefire and because it implies that when it fails, it
   does so in a safe way.
 
@@ -56,9 +56,9 @@ Maven ${thisPlugin} Plugin
 
   The Failsafe Plugin is used during the <<<integration-test>>> and <<<verify>>> phases of the build
   lifecycle to execute the integration tests of an application. The Failsafe Plugin will not fail the build during
-  the <<<integration-test>>> phase thus enabling the <<<post-integration-test>>> phase to execute.
+  the <<<integration-test>>> phase, thus enabling the <<<post-integration-test>>> phase to execute.
 
-  NOTE: when running integration tests, you should invoke maven with the (shorter to type too)
+  NOTE: when running integration tests, you should invoke Maven with the (shorter to type too)
 
 +---+
 mvn verify
@@ -67,7 +67,7 @@ mvn verify
   rather than trying to invoke the <<<integration-test>>> phase directly, as otherwise the <<<post-integration-test>>>
   phase will not be executed.
 
-  The Failsafe Plugin generates reports in 2 different file formats:
+  The Failsafe Plugin generates reports in two different file formats:
 
 #{end}
 
@@ -85,14 +85,14 @@ mvn verify
 * Goals Overview
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
-  The Surefire Plugin has only 1 goal:
+  The Surefire Plugin has only one goal:
 
   * {{{./test-mojo.html}surefire:test}} runs the unit tests of an application.
 
   []
 
 #{else}
-  The Failsafe Plugin has only 2 goals:
+  The Failsafe Plugin has only two goals:
 
   * {{{./integration-test-mojo.html}failsafe:integration-test}} runs the integration tests of an application.
 
@@ -105,7 +105,7 @@ mvn verify
 * Usage
 
   General instructions on how to use the ${thisPlugin} Plugin can be found on the {{{./usage.html}usage page}}. Some more
-  specific use cases are described in the examples given below.
+  specific use cases are described in the examples listed below.
   #{if}(${project.artifactId}=="maven-surefire-plugin") Last but not least, users occasionally contribute
   additional examples, tips or errata to the
   {{{http://docs.codehaus.org/display/MAVENUSER/Surefire+Plugin}plugin's wiki page}}.#{end}
@@ -115,7 +115,7 @@ mvn verify
   already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching
   the {{{./mail-lists.html}mail archive}}.
 
-  If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our
+  If you feel like the plugin is missing a feature or has a defect, you can file a feature request or bug report in our
   {{{./issue-tracking.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your
   concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason,
   entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
@@ -125,7 +125,7 @@ mvn verify
 
 * Examples
 
-  The following examples show how to use the ${thisPlugin} Plugin in more advanced use-cases:
+  The following examples show how to use the ${thisPlugin} Plugin in more advanced use cases:
 
   * {{{./examples/testng.html}Using TestNG}}
 
@@ -139,7 +139,7 @@ mvn verify
 
   * {{{./examples/single-test.html}Running a Single Test}}
 
-  * {{{./examples/class-loading.html}Class Loading Issues}}
+  * {{{./examples/class-loading.html}Class Loading and Forking}}
 
   * {{{./examples/debugging.html}Debugging Tests}}
 
@@ -147,6 +147,8 @@ mvn verify
 
   * {{{./examples/configuring-classpath.html}Configuring the Classpath}}
 
-  * {{{./examples/providers.html}Selecting providers}}
+  * {{{./examples/providers.html}Selecting Providers}}
+
+  * {{{./examples/fork-options-and-parallel-execution.html}Fork Options and Parallel Test Execution}}
 
   []

--- a/maven-surefire-plugin/src/site/apt/usage.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/usage.apt.vm
@@ -31,8 +31,8 @@
 Usage
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
-  Best practice is to define the version of the Surefire plugin that you want to use in either your <<<pom.xml>>>
-  or a parent <<<pom.xml>>>
+  Best practice is to define the version of the Surefire Plugin that you want to use in either your <<<pom.xml>>>
+  or a parent <<<pom.xml>>>:
 
 +---+
 <project>
@@ -54,7 +54,7 @@ Usage
 
 #{else}
   To use the ${thisPlugin} Plugin, you need to add the following configuration to
-  your <<<pom.xml>>>
+  your <<<pom.xml>>>:
 
 +---+
 <project>
@@ -98,7 +98,7 @@ mvn verify
 +---+
 #{end}
 
-* Using different testing providers
+* Using Different Testing Providers
 
   Tests in your test source directory can be any combination of the following:
 
@@ -109,7 +109,7 @@ mvn verify
    * POJO
 
   Which providers are available is controlled simply by the inclusion of the
-  appropriate dependencies (ie, junit:junit for JUnit, org.testng:testng 4.7+
+  appropriate dependencies (i.e., <<<junit:junit>>> or <<<junit:junit-dep>>> for JUnit and <<<org.testng:testng>>> 4.7+
   for TestNG). Since this is required to compile the test classes anyway, no
   additional configuration is required.
 
@@ -118,11 +118,11 @@ mvn verify
   Surefire results report on your project web site for your TestNG tests,
   for example.
 
-  The POJO provider above allows you to write tests that do not depend on
-  JUnit. They behave in the same way, running all <<<test*>>> methods that are
+  The POJO provider above allows you to write tests that do not depend on either of
+  JUnit and TestNG. It behaves in the same way, running all <<<test*>>> methods that are
   public in the class, but the API dependency is not required. To perform
   assertions, the JDK 1.4 <<<assert>>> keyword can be used.
-  See {{{./examples/pojo-test.html} using POJO tests}} for more information.
+  See {{{./examples/pojo-test.html} Using POJO Tests}} for more information.
 
   All of the providers support the Surefire Plugin parameter configurations.
   However, there are additional options available if you are running TestNG
@@ -135,7 +135,7 @@ mvn verify
 * Using jetty and ${project.artifactId}
 
   You need to bind one of <<<jetty:run>>>, <<<jetty:run-exploded>>> or <<<jetty:run-war>>>
-  to the <<<pre-integration-test>>> phase with <<<deamon>>> set to true, bind
+  to the <<<pre-integration-test>>> phase with <<<daemon>>> set to true, bind
   <<<failsafe:integration-test>>> to the <<<integration-test>>> phase, bind <<<jetty:stop>>>
   to the <<<post-integration-test>>> phase and finally bind <<<failsafe:verify>>> to
   the <<<verify>>> phase.  Here is an example:
@@ -212,8 +212,8 @@ mvn verify
 </project>
 +---+
 
-  You then invoke maven with a phase of <<<verify>>> or later in order to run
-  the integration tests.  DO NOT directly invoke any of the phases:
+  You then invoke Maven with a phase of <<<verify>>> or later in order to run
+  the integration tests.  <<DO NOT>> directly invoke any of the phases
   <<<pre-integration-test>>>, <<<integration-test>>>, or <<<post-integration-test>>> as
   these are too long to type and they will likely leave a jetty container running.
 
@@ -350,12 +350,12 @@ mvn verify
 </project>
 +---+
 
-* Using in multi-module projects
+* Usage in multi-module projects
 
   The recommendations for using the ${thisPlugin} Plugin listed at the top of this page are fine for 95% of use cases.
   When you are defining a shared definition of the ${thisPlugin} Plugin in a parent pom, it is considered best practice
   to define an execution id in order to allow child projects to override the configuration. Thus you might have the
-  following in your parent <<<pom.xml>>>
+  following in your parent <<<pom.xml>>>:
 
 +---+
 <project>

--- a/maven-surefire-plugin/src/site/fml/faq.fml
+++ b/maven-surefire-plugin/src/site/fml/faq.fml
@@ -51,27 +51,27 @@ under the License.
       </answer>
     </faq>
     <faq id="vm-termination">
-      <question>Surefire fails with the message "The forked VM terminated without properly saying  goodbye"</question>
+      <question>Surefire fails with the message "The forked VM terminated without properly saying goodbye".</question>
       <answer>
         <p>
-        Surefire does not support tests or any referenced libraries calling System.exit() at any time. If
-        they do so, they are incompatible with surefire and you should probably file an issue with the library/vendor.
+        Surefire does not support tests or any referenced libraries calling <code>System.exit()</code> at any time. If
+        they do so, they are incompatible with Surefire and you should probably file an issue with the library/vendor.
 
-        Alternatively the forked VM could also crash for a number of reasons, which can also make this issue happen.
-        Look for the classical "hs_err*" files indicating VM crashes or examine the log output from running maven
+        Alternatively the forked VM could also have crashed for a number of reasons.
+        Look for the classical "<code>hs_err*</code>" files indicating VM crashes or examine the Maven log output
         when the tests execute. Some "extraordinary" output from crashing processes may be dumped to the console/log.
 
-        If this happens on a CI environment and only after some time runs there is a fair chance your test suite is
-        leaking some kind of OS-level resource that makes things worse for every run. Regular os-level monitoring tools
+        If this happens on a CI environment and only after it runs for some time, there is a fair chance your test suite is
+        leaking some kind of OS-level resource that makes things worse at every run. Regular OS-level monitoring tools
         may give you some indication.
         </p>
       </answer>
     </faq>
     <faq id="GWT">
-      <question>How can I run GWT tests ?</question>
+      <question>How can I run GWT tests?</question>
       <answer>
         There is a specific gwt-maven-plugin at codehaus, but if you want to run
-        with surefire, you need the following settings:
+        with Surefire, you need the following settings:
         <p>
         Use the following configuration:<br/>
         <code>
@@ -79,16 +79,16 @@ under the License.
         <![CDATA[ <useManifestOnlyJar>false</useManifestOnlyJar>]]><br/>
         <![CDATA[ <forkCount>1</forkCount>]]><br/>
         </code>
-        try reuseForks=true and if it doesn't work, fall back to reuseForks=false
+        Try <code>reuseForks=true</code> and if it doesn't work, fall back to <code>reuseForks=false</code>
         </p>
       </answer>
     </faq>
     <faq id="late-property-evaluation">
-      <question>How do I use properties set by other plugins in argLine?</question>
+      <question>How do I use properties set by other plugins in <code>argLine</code>?</question>
       <answer>
         <p>
           Maven does property replacement for <pre>${...}</pre> values in pom.xml before any
-          plugin is run. So surefire would never see the place-holders in its argLine property.
+          plugin is run. So Surefire would never see the place-holders in its argLine property.
         </p>
         <p>
           Using an alternate syntax for these properties, <pre>@{...}</pre> allows late replacement

--- a/maven-surefire-plugin/src/site/markdown/newerrorsummary.md
+++ b/maven-surefire-plugin/src/site/markdown/newerrorsummary.md
@@ -19,9 +19,10 @@ report of the run or the files on disk.
       Test2.test6281:33 Runtime FailHere
 
 The main rules of the format are:
- * Assertion failures only show the message
- * Exception/Error is stripped from the Exception name to save space.
+
+ * Assertion failures only show the message.
+ * An Exception/Error is stripped from the Exception name to save space.
  * The exception message is trimmed to an approximate 80 chars.
- * The » symbol means that the exception happened below the method shown (in library code called by test)
- * Methods in superclasses are normally shown as SuperClassName.methodName
- * If the first method in the stacktrace is in a a superclass it will be show as this: TestClass>Superclass.method
+ * The » symbol means that the exception happened below the method shown (in library code called by test).
+ * Methods in superclasses are normally shown as `SuperClassName.methodName`.
+ * If the first method in the stacktrace is in a superclass it will be show as `TestClass>Superclass.method`.

--- a/maven-surefire-plugin/src/site/site.xml
+++ b/maven-surefire-plugin/src/site/site.xml
@@ -31,7 +31,7 @@
       <item name="Introduction" href="index.html"/>
       <item name="Goals" href="plugin-info.html"/>
       <item name="Usage" href="usage.html"/>
-      <item name="Feature matrix" href="featurematrix.html"/>
+      <item name="Feature Matrix" href="featurematrix.html"/>
       <item name="API" href="api.html"/>
       <item name="FAQ" href="faq.html"/>
       <item name="Developing" href="developing.html"/>
@@ -39,15 +39,16 @@
     <menu name="Examples">
       <item name="Using TestNG" href="examples/testng.html"/>
       <item name="Using JUnit" href="examples/junit.html"/>
+      <item name="Using POJO Tests" href="examples/pojo-test.html"/>
       <item name="Skipping Tests" href="examples/skipping-test.html"/>
       <item name="Inclusions and Exclusions of Tests" href="examples/inclusion-exclusion.html"/>
       <item name="Running a Single Test" href="examples/single-test.html"/>
-      <item name="Class Loading Issues" href="examples/class-loading.html"/>
+      <item name="Class Loading and Forking" href="examples/class-loading.html"/>
       <item name="Debugging Tests" href="examples/debugging.html"/>
-      <item name="System Properties" href="examples/system-properties.html"/>
+      <item name="Using System Properties" href="examples/system-properties.html"/>
       <item name="Configuring the Classpath" href="examples/configuring-classpath.html"/>
-      <item name="Selecting providers" href="examples/providers.html"/>
-      <item name="New error summary" href="newerrorsummary.html"/>
+      <item name="Selecting Providers" href="examples/providers.html"/>
+      <item name="New Error Summary" href="newerrorsummary.html"/>
       <item name="Fork Options and Parallel Test Execution" href="examples/fork-options-and-parallel-execution.html"/>
     </menu>
   </body>

--- a/maven-surefire-report-plugin/src/site/apt/examples/changing-report-name.apt.vm
+++ b/maven-surefire-report-plugin/src/site/apt/examples/changing-report-name.apt.vm
@@ -1,5 +1,5 @@
   ------
-  Changing Report Name
+  Changing the Report Name
   ------
   Allan Ramirez
   ------
@@ -23,11 +23,11 @@
 ~~ NOTE: For help with the syntax of this file, see:
 ~~ http://maven.apache.org/doxia/references/apt-format.html
 
-Changing Report Name
+Changing the Report Name
 
   In order to configure the file name of the generated report (which is
-  <"surefire-report"> by default), the <<outputName>> property should
-  be set to its new name.
+  "<surefire-report>" by default), the <<outputName>> property should
+  be set to the desired name.
 
 +----+
 <project>
@@ -39,7 +39,7 @@ Changing Report Name
         <artifactId>maven-surefire-report-plugin</artifactId>
         <version>${project.version}</version>
         <configuration>
-          <outputName>newname</outputName>
+          <outputName>desired_name</outputName>
         </configuration>
       </plugin>
     </plugins>
@@ -48,5 +48,5 @@ Changing Report Name
 </project>
 +----+
 
-  And after executing the <<<mvn site>>>, the generated report file is named
-  to <<newname.html>>.
+  And after executing <<<mvn site>>>, the generated report file is named
+  <<desired_name.html>>.

--- a/maven-surefire-report-plugin/src/site/apt/examples/cross-referencing.apt.vm
+++ b/maven-surefire-report-plugin/src/site/apt/examples/cross-referencing.apt.vm
@@ -25,11 +25,11 @@
 
 Source Code Cross Reference
 
-  There are times when we need to know right away the line number of the
-  source code that caused the failure of the test. The Surefire Report Plugin
+  There are times when we wish to know right away the line number of the
+  source code that caused a test to the fail. The Surefire Report Plugin
   has the capability to cross reference the source code that made the test
-  failed. To be able to activate it, the <<<maven-jxr-plugin>>> should
-  also be declared in the \<reporting\> section of the POM along with the
+  fail. In order to activate this feature, the <<<maven-jxr-plugin>>> should
+  be declared in the <<<\<reporting\>>>> section of the POM along with the
   <<<maven-surefire-report-plugin>>>. For more details, please read the
   documentation of the
   {{{http://maven.apache.org/plugins/maven-jxr-plugin/}Maven JXR Plugin}}.
@@ -58,11 +58,11 @@ Source Code Cross Reference
 </project>
 +----+
 
-  After executing <<<mvn site>>> for site generation, You'll notice that from
-  the <<Failure Details>> section of the report, the link is available to
+  After executing <<<mvn site>>> for site generation, you'll notice that from
+  the <<Failure Details>> section of the report, a link is available to
   redirect you to the source code that caused the failure.
 
-  From the figure below the code that caused the failure is
+  In the figure below the code that caused the failure is
   <com.test.proj.AppTest:36>
 
 [../images/failure-details.PNG] Failure Details
@@ -71,8 +71,8 @@ Source Code Cross Reference
 
 [../images/xref.PNG] The source
 
-* Disable the Cross Reference Link
+* Disabling the Cross Reference Link
 
   To disable the link to the source code, the <<linkXRef>> property should
-  be set to <<false>>. Or another way is by not declaring the
-  <<<maven-jxr-plugin>>> to the \<reporting\> section.
+  be set to <<false>>. Alternatively one may simply omit the
+  <<<maven-jxr-plugin>>> from the <<<\<reporting\>>>> section.

--- a/maven-surefire-report-plugin/src/site/apt/examples/report-custom-location.apt.vm
+++ b/maven-surefire-report-plugin/src/site/apt/examples/report-custom-location.apt.vm
@@ -1,5 +1,5 @@
   ------
-  Custom Location of the Surefire Report
+  Configuring the Output Location of the Report
   ------
   Allan Ramirez
   ------
@@ -23,12 +23,12 @@
 ~~ NOTE: For help with the syntax of this file, see:
 ~~ http://maven.apache.org/doxia/references/apt-format.html
 
-Configuring the Output Location as part of the Project Reports
+Configuring the Output Location of the Report
 
   To change the location of the generated output report along with other
-  project reports. The <<outputDirectory>> property of both
+  project reports the <<outputDirectory>> property of both the
   <<<maven-site-plugin>>> and <<<maven-surefire-report-plugin>>> should be set to the
-  new path. For more information, see the documentation of the
+  desired alternative location. For more information, see the documentation of the
   {{{http://maven.apache.org/plugins/maven-site-plugin/}Maven Site Plugin}}.
 
 +----+
@@ -62,10 +62,10 @@ Configuring the Output Location as part of the Project Reports
   is not configured, the output location of the Surefire report will still
   be the default.
 
-* Configuring the Output Location using Standalone Goal
+* Configuring the Output Location using the Standalone Goal
 
   To change the location of the generated output report using the standalone
-  goal, the <<outputDirectory>> property should be set to the new path.
+  goal, the <<outputDirectory>> property should be set to the new path:
 
 +---+
 mvn surefire-report:report -DoutputDirectory=newpath

--- a/maven-surefire-report-plugin/src/site/apt/examples/show-failures.apt.vm
+++ b/maven-surefire-report-plugin/src/site/apt/examples/show-failures.apt.vm
@@ -1,5 +1,5 @@
   ------
-  Showing Failure Tests
+  Showing Only Failed Tests
   ------
   Allan Ramirez
   ------
@@ -23,10 +23,10 @@
 ~~ NOTE: For help with the syntax of this file, see:
 ~~ http://maven.apache.org/doxia/references/apt-format.html
 
-Showing Failure Tests
+Showing Only Failed Tests
 
-  By default, the Surefire Report Plugin shows all test result status (success
-  and failures) in the generated HTML. To be able to show the failures only, the
+  By default, the Surefire Report Plugin shows the full test result (i.e., successes
+  as well as failures) in the generated HTML. To be able to show the failures only, the
   property <<showSuccess>> should be set to <<false>>.
 
 +----+
@@ -50,7 +50,7 @@ Showing Failure Tests
 
   Then execute <<<mvn site>>> for the report generation.
 
-  It can also be set via commandline with the standalone goal.
+  It can also be set via command line with the standalone goal:
 
 +----+
   mvn surefire-report:report -DshowSuccess=false

--- a/maven-surefire-report-plugin/src/site/apt/index.apt
+++ b/maven-surefire-report-plugin/src/site/apt/index.apt
@@ -26,12 +26,12 @@
 Maven Surefire Report Plugin
 
   The Surefire Report Plugin parses the generated <<<TEST-*.xml>>> files under
-  <<<$\{basedir\}/target/surefire-reports>>> and renders them to DOXIA
+  <<<$\{basedir\}/target/surefire-reports>>> and renders them using DOXIA,
   which creates the web interface version of the test results.
 
 * Goals Overview
 
-  Surefire Report Plugin only has one goal (the other is a workaround):
+  The Surefire Report Plugin only has one goal (the other is a workaround):
 
   * {{{./report-mojo.html}surefire-report:report}} Generates the test
   results report into HTML format.
@@ -40,15 +40,15 @@ Maven Surefire Report Plugin
   not run the tests, it only builds the reports. It is provided as a work 
   around for {{{http://jira.codehaus.org/browse/SUREFIRE-257}SUREFIRE-257}}
 
-  <Note:> As of version 2.8 this plugin requires Maven Site Plugin 2.1 or higher to work properly. Version 2.7.2 and
-  older are still compatible with newer surefire versions, so mixing is possible.
-
   []
+
+  <Note:> As of version 2.8 this plugin requires Maven Site Plugin 2.1 or newer to work properly. Version 2.7.2 and
+  older are still compatible with newer Surefire versions, so mixing is possible.
 
 * Usage
 
   General instructions on how to use the Surefire Report Plugin can be found on the {{{./usage.html}usage page}}. Some more
-  specific use cases are described in the examples given below. Last but not least, users occasionally contribute
+  specific use cases are described in the examples listed below. Last but not least, users occasionally contribute
   additional examples, tips or errata to the
   {{{http://docs.codehaus.org/display/MAVENUSER/Surefire+Report+Plugin}plugin's wiki page}}.
 
@@ -57,7 +57,7 @@ Maven Surefire Report Plugin
   already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching
   the {{{./mail-lists.html}mail archive}}.
 
-  If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our
+  If you feel like the plugin is missing a feature or has a defect, you can file a feature request or bug report in our
   {{{./issue-tracking.html}issue tracker}}. When creating a new issue, please provide a comprehensive description of your
   concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason,
   entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
@@ -67,11 +67,11 @@ Maven Surefire Report Plugin
 
 * Examples
 
-  The following examples show how to use the Surefire Report Plugin in more advanced usecases:
+  The following examples show how to use the Surefire Report Plugin in more advanced use cases:
 
-  * {{{./examples/show-failures.html}Showing Failure Tests}}
+  * {{{./examples/show-failures.html}Showing Only Failed Tests}}
 
-  * {{{./examples/changing-report-name.html}Changing Report Name}}
+  * {{{./examples/changing-report-name.html}Changing the Report Name}}
 
   * {{{./examples/report-custom-location.html}Configuring the Output Location of the Report}}
 

--- a/maven-surefire-report-plugin/src/site/apt/usage.apt.vm
+++ b/maven-surefire-report-plugin/src/site/apt/usage.apt.vm
@@ -25,10 +25,10 @@
 
 Usage
 
-* Generate the report as part of Project Reports
+* Generate the Report as Part of Project Reports
 
   To generate the Surefire report as part of the site generation, add the following in
-  the \<reporting\> section of your POM:
+  the <<<\<reporting\>>>> section of your POM:
 
 +---+
 <project>
@@ -46,14 +46,14 @@ Usage
 </project>
 +---+
 
-  When the <<<mvn site>>> is invoked, the report will be automatically
+  When <<<mvn site>>> is invoked, the report will automatically be
   included in the Project Reports menu as shown in the figure below.
 
 [images/surefire-sample1.PNG] Sample Surefire Report
 
-* Generate the report as standalone
+* Generate the Report in a Standalone Fashion
 
-  The Surefire report can also generate the report using its standalone goal:
+  The plugin can also generate the report using its standalone goal:
 
 +---+
 mvn surefire-report:report  

--- a/maven-surefire-report-plugin/src/site/fml/faq.fml
+++ b/maven-surefire-report-plugin/src/site/fml/faq.fml
@@ -22,13 +22,12 @@ under the License.
 <faqs id="FAQ" title="Frequently Asked Questions">
   <part id="General">
     <faq id="question">
-      <question>The Surefire Report Plugin reruns test. Is this its desired behavior?</question>
+      <question>The Surefire Report Plugin reruns tests. Is this its desired behavior?</question>
       <answer>
         <p>
-          No. This is a very known issue for the plugin. Please see
+          No. This is a well-known issue with older versions of the plugin. Please see
           <a href="http://jira.codehaus.org/browse/SUREFIRE-257">SUREFIRE-257</a>
-          for
-          details.
+          for details. Upgrading to version 2.7.2 or newer will resolve this issue.
         </p>
       </answer>
     </faq>

--- a/maven-surefire-report-plugin/src/site/site.xml
+++ b/maven-surefire-report-plugin/src/site/site.xml
@@ -29,8 +29,8 @@
       <item name="FAQ" href="faq.html"/>
     </menu>
     <menu name="Examples">
-      <item name="Showing Failure Tests" href="examples/show-failures.html"/>
-      <item name="Changing Report Name" href="examples/changing-report-name.html"/>
+      <item name="Showing Only Failed Tests" href="examples/show-failures.html"/>
+      <item name="Changing the Report Name" href="examples/changing-report-name.html"/>
       <item name="Configuring the Output Location of the Report" href="examples/report-custom-location.html"/>
       <item name="Source Code Cross Reference" href="examples/cross-referencing.html"/>
     </menu>

--- a/surefire-api/src/site/apt/index.apt
+++ b/surefire-api/src/site/apt/index.apt
@@ -28,7 +28,7 @@ Surefire API
 * Definitions
 
 *-------------+-----------------------------------------------+
-| test method | individual test method within a class         |
+| test method | Individual test method within a class         |
 *-------------+-----------------------------------------------+
 | test        | 1..N test methods in 1 or more classes.       |
 *-------------+-----------------------------------------------+
@@ -39,11 +39,13 @@ Surefire API
 
   How each definition is applied depends on the provider, and the test suite being used.
 
-  Directory test suite: this constructs a single suite from a directory file set. Each discovered class is treated as a test.
+  * Directory test suite: this constructs a single suite from a directory file set. Each discovered class is treated as a test.
 
-  TestNG XML test suite: this constructs a single suite from a testng.xml file. The definitions inside the file will match those above. 
+  * TestNG XML test suite: this constructs a single suite from a <<<testng.xml>>> file. The definitions inside the file will match those above.
 
-  JUnit 3.x: Groups are not supported.
+  * JUnit 3.x: Groups are not supported.
+
+  []
 
   See {{{../surefire-providers/index.html}Surefire Providers}} for more information on specific providers.
 

--- a/surefire-report-parser/pom.xml
+++ b/surefire-report-parser/pom.xml
@@ -31,7 +31,7 @@
   <artifactId>surefire-report-parser</artifactId>
 
   <name>Surefire Report Parser</name>
-  <description>Parses report output files from surefire</description>
+  <description>Parses report output files from surefire.</description>
 
   <prerequisites>
     <maven>2.0.9</maven>

--- a/surefire-shadefire/pom.xml
+++ b/surefire-shadefire/pom.xml
@@ -32,7 +32,7 @@
   <name>ShadeFire JUnit3 Provider</name>
   <description>A super-shaded junit3 provider that is used by surefire to build itself,
     that basically has ALL classes relocated to facilitate no API-conflict whatsoever with ourself.
-    The only remaining point of conflict is around the booter properties file format
+    The only remaining point of conflict is around the booter properties file format.
   </description>
   <licenses>
     <license>


### PR DESCRIPTION
Highlights:
- In `maven-surefire-plugin/src/site/apt/developing.apt.vm`, make sure text is not rendered bold.
- In `maven-surefire-plugin/src/site/markdown/newerrorsummary.md`, ensure proper formatting of the list at the bottom of the page.
- In `maven-surefire-plugin/src/site/site.xml`, add link to "Using POJO Tests" example.
- In `maven-surefire-report-plugin/src/site/fml/faq.fml`, mention that upgrading Surefire will resolve the listed known issue.
- Settle on a consistent title casing for (sub)headings.
- Synchronize page titles with window titles and menu titles, where sensible.
- Fix/make consistent italic/bold/monospace typesetting of various terms.
