### PR TITLE
Break tag to make stack traces formatted

### DIFF
--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
@@ -508,6 +508,7 @@ public class SurefireReportGenerator
                                     for ( String line : detail )
                                     {
                                         sink.text( line );
+                                        sink.unknown( "br", new Object[]{ HtmlMarkup.TAG_TYPE_SIMPLE }, null );
                                         sink.lineBreak();
                                     }
                                     sink.verbatim_();


### PR DESCRIPTION
Breaks would make the stack traces appear properly formatted instead of a single long line of text.