### PR TITLE
The module surefire-setup-integration-tests fails with Maven 3.2.3

### DIFF
--- a/surefire-setup-integration-tests/pom.xml
+++ b/surefire-setup-integration-tests/pom.xml
@@ -115,7 +115,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-help-plugin</artifactId>
-        <version>2.1</version>
+        <version>2.2</version>
         <executions>
           <execution>
             <id>settings.xml</id>


### PR DESCRIPTION
The module surefire-setup-integration-tests which fails with Maven 3.2.3 due to https://jira.codehaus.org/i#browse/MPH-101
The fix is to upgrade maven-help-plugin to the version 2.2 from 2.1.
