### PR TITLE
[SUREFIRE-649] empty strings in systemPropertyVariables element

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireProperties.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireProperties.java
@@ -171,11 +171,7 @@ public class SurefireProperties
             for ( String key : source.keySet() )
             {
                 String value = source.get( key );
-                //java Properties does not accept null value
-                if ( value != null )
-                {
-                    target.setProperty( key, value );
-                }
+                target.setProperty( key, value == null ? "" : value );
             }
         }
     }

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire649EmptyStringSystemPropertiesIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire649EmptyStringSystemPropertiesIT.java
@@ -1,0 +1,84 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+/**
+ * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
+ * @see {@linkplain https://jira.codehaus.org/browse/SUREFIRE-649}
+ * @since 2.18
+ */
+public class Surefire649EmptyStringSystemPropertiesIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+
+    @Test
+    public void systemProperties()
+        throws VerificationException
+    {
+        SurefireLauncher launcher = unpack1();
+
+        OutputValidator validator = launcher.executeTest().verifyErrorFree( 1 );
+
+        for ( String line : validator.loadLogLines() )
+        {
+            if ( "emptyProperty=''".equals( line ) )
+            {
+                return;
+            }
+        }
+        fail("Could not find text in log: emptyProperty=''");
+    }
+
+    @Test
+    public void systemPropertyVariables()
+        throws VerificationException
+    {
+        SurefireLauncher launcher = unpack2();
+
+        OutputValidator validator = launcher.executeTest().verifyErrorFree( 1 );
+
+        for ( String line : validator.loadLogLines() )
+        {
+            if ( "emptyProperty=''".equals( line ) )
+            {
+                return;
+            }
+        }
+        fail("Could not find text in log: emptyProperty=''");
+    }
+
+    private SurefireLauncher unpack1()
+    {
+        return unpack( "surefire-649-systemProperties" );
+    }
+
+    private SurefireLauncher unpack2()
+    {
+        return unpack( "surefire-649-systemPropertyVariables" );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-649-systemProperties/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-649-systemProperties/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-649-sys-props</artifactId>
+  <version>1.0</version>
+  <url>http://maven.apache.org</url>
+  <developers>
+    <developer>
+      <id>tibordigana</id>
+      <name>Tibor Digaňa (tibor17)</name>
+      <email>tibordigana@apache.org</email>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Bratislava</timezone>
+    </developer>
+  </developers>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <property>
+              <name>emptyProperty</name>
+              <value/>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-649-systemProperties/src/test/java/jiras/surefire649/SystemPropertiesTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-649-systemProperties/src/test/java/jiras/surefire649/SystemPropertiesTest.java
@@ -1,0 +1,32 @@
+package jiras.surefire649;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+public final class SystemPropertiesTest {
+
+    @Test
+    public void someMethod() throws InterruptedException {
+        String prop = System.getProperty( "emptyProperty" );
+        System.out.println( "emptyProperty=" + ( prop == null ? null : "'" + prop + "'" ) );
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/surefire-649-systemPropertyVariables/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-649-systemPropertyVariables/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-649-sys-prop-vars</artifactId>
+  <version>1.0</version>
+  <url>http://maven.apache.org</url>
+  <developers>
+    <developer>
+      <id>tibordigana</id>
+      <name>Tibor Digaňa (tibor17)</name>
+      <email>tibordigana@apache.org</email>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Bratislava</timezone>
+    </developer>
+  </developers>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <emptyProperty/>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-649-systemPropertyVariables/src/test/java/jiras/surefire649/SystemPropertyVariablesTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-649-systemPropertyVariables/src/test/java/jiras/surefire649/SystemPropertyVariablesTest.java
@@ -1,0 +1,32 @@
+package jiras.surefire649;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+public final class SystemPropertyVariablesTest {
+
+    @Test
+    public void someMethod() throws InterruptedException {
+        String prop = System.getProperty( "emptyProperty" );
+        System.out.println( "emptyProperty=" + ( prop == null ? null : "'" + prop + "'" ) );
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/system-properties/pom.xml
+++ b/surefire-integration-tests/src/test/resources/system-properties/pom.xml
@@ -66,7 +66,7 @@
             <buildDirectory>${project.build.directory}</buildDirectory>
             <reservedPort1>${reservedPort1}</reservedPort1>
             <reservedPort2>${reservedPort2}</reservedPort2>
-            <nullProperty></nullProperty>
+            <emptyProperty/>
             <blankProperty> </blankProperty>
             <!--  this is a work around for SUREFIRE-121 -->
             <setOnArgLineWorkAround>${setOnArgLineWorkAround}</setOnArgLineWorkAround>

--- a/surefire-integration-tests/src/test/resources/system-properties/src/test/java/systemProperties/BasicTest.java
+++ b/surefire-integration-tests/src/test/resources/system-properties/src/test/java/systemProperties/BasicTest.java
@@ -62,7 +62,9 @@ public class BasicTest
     public void testEmptySystemProperties()
     {
         assertNull( "Null property is not null", System.getProperty( "nullProperty" ) );
-        assertNull( "Blank property is not null", System.getProperty( "blankProperty" ) );
+        assertEquals( "Empty property is not empty", "", System.getProperty( "emptyProperty" ) );
+        assertNotNull( "Blank property is null", System.getProperty( "blankProperty" ) );
+        assertEquals( "Blank property is not trimmed", "", System.getProperty( "blankProperty" ) );
     }
 
     /**


### PR DESCRIPTION
The fix for
https://jira.codehaus.org/browse/SUREFIRE-649
