### PR TITLE
Support for TestNG successPercentage

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestNgSuccessPercentageIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestNgSuccessPercentageIT.java
@@ -1,0 +1,27 @@
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
+
+/**
+ * Test that TestNG's @Test(successPercentage = n, invocationCount=n) passes so long as successPercentage tests
+ * have passed.
+ *
+ * @author Jon Todd
+ */
+public class TestNgSuccessPercentageIT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void testPassesWhenFailuresLessThanSuccessPercentage()
+    {
+        OutputValidator validator = unpack("/testng-succes-percentage-pass").executeTest();
+        validator.assertTestSuiteResults(4, 0, 0, 0);
+    }
+
+    @Test
+    public void testFailsWhenFailuresMoreThanSuccessPercentage()
+    {
+        OutputValidator validator = unpack("/testng-succes-percentage-fail").executeTest();
+        validator.assertTestSuiteResults(4, 0, 1, 0);
+    }
+}

--- a/surefire-integration-tests/src/test/resources/testng-succes-percentage-fail/pom.xml
+++ b/surefire-integration-tests/src/test/resources/testng-succes-percentage-fail/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>junit4</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test for Testng</name>
+
+
+  <properties>
+    <testNgVersion>5.7</testNgVersion>
+    <testNgClassifier>jdk15</testNgClassifier>
+  </properties>
+
+  <profiles>
+    <profile>
+      <id>testng-old</id>
+      <activation>
+        <property><name>testNgClassifier</name></property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>${testNgVersion}</version>
+          <classifier>${testNgClassifier}</classifier>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>testng-new</id>
+      <activation>
+        <property><name>!testNgClassifier</name></property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>${testNgVersion}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>  
+  
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <test>TestNGSuccessPercentTest</test>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-integration-tests/src/test/resources/testng-succes-percentage-fail/src/test/java/testng/TestNGSuccessPercentTest.java
+++ b/surefire-integration-tests/src/test/resources/testng-succes-percentage-fail/src/test/java/testng/TestNGSuccessPercentTest.java
@@ -1,0 +1,44 @@
+package testng;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.testng.annotations.*;
+import static org.testng.Assert.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestNGSuccessPercentTest
+{
+
+    private static AtomicInteger counter = new AtomicInteger(0);
+
+    // Pass 2 of 4 tests, expect this test to fail when 60% success is required
+    @Test(invocationCount = 4, successPercentage = 60)
+    public void testFailure() {
+        if (isOdd(counter.get())) {
+            assertTrue(false); // Fail
+        }
+        counter.addAndGet(1);
+    }
+
+    private boolean isOdd(int number) {
+        return number % 2 == 0;
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/testng-succes-percentage-pass/pom.xml
+++ b/surefire-integration-tests/src/test/resources/testng-succes-percentage-pass/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>junit4</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test for Testng</name>
+
+
+  <properties>
+    <testNgVersion>5.7</testNgVersion>
+    <testNgClassifier>jdk15</testNgClassifier>
+  </properties>
+
+  <profiles>
+    <profile>
+      <id>testng-old</id>
+      <activation>
+        <property><name>testNgClassifier</name></property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>${testNgVersion}</version>
+          <classifier>${testNgClassifier}</classifier>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>testng-new</id>
+      <activation>
+        <property><name>!testNgClassifier</name></property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>${testNgVersion}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>  
+  
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <test>TestNGSuccessPercentTest</test>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-integration-tests/src/test/resources/testng-succes-percentage-pass/src/test/java/testng/TestNGSuccessPercentTest.java
+++ b/surefire-integration-tests/src/test/resources/testng-succes-percentage-pass/src/test/java/testng/TestNGSuccessPercentTest.java
@@ -1,0 +1,44 @@
+package testng;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.testng.annotations.*;
+import static org.testng.Assert.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestNGSuccessPercentTest
+{
+
+    private static AtomicInteger counter = new AtomicInteger(0);
+
+    // Pass 2 of 4 tests, expect this test to pass when 50% success is required
+    @Test(invocationCount = 4, successPercentage = 50)
+    public void testSuccess() {
+        if (isOdd(counter.get())) {
+            assertTrue(false); // Fail
+        }
+        counter.addAndGet(1);
+    }
+
+    private boolean isOdd(int number) {
+        return number % 2 == 0;
+    }
+
+}

--- a/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/TestNGReporter.java
+++ b/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/TestNGReporter.java
@@ -126,7 +126,7 @@ public class TestNGReporter
                                                                   result.getMethod().getMethodName(),
                                                                   result.getThrowable() ) );
 
-        reporter.testError( report );
+        reporter.testSucceeded( report );
     }
 
     public void onStart( ITestContext context )


### PR DESCRIPTION
TestNG has the concept of "successPercentage" where a probabilistic test can be run some number of invocations and then if the successPercentage is met, the test is considered passing.

Example code might look like:

``` java
   @Test(invocationCount = 100, successPercentage = 25)
    void testRandom() {
        // ~50% chance of generating 0 & 1
        int num = new Random().nextInt(2);
        Assert.assertEquals(num, 1);
    }
```

As detailed in SUREFIRE-654, the problem is that surefire is currently mapping each invocation to a new test run, and any failure, regardless of whether we're within the allowed success percentage or not will result in this test failing. This renders any other value for successPercentage aside from 100 useless.

Digging into the code it looks like this was just an oversight in the inital implementation of the TestNGReporter. The TestNG ITestListener#onTestFailedButWithinSuccessPercentage method API stipulates that it will only be called when we're still within the passing limit:

```
Invoked each time a method fails but has been annotated with successPercentage and this failure still keeps it within the success percentage requested.
```

This change maps tests which pass within the successPercentage as passing which is safe because if we go beyond the passing threshold the test will be marked failed as desired.

**What about tests?**
Yes, there are no test changes. It looks like the providers aren't being tested. I'd be happy to add coverage that asserts the correct stubbed reporter method is called but that seems like overkill given the existing testing conventions.

**What about breaking existing users?**
As mentioned earlier, essentially successPercentage wasn't even usable within surefire before, so this should only provide net-new functionality to users. In the example above, before my change that test would fail every time and would result in ~50 failures. After this change the above example would pass so long as there are only 25 or fewer failures.
