### PR TITLE
[SUREFIRE-797] Parallel junit does not run in parallel when a Suite is used at the top level

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire747MethodParallelWithSuiteCountIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire747MethodParallelWithSuiteCountIT.java
@@ -19,9 +19,19 @@ package org.apache.maven.surefire.its.jiras;
  * under the License.
  */
 
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.apache.maven.surefire.its.fixture.SurefireLauncher;
 import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Kristian Rosenvold
@@ -30,21 +40,72 @@ public class Surefire747MethodParallelWithSuiteCountIT
     extends SurefireJUnit4IntegrationTestCase
 {
 
+    private static Set<String> printTestLines( OutputValidator validator, String pattern )
+        throws VerificationException
+    {
+        Set<String> log = new TreeSet<String>( validator.loadLogLines() );
+        for ( Iterator<String> it = log.iterator(); it.hasNext(); )
+        {
+            String line = it.next();
+            if ( !line.contains( pattern ) )
+            {
+                it.remove();
+            }
+        }
+        return log;
+    }
+
+    private static long duration( String logLine )
+    {
+        return Integer.decode( logLine.split( "=" )[1] );
+    }
+
     @Test
     public void testMethodsParallelWithSuite()
+        throws VerificationException
     {
-        unpack().executeTest().verifyErrorFree( 6 );
+        OutputValidator validator = unpack().executeTest().verifyErrorFree( 6 );
+        Set<String> testLines = printTestLines( validator, "test finished after duration=" );
+        assertThat( testLines.size(), is( 2 ) );
+        for ( String testLine : testLines )
+        {
+            long duration = duration( testLine );
+            long min = 250, max = 750;
+            assertTrue( String.format( "duration %d should be between %d and %d millis", duration, min, max ),
+                        duration > min && duration < max );
+        }
+        Set<String> suiteLines = printTestLines( validator, "suite finished after duration=" );
+        assertThat( suiteLines.size(), is( 1 ) );
+        long duration = duration( suiteLines.iterator().next() );
+        long min = 750, max = 1250;
+        assertTrue( String.format( "duration %d should be between %d and %d millis", duration, min, max ),
+                    duration > min && duration < max );
     }
 
     @Test
     public void testClassesParallelWithSuite()
+        throws VerificationException
     {
-        unpack().parallelClasses().executeTest().verifyErrorFree( 6 );
+        OutputValidator validator = unpack().parallelClasses().executeTest().verifyErrorFree( 6 );
+        Set<String> testLines = printTestLines( validator, "test finished after duration=" );
+        assertThat( testLines.size(), is( 2 ) );
+        for ( String testLine : testLines )
+        {
+            long duration = duration( testLine );
+            long min = 1250, max = 1750;
+            assertTrue( String.format( "duration %d should be between %d and %d millis", duration, min, max ),
+                        duration > min && duration < max );
+        }
+        Set<String> suiteLines = printTestLines( validator, "suite finished after duration=" );
+        assertThat( suiteLines.size(), is( 1 ) );
+        long duration = duration( suiteLines.iterator().next() );
+        long min = 1250, max = 1750;
+        assertTrue( String.format( "duration %d should be between %d and %d millis", duration, min, max ),
+                    duration > min && duration < max );
     }
 
     public SurefireLauncher unpack()
     {
         return unpack( "junit47-parallel-with-suite" );
     }
-
 }

--- a/surefire-integration-tests/src/test/resources/junit47-parallel-with-suite/src/test/java/surefire747/SuiteTest1.java
+++ b/surefire-integration-tests/src/test/resources/junit47-parallel-with-suite/src/test/java/surefire747/SuiteTest1.java
@@ -20,7 +20,9 @@ package surefire747;
  */
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -28,9 +30,24 @@ import org.junit.Test;
  */
 public class SuiteTest1
 {
+    private static long startedAt;
+
     public SuiteTest1()
     {
         System.out.println( "SuiteTest1.constructor" );
+    }
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        startedAt = System.currentTimeMillis();
+    }
+
+    @AfterClass
+    public static void afterClass()
+    {
+        System.out.println( String.format( "%s test finished after duration=%d", SuiteTest1.class.getSimpleName(),
+                                           System.currentTimeMillis() - startedAt ) );
     }
 
     @Before
