### PR TITLE
[SUREFIRE-1108] Surefire should print parallel tests in progress been stopped after elapsed timeout

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit47ParallelIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit47ParallelIT.java
@@ -521,6 +521,17 @@ public class JUnit47ParallelIT
             "The test run has finished abruptly after timeout of 1.0 seconds." );
     }
 
+    @Test
+    public void forcedShutdownVerifyingLogs()
+    {
+        // executes for 2.5 sec until timeout has elapsed
+        unpack().parallelMethods().threadCountMethods( 3 ).disablePerCoreThreadCount()
+            .parallelTestsTimeoutForcedInSeconds( 1.05d ).setTestToRun( "Waiting*Test" ).failNever().executeTest()
+            .verifyTextInLog( "The test run has finished abruptly after timeout of 1.05 seconds." )
+            .verifyTextInLog( "These tests were executed in prior to the shutdown operation:" )
+            .verifyTextInLog( "These tests are incomplete:" );
+    }
+
     private SurefireLauncher unpack()
     {
         return unpack( "junit47-parallel" );

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/AsynchronousRunner.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/AsynchronousRunner.java
@@ -30,8 +30,12 @@ import java.util.concurrent.Future;
 import org.junit.runners.model.RunnerScheduler;
 
 /**
+ * Since SUREFIRE 2.18 this class is deprecated.
+ * Please use {@link org.apache.maven.surefire.junitcore.pc.ParallelComputerBuilder} instead.
+ *
  * @author <a href="mailto:kristian@zenior.no">Kristian Rosenvold</a>
  */
+@Deprecated
 public class AsynchronousRunner
     implements RunnerScheduler
 {

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/ConfigurableParallelComputer.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/ConfigurableParallelComputer.java
@@ -35,8 +35,12 @@ import org.junit.runners.model.RunnerBuilder;
 import org.junit.runners.model.RunnerScheduler;
 
 /**
+ * Since SUREFIRE 2.18 this class is deprecated.
+ * Please use {@link org.apache.maven.surefire.junitcore.pc.ParallelComputerBuilder} instead.
+ *
  * @author Kristian Rosenvold
  */
+@Deprecated
 public class ConfigurableParallelComputer
     extends Computer
 {

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/SynchronousRunner.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/SynchronousRunner.java
@@ -22,8 +22,12 @@ package org.apache.maven.surefire.junitcore;
 import org.junit.runners.model.RunnerScheduler;
 
 /**
+ * Since SUREFIRE 2.18 this class is deprecated.
+ * Please use {@link org.apache.maven.surefire.junitcore.pc.ParallelComputerBuilder} instead.
+ *
  * @author <a href="mailto:kristian@zenior.no">Kristian Rosenvold</a>
  */
+@Deprecated
 class SynchronousRunner
     implements RunnerScheduler
 {

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilder.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilder.java
@@ -257,15 +257,17 @@ public final class ParallelComputerBuilder
         }
 
         @Override
-        protected Collection<Description> describeStopped( boolean shutdownNow )
+        protected ShutdownResult describeStopped( boolean shutdownNow )
         {
-            Collection<Description> startedTests = notThreadSafeTests.describeStopped( shutdownNow );
+            ShutdownResult shutdownResult = notThreadSafeTests.describeStopped( shutdownNow );
             final Scheduler m = master;
             if ( m != null )
             {
-                startedTests.addAll( m.describeStopped( shutdownNow ) );
+                ShutdownResult shutdownResultOfMaster = m.describeStopped( shutdownNow );
+                shutdownResult.getTriggeredTests().addAll( shutdownResultOfMaster.getTriggeredTests() );
+                shutdownResult.getIncompleteTests().addAll( shutdownResultOfMaster.getIncompleteTests() );
             }
-            return startedTests;
+            return shutdownResult;
         }
 
         @Override

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ShutdownResult.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ShutdownResult.java
@@ -1,0 +1,57 @@
+package org.apache.maven.surefire.junitcore.pc;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.runner.Description;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Populates collection {@code triggeredTests} of descriptions started before shutting down.
+ * Populates collection {@code incompleteTests} which describes started tests but unfinished due to abrupt shutdown.
+ * The collection {@code triggeredTests} contains all elements from {@code incompleteTests}.
+ *
+ * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
+ * @see Scheduler
+ * @since 2.18
+ */
+public final class ShutdownResult
+{
+    private final Collection<Description> triggeredTests;
+
+    private final Collection<Description> incompleteTests;
+
+    public ShutdownResult( Collection<Description> triggeredTests, Collection<Description> incompleteTests )
+    {
+        this.triggeredTests = triggeredTests == null ? Collections.<Description>emptySet() : triggeredTests;
+        this.incompleteTests = incompleteTests == null ? Collections.<Description>emptySet() : incompleteTests;
+    }
+
+    public Collection<Description> getTriggeredTests()
+    {
+        return triggeredTests;
+    }
+
+    public Collection<Description> getIncompleteTests()
+    {
+        return incompleteTests;
+    }
+}

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ShutdownStatus.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ShutdownStatus.java
@@ -19,14 +19,8 @@ package org.apache.maven.surefire.junitcore.pc;
  * under the License.
  */
 
-import org.junit.runner.Description;
-
-import java.util.Collection;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
-
-// CHECKSTYLE_OFF: imports
-import static org.apache.maven.surefire.junitcore.pc.ExecutionStatus.*;
 
 /**
  * Wrapper of {@link ParallelComputer ParallelComputer status information} and tests been populated before
@@ -38,31 +32,32 @@ import static org.apache.maven.surefire.junitcore.pc.ExecutionStatus.*;
  */
 final class ShutdownStatus
 {
-    private final AtomicReference<ExecutionStatus> status = new AtomicReference<ExecutionStatus>( STARTED );
+    private final AtomicReference<ExecutionStatus> status =
+        new AtomicReference<ExecutionStatus>( ExecutionStatus.STARTED );
 
-    private Future<Collection<Description>> descriptionsBeforeShutdown;
+    private Future<ShutdownResult> descriptionsBeforeShutdown;
 
     boolean tryFinish()
     {
-        return status.compareAndSet( STARTED, FINISHED );
+        return status.compareAndSet( ExecutionStatus.STARTED, ExecutionStatus.FINISHED );
     }
 
     boolean tryTimeout()
     {
-        return status.compareAndSet( STARTED, TIMEOUT );
+        return status.compareAndSet( ExecutionStatus.STARTED, ExecutionStatus.TIMEOUT );
     }
 
     boolean isTimeoutElapsed()
     {
-        return status.get() == TIMEOUT;
+        return status.get() == ExecutionStatus.TIMEOUT;
     }
 
-    Future<Collection<Description>> getDescriptionsBeforeShutdown()
+    Future<ShutdownResult> getDescriptionsBeforeShutdown()
     {
         return descriptionsBeforeShutdown;
     }
 
-    void setDescriptionsBeforeShutdown( Future<Collection<Description>> descriptionsBeforeShutdown )
+    void setDescriptionsBeforeShutdown( Future<ShutdownResult> descriptionsBeforeShutdown )
     {
         this.descriptionsBeforeShutdown = descriptionsBeforeShutdown;
     }

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/SingleThreadScheduler.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/SingleThreadScheduler.java
@@ -68,12 +68,11 @@ final class SingleThreadScheduler
     /**
      * @see Scheduler#describeStopped(boolean)
      */
-    Collection<Description> describeStopped( boolean shutdownNow )
+    ShutdownResult describeStopped( boolean shutdownNow )
     {
-        Collection<Description> activeChildren =
-            new ConcurrentLinkedQueue<Description>( master.describeStopped( shutdownNow ) );
-        activeChildren.removeAll( UNUSED_DESCRIPTIONS );
-        return activeChildren;
+        ShutdownResult shutdownResult = master.describeStopped( shutdownNow );
+        return new ShutdownResult( copyExisting( shutdownResult.getTriggeredTests() ),
+                                   copyExisting( shutdownResult.getIncompleteTests() ) );
     }
 
     /**
@@ -82,5 +81,12 @@ final class SingleThreadScheduler
     boolean shutdownThreadPoolsAwaitingKilled()
     {
         return master.shutdownThreadPoolsAwaitingKilled();
+    }
+
+    private Collection<Description> copyExisting( Collection<Description> descriptions )
+    {
+        Collection<Description> activeChildren = new ConcurrentLinkedQueue<Description>( descriptions );
+        activeChildren.removeAll( UNUSED_DESCRIPTIONS );
+        return activeChildren;
     }
 }

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilderTest.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilderTest.java
@@ -561,7 +561,7 @@ public class ParallelComputerBuilderTest
             {
                 public void run()
                 {
-                    Collection<Description> startedTests = computer.describeStopped( useInterrupt );
+                    Collection<Description> startedTests = computer.describeStopped( useInterrupt ).getTriggeredTests();
                     assertThat( startedTests.size(), is( not( 0 ) ) );
                 }
             };


### PR DESCRIPTION
An improvement for SUREFIRE-1108
