### PR TITLE
[SUREFIRE-1098] Fix runOrder=balanced is not working

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/fixture/OutputValidator.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/fixture/OutputValidator.java
@@ -22,6 +22,7 @@ package org.apache.maven.surefire.its.fixture;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -85,6 +86,12 @@ public class OutputValidator
         {
             throw new SurefireVerifierException( e );
         }
+    }
+
+    public Collection<String> loadLogLines()
+        throws VerificationException
+    {
+        return verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
     }
 
     public List<String> loadFile( File file, Charset charset )

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1098BalancedRunOrderIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1098BalancedRunOrderIT.java
@@ -1,0 +1,119 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.AnyOf.anyOf;
+
+/**
+ * The purpose of this IT is to assert that the run order of test classes is according to the settings:<p/>
+ *
+ * runOrder=balanced<p/>
+ * parallel=classes<p/>
+ * threadCount=2<p/>
+ * perCoreThreadCount=false<p/>
+ * <p/>
+ * The list of tests should be reordered to (DTest, CTest, BTest, ATest) in the second run.
+ *
+ * @author <a href="mailto:tibor.digana@gmail.com">Tibor Digana (tibor17)</a>
+ * @see {@linkplain https://jira.codehaus.org/browse/SUREFIRE-1098}
+ * @since 2.18
+ */
+public class Surefire1098BalancedRunOrderIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+
+    @Test
+    public void reorderedParallelClasses()
+        throws VerificationException
+    {
+        SurefireLauncher launcher = unpack();
+
+        launcher
+            // .runOrder( "balanced" ) call it in 3.x and remove it in surefire-1098-balanced-runorder/pom.xml
+            // as soon as there is prefix available "failsafe" and "surefire" in system property for this parameter.
+            .parallelClasses().threadCount( 2 ).disablePerCoreThreadCount()
+            .executeTest().verifyErrorFree( 4 );
+
+        OutputValidator validator =
+            launcher
+                // .runOrder( "balanced" ) call it in 3.x and remove it in surefire-1098-balanced-runorder/pom.xml
+                // as soon as there is prefix available "failsafe" and "surefire" in system property for this parameter.
+                .parallelClasses().threadCount( 2 ).disablePerCoreThreadCount()
+                .executeTest().verifyErrorFree( 4 );
+
+        List<String> log = printOnlyTestLines( validator );
+        assertThat( log.size(), is( 4 ) );
+        Collections.sort( log );
+        final int[] threadPoolIdsOfLongestTest = extractThreadPoolIds( log.get( 3 ) );
+        final int pool = threadPoolIdsOfLongestTest[0];
+        int thread = threadPoolIdsOfLongestTest[1];
+        assertThat( thread, anyOf( is( 1 ), is( 2 ) ) );
+        thread = thread == 1 ? 2 : 1;
+        // If the longest test class DTest is running in pool-2-thread-1, the others should run in pool-2-thread-2
+        // and vice versa.
+        assertThat( log.get( 0 ), is( testLine( "A", pool, thread ) ) );
+        assertThat( log.get( 1 ), is( testLine( "B", pool, thread ) ) );
+        assertThat( log.get( 2 ), is( testLine( "C", pool, thread ) ) );
+    }
+
+    private SurefireLauncher unpack()
+    {
+        return unpack( "surefire-1098-balanced-runorder" );
+    }
+
+    private static List<String> printOnlyTestLines( OutputValidator validator )
+        throws VerificationException
+    {
+        List<String> log = new ArrayList<String>( validator.loadLogLines() );
+        for ( Iterator<String> it = log.iterator(); it.hasNext(); ) {
+            String line = it.next();
+            if ( !line.startsWith( "class jiras.surefire1098." ) ) {
+                it.remove();
+            }
+        }
+        return log;
+    }
+
+    private static int[] extractThreadPoolIds(String logLine)
+    {
+        //Example to parse "class jiras.surefire1098.DTest pool-2-thread-1" into {2, 1}.
+        String t = logLine.split( " " )[2];
+        String[] ids = t.split( "-" );
+        return new int[]{ Integer.parseInt( ids[1] ), Integer.parseInt( ids[3] )};
+    }
+
+    private String testLine(String test, int pool, int thread)
+    {
+        return String.format( "class jiras.surefire1098.%sTest pool-%d-thread-%d", test, pool, thread );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-1098</artifactId>
+  <version>1.0</version>
+  <url>http://maven.apache.org</url>
+  <contributors>
+    <contributor>
+      <name>Tibor Digana (tibor17)</name>
+      <email>tibor.digana@gmail.com</email>
+      <timezone>+1</timezone>
+    </contributor>
+  </contributors>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.7</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <runOrder>balanced</runOrder>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/src/test/java/jiras/surefire1098/ATest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/src/test/java/jiras/surefire1098/ATest.java
@@ -1,0 +1,34 @@
+package jiras.surefire1098;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public final class ATest {
+
+    @Test
+    public void someMethod() throws InterruptedException {
+        System.out.println(getClass() + " " + Thread.currentThread().getName());
+        TimeUnit.SECONDS.sleep(1);
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/src/test/java/jiras/surefire1098/BTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/src/test/java/jiras/surefire1098/BTest.java
@@ -1,0 +1,34 @@
+package jiras.surefire1098;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public final class BTest {
+
+    @Test
+    public void someMethod() throws InterruptedException {
+        System.out.println(getClass() + " " + Thread.currentThread().getName());
+        TimeUnit.SECONDS.sleep(2);
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/src/test/java/jiras/surefire1098/CTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/src/test/java/jiras/surefire1098/CTest.java
@@ -1,0 +1,34 @@
+package jiras.surefire1098;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public final class CTest {
+
+    @Test
+    public void someMethod() throws InterruptedException {
+        System.out.println(getClass() + " " + Thread.currentThread().getName());
+        TimeUnit.SECONDS.sleep(4);
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/src/test/java/jiras/surefire1098/DTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1098-balanced-runorder/src/test/java/jiras/surefire1098/DTest.java
@@ -1,0 +1,34 @@
+package jiras.surefire1098;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public final class DTest {
+
+    @Test
+    public void someMethod() throws InterruptedException {
+        System.out.println(getClass() + " " + Thread.currentThread().getName());
+        TimeUnit.SECONDS.sleep(8);
+    }
+
+}


### PR DESCRIPTION
Fix for #48 with IT.
Updated documentation for runOrder parameter.