@@ -50,7 +67,7 @@ public class SuiteTest1
         throws InterruptedException
     {
         System.out.println( "begin SuiteTest1.first" );
-        Thread.sleep( 300 );
+        Thread.sleep( 500 );
         System.out.println( "end SuiteTest1.first" );
     }
 
@@ -59,7 +76,7 @@ public class SuiteTest1
         throws InterruptedException
     {
         System.out.println( "begin SuiteTest1.second" );
-        Thread.sleep( 300 );
+        Thread.sleep( 500 );
         System.out.println( "end SuiteTest1.second" );
     }
 
@@ -68,7 +85,7 @@ public class SuiteTest1
         throws InterruptedException
     {
         System.out.println( "begin SuiteTest1.third" );
-        Thread.sleep( 300 );
+        Thread.sleep( 500 );
         System.out.println( "end SuiteTest1.third" );
     }
 }

--- a/surefire-integration-tests/src/test/resources/junit47-parallel-with-suite/src/test/java/surefire747/SuiteTest2.java
+++ b/surefire-integration-tests/src/test/resources/junit47-parallel-with-suite/src/test/java/surefire747/SuiteTest2.java
@@ -20,7 +20,9 @@ package surefire747;
  */
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -28,9 +30,24 @@ import org.junit.Test;
  */
 public class SuiteTest2
 {
+    private static long startedAt;
+
     public SuiteTest2()
     {
         System.out.println( "SuiteTest2.constructor" );
+    }
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        startedAt = System.currentTimeMillis();
+    }
+
+    @AfterClass
+    public static void afterClass()
+    {
+        System.out.println( String.format( "%s test finished after duration=%d", SuiteTest2.class.getSimpleName(),
+                                           System.currentTimeMillis() - startedAt ) );
     }
 
     @Before
@@ -50,7 +67,7 @@ public class SuiteTest2
         throws InterruptedException
     {
         System.out.println( "begin SuiteTest2.first" );
-        Thread.sleep( 300 );
+        Thread.sleep( 500 );
         System.out.println( "end SuiteTest2.first" );
     }
 
@@ -59,7 +76,7 @@ public class SuiteTest2
         throws InterruptedException
     {
         System.out.println( "begin SuiteTest2.second" );
-        Thread.sleep( 300 );
+        Thread.sleep( 500 );
         System.out.println( "end SuiteTest2.second" );
     }
 
@@ -68,7 +85,7 @@ public class SuiteTest2
         throws InterruptedException
     {
         System.out.println( "begin SuiteTest2.third" );
-        Thread.sleep( 300 );
+        Thread.sleep( 500 );
         System.out.println( "end SuiteTest2.third" );
     }
 }

--- a/surefire-integration-tests/src/test/resources/junit47-parallel-with-suite/src/test/java/surefire747/TestSuite.java
+++ b/surefire-integration-tests/src/test/resources/junit47-parallel-with-suite/src/test/java/surefire747/TestSuite.java
@@ -19,6 +19,8 @@ package surefire747;
  * under the License.
  */
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -33,4 +35,18 @@ import org.junit.runners.Suite;
 })
 public class TestSuite
 {
+    private static long startedAt;
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        startedAt = System.currentTimeMillis();
+    }
+
+    @AfterClass
+    public static void afterClass()
+    {
+        System.out.println( String.format( "%s suite finished after duration=%d", TestSuite.class.getSimpleName(),
+                                           System.currentTimeMillis() - startedAt ) );
+    }
 }


### PR DESCRIPTION
This is not a fix.
Commit only IT.
The IT proves expected behavior in [SUREFIRE-797] since of 2.16.
The IT asserts execution time with parallel=classes or parallel=mehods on test=**/TestSuite.java.
