### PR TITLE
SUREFIRE-1028 Unable to run single test (junit)

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1028UnableToRunSingleTest.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1028UnableToRunSingleTest.java
@@ -1,0 +1,59 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Test;
+
+/**
+ * Plugin Configuration: parallel=classes
+ * <p/>
+ * With Surefire 2.15
+ * {@code $ mvn test -Dtest=MyTest#testFoo}
+ * Results :
+ * Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+ * <p/>
+ * With Surefire 2.16
+ * {@code $ mvn test -Dtest=MyTest#testFoo}
+ * <p/>
+ * Results :
+ * Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
+ *
+ * @author <a href="mailto:tibor.digana@gmail.com">Tibor Digana (tibor17)</a>
+ * @see {@linkplain https://jira.codehaus.org/browse/SUREFIRE-1028}
+ * @since 2.18
+ */
+public class Surefire1028UnableToRunSingleTest
+    extends SurefireJUnit4IntegrationTestCase
+{
+
+    @Test
+    public void methodFilteringParallelExecution()
+    {
+        unpack().setTestToRun( "SomeTest#test" ).parallelClasses().useUnlimitedThreads()
+                .executeTest().verifyErrorFree( 1 ).verifyTextInLog( "OK!" );
+    }
+
+    private SurefireLauncher unpack()
+    {
+        return unpack( "surefire-1028-unable-to-run-single-test" );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1028-unable-to-run-single-test/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1028-unable-to-run-single-test/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-1028</artifactId>
+  <version>1.0</version>
+  <name>jiras-surefire-1028</name>
+  <url>http://maven.apache.org</url>
+  <contributors>
+    <contributor>
+      <name>Tibor Digana (tibor17)</name>
+      <email>tibor.digana@gmail.com</email>
+      <timezone>+1</timezone>
+    </contributor>
+  </contributors>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-1028-unable-to-run-single-test/src/test/java/jiras/surefire1028/SomeTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1028-unable-to-run-single-test/src/test/java/jiras/surefire1028/SomeTest.java
@@ -1,0 +1,36 @@
+package jiras.surefire1028;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SomeTest {
+
+    @Test
+    public void test() {
+        System.out.println("OK!");
+    }
+
+    @Test
+    public void filteredOutTest() {
+        Assert.fail();
+    }
+}

--- a/surefire-providers/common-junit48/src/main/java/org/apache/maven/surefire/common/junit48/FilterFactory.java
+++ b/surefire-providers/common-junit48/src/main/java/org/apache/maven/surefire/common/junit48/FilterFactory.java
@@ -128,7 +128,7 @@ public class FilterFactory
         {
             for ( Description o : description.getChildren() )
             {
-                if ( isDescriptionMatch( o ) )
+                if ( isDescriptionMatch( o ) || shouldRun( o ) )
                 {
                     return true;
                 }


### PR DESCRIPTION
Fix for a critical bug:
https://jira.codehaus.org/browse/SUREFIRE-1028

Fixed in subclass `FilterFactory.MethodFilter`.
The nested children need to be scanned with filtering conditions recursively.
The PC uses aggregared structure of JUnit Runners and therefore filtered test methods should be scanned in whole hierarchy.

Problem of this bug: No tests to execute while parallel execution is triggered on filtered test method (see single-test.apt.vm).
`mvn test -Dtest=SomeTest#test`
Plugin configuration:
parallel='classes', useUnlimitedThreads=true
