### PR TITLE
Testcase: 'java.io.IOException: Stream Closed' if test's console output exceeds 1Mb

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/Junit4DmKernelRunnerIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/Junit4DmKernelRunnerIT.java
@@ -1,0 +1,46 @@
+package org.apache.maven.surefire.its;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Test;
+
+/**
+ * Test JUnit 4 tests with custom runner and two sequential tests
+ *
+ * @author Vitali Skleenkov
+ */
+public class Junit4DmKernelRunnerIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+
+    @Test
+    public void test()
+    {
+        unpack().setJUnitVersion("4.11")
+        .maven().executeVerify().assertIntegrationTestSuiteResults( 2, 0, 0, 1 );
+    }
+
+    private SurefireLauncher unpack()
+    {
+        return unpack( "/junit411-dmkernel-runner-seq-tests" );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>junit411-dmkernel-runner-seq-tests</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test for JUnit 4.11 with custom runner and two sequential tests</name>
+
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <junitVersion>4.11</junitVersion>
+    <surefire.version>2.17</surefire.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junitVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <executions>
+          <execution>
+            <id>integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <groups>junit4.IntegrationTest</groups>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/src/test/java/junit4/DmKernelRunnerFirstIT.java
+++ b/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/src/test/java/junit4/DmKernelRunnerFirstIT.java
@@ -1,0 +1,41 @@
+package junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@Category({ IntegrationTest.class })
+@RunWith(DmKernelTestRunner.class)
+public class DmKernelRunnerFirstIT {
+
+    @Test
+    public void test() throws InterruptedException
+    {
+        System.out.println("Test 1: Doing some testing...");
+        assertTrue("Obvious first assertion failed", true);
+        System.out.println("Test 1: Done.");
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/src/test/java/junit4/DmKernelRunnerSecondIT.java
+++ b/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/src/test/java/junit4/DmKernelRunnerSecondIT.java
@@ -1,0 +1,40 @@
+package junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@Category({ IntegrationTest.class })
+@RunWith(DmKernelTestRunner.class)
+public class DmKernelRunnerSecondIT {
+
+    @Test
+    public void test() throws InterruptedException
+    {
+        System.out.println("Test 2: Doing some testing...");
+        assertTrue("Obvious second assertion failed", true);
+        System.out.println("Test 2: Done.");
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/src/test/java/junit4/DmKernelTestRunner.java
+++ b/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/src/test/java/junit4/DmKernelTestRunner.java
@@ -1,0 +1,80 @@
+package junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+public class DmKernelTestRunner extends BlockJUnit4ClassRunner {
+
+    public DmKernelTestRunner(Class<?> klass) throws InitializationError
+    {
+        super(klass);
+    }
+
+    @Override
+    public void run(RunNotifier notifier)
+    {
+        try
+        {
+            launchOsgi();
+            Object targetBundleContext = null;
+            Class<?> realTestClass = createOsgiTestClass(targetBundleContext);
+            BlockJUnit4ClassRunner realRunner = new BlockJUnit4ClassRunner(realTestClass);
+            realRunner.run(notifier);
+        } catch (Throwable e)
+        {
+            notifier.fireTestFailure(new Failure(getDescription(), e));
+        } finally
+        {
+            stopOsgi();
+        }
+    }
+
+    private void launchOsgi() throws InterruptedException
+    {
+        System.out.println("Launching OSGi framework for " + getTestClass().getJavaClass().getName());
+        generateOsgiOutput(1100000);
+        System.out.println("Virgo ready for " + getTestClass().getJavaClass().getName());
+    }
+
+    private void stopOsgi()
+    {
+        System.out.println("Shutting down OSGi framework for " + getTestClass().getJavaClass().getName());
+        generateOsgiOutput(1000);
+    }
+
+    private Class<?> createOsgiTestClass(Object targetBundleContext)
+    {
+        return getTestClass().getJavaClass();
+    }
+
+    private void generateOsgiOutput(int n)
+    {
+        for (int i = 0; i < n / 100; i++)
+        {
+            System.out.println(RandomStringUtils.randomAlphabetic(100));
+        }
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/src/test/java/junit4/IntegrationTest.java
+++ b/surefire-integration-tests/src/test/resources/junit411-dmkernel-runner-seq-tests/src/test/java/junit4/IntegrationTest.java
@@ -1,0 +1,25 @@
+package junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public interface IntegrationTest
+{
+
+}


### PR DESCRIPTION
A test case to reproduce 'java.io.IOException: Stream Closed'. Which is thrown when FailSafe runs a couple of integration tests with a custom Junit test runner and their console output exceeds 1Mb.

My comments below might help to pinpoint the cause of the problem.

Applicable only for JUnitCoreRunListener (forced in the provided test case by specifying groups in failsafe's configuration). And only if Test's and/or TestRunner's console output exceeds 1Mb.

If console output exceeds 1Mb limit set on Utf8RecodingDeferredFileOutputStream.deferredFileOutputStream field, the DeferredFileOutputStream will switch from DeferredFileOutputStream.memoryOutputStream to a stream backed by DeferredFileOutputStream.outputFile.

When TestSetRunListener.testSetCompleted event is received, TestSetRunListener will call Utf8RecodingDeferredFileOutputStream.free method that in turn will delete Utf8RecodingDeferredFileOutputStream.deferredFileOutputStream.getFile() file. And for a 'double tap' the same free() method will be called in TestSetStats.reset()

```
    wrap.getStdout().free();
    wrap.getStdErr().free();

    globalStatistics.add( detailsForThis );
    detailsForThis.reset();
```

But having TestSetRunListener.testSetCompleted event received is not a guarantee that Fork is finished. And an output of the next TestSet in the same Fork will be pushed into the already closed stream (backed by DeferredFileOutputStream.outputFile).

Hence, 'java.io.IOException: Stream Closed' exception.

I'm not familiar enough with the surefire's codebase to assert the impact of any fixes I might suggest.
But I think the whole usage of Utf8RecodingDeferredFileOutputStream/DeferredFileOutputStream in TestSetRunListener must be relooked at. I mean, underlying file of DeferredFileOutputStream is meticulously deleted on 'testSetCompleted' event but blissfully discarded in TestSetRunListener.clearCapture() method on testSucceeded, testError, testFailed and testSkipped events.
