### PR TITLE
[SUREFIRE-1105] Surefire build should check Java 1.5 API signatures with JDK version > 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,26 @@
           <version>2.5.1</version>
         </plugin>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-maven-plugin</artifactId>
+          <version>1.11</version>
+          <executions>
+            <execution>
+              <id>signature-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <signature>
+              <groupId>org.codehaus.mojo.signature</groupId>
+              <artifactId>java15</artifactId>
+              <version>1.0</version>
+            </signature>
+          </configuration>
+        </plugin>
+        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${shadedVersion}</version>
           <configuration>
@@ -306,6 +326,12 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
   <reporting>


### PR DESCRIPTION
The Maven Surefire project should use animal-sniffer-maven-plugin to check Java 1.5 API signatures.
It has advantages where JDK 8 speeds up the build, however the Java classes are properly compiled to *.class 1.5.

It is going to fix the Jenkins build with currently minimal JDK version 1.5:
[Maven Surefire] $ /opt/jdk/jdk1.5.0_22/bin/java -Xmx1196m -XX:MaxPermSize=512m
Exception in thread "main" java.lang.UnsupportedClassVersionError: Bad version number in .class file

I have extended pluginManagement and plugins section in parent POM.

`````` <plugin>
<groupId>org.codehaus.mojo</groupId>
<artifactId>animal-sniffer-maven-plugin</artifactId>
<version>1.11</version>
<executions>
<execution>
<id>signature-check</id>
<goals>
<goal>check</goal>
</goals>
</execution>
</executions>
<configuration>
<signature>
<groupId>org.codehaus.mojo.signature</groupId>
<artifactId>java15</artifactId>
<version>1.0</version>
</signature>
</configuration>
</plugin>```
``````
