### PR TITLE
[SUREFIRE-1098] Fix runOrder=balanced is not working

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1908,7 +1908,6 @@ public abstract class AbstractSurefireMojo
         checksum.add( getSystemProperties() );
         checksum.add( getSystemPropertyVariables() );
         checksum.add( getSystemPropertiesFile() );
-        checksum.add( getProperties() );
         checksum.add( isPrintSummary() );
         checksum.add( getReportFormat() );
         checksum.add( getReportNameSuffix() );


### PR DESCRIPTION
http://jira.codehaus.org/browse/SUREFIRE-1098

The first "getConfigChecksum" in "executeProvider" is calculated with empty properties.
The next "getConfigChecksum" in "createForkStarter" or "createInprocessStarter" is calculated with properties having parameters.
Since the properties are setup in "createStartupConfiguration" called between first and second "getConfigChecksum".
For this reason, runOrder=balanced is not working.

It seems that the "properties" is not necessary for calculating checksum.
The parameters are added directly.

I'm sorry for not writing tests.
It is too difficult for me..
Please help if possible.
