### PR TITLE
Fixed NullPointerException on SmartStackTraceParser init occurring when ...

### DIFF
--- a/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/SmartStackTraceParser.java
+++ b/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/SmartStackTraceParser.java
@@ -64,7 +64,8 @@ public class SmartStackTraceParser
     {
         try
         {
-            return Thread.currentThread().getContextClassLoader().loadClass( name );
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            return classLoader != null ? classLoader.loadClass( name ) : null;
         }
         catch ( ClassNotFoundException e )
         {


### PR DESCRIPTION
Failsafe report crushes when Thread.contextCassLoader is null:

ERROR] org.apache.maven.surefire.testset.TestSetFailedException: java.lang.NullPointerException
[ERROR] at org.apache.maven.surefire.common.junit4.JUnit4RunListener.rethrowAnyTestMechanismFailures(JUnit4RunListener.java:206)
[ERROR] at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:129)
[ERROR] at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
[ERROR] at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
[ERROR] at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
[ERROR] Caused by: java.lang.NullPointerException
[ERROR] at org.apache.maven.surefire.report.SmartStackTraceParser.getClass(SmartStackTraceParser.java:67)
[ERROR] at org.apache.maven.surefire.report.SmartStackTraceParser.<init>(SmartStackTraceParser.java:57)
[ERROR] at org.apache.maven.surefire.common.junit4.JUnit4StackTraceWriter.smartTrimmedStackTrace(JUnit4StackTraceWriter.java:77)
