### PR TITLE
[SUREFIRE-1036] Tests using MockitoJUnitRunner are always run regardless of membership in specified group

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1036NonFilterableJUnitRunnerWithCategoriesIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1036NonFilterableJUnitRunnerWithCategoriesIT.java
@@ -1,0 +1,71 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.shared.utils.xml.Xpp3Dom;
+import org.apache.maven.shared.utils.xml.Xpp3DomBuilder;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.apache.maven.surefire.its.fixture.TestFile;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
+ * @see {@linkplain https://jira.codehaus.org/browse/SUREFIRE-1036}
+ * @since 2.18
+ */
+public class Surefire1036NonFilterableJUnitRunnerWithCategoriesIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+
+    @Test
+    public void test()
+        throws VerificationException, FileNotFoundException
+    {
+        OutputValidator validator = unpack().maven().executeTest();
+        validator.assertTestSuiteResults( 1, 0, 0, 0 );
+        assertFalse( validator.getSurefireReportsXmlFile(
+            "TEST-jiras.surefire1036.TestSomethingWithMockitoRunner.xml" ).exists() );
+        assertFalse( validator.getSurefireReportsXmlFile( "TEST-jiras.surefire1036.TestSomeUnit.xml" ).exists() );
+        TestFile reportFile =
+            validator.getSurefireReportsXmlFile( "TEST-jiras.surefire1036.TestSomeIntegration.xml" );
+        assertTestCount( reportFile, 1 );
+    }
+
+    private SurefireLauncher unpack()
+    {
+        return unpack( "surefire-1036-NonFilterableJUnitRunnerWithCategories" );
+    }
+
+    private void assertTestCount( TestFile reportFile, int tests )
+        throws FileNotFoundException
+    {
+        assertTrue( reportFile.exists() );
+        Xpp3Dom testResult = Xpp3DomBuilder.build( reportFile.getFileInputStream(), "UTF-8" );
+        Xpp3Dom[] children = testResult.getChildren( "testcase" );
+        assertEquals( tests, children.length );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-1036</artifactId>
+  <version>1.0</version>
+  <name>jiras-surefire-1036</name>
+  <url>http://maven.apache.org</url>
+  <developers>
+    <developer>
+      <id>tibordigana</id>
+      <name>Tibor Digaňa (tibor17)</name>
+      <email>tibordigana@apache.org</email>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Bratislava</timezone>
+    </developer>
+  </developers>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <groups>jiras.surefire1036.IntegrationTest</groups>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/src/test/java/jiras/surefire1036/IntegrationTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/src/test/java/jiras/surefire1036/IntegrationTest.java
@@ -1,0 +1,24 @@
+package jiras.surefire1036;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public interface IntegrationTest
+{
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/src/test/java/jiras/surefire1036/TestSomeIntegration.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/src/test/java/jiras/surefire1036/TestSomeIntegration.java
@@ -1,0 +1,37 @@
+package jiras.surefire1036;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category( IntegrationTest.class )
+public class TestSomeIntegration
+{
+  @Test
+  public void thisIsAnIntegrationTest() throws Exception
+  {
+    String message = "This integration test will always pass";
+    System.out.println( message );
+    assertTrue( message, true );
+  }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/src/test/java/jiras/surefire1036/TestSomeUnit.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/src/test/java/jiras/surefire1036/TestSomeUnit.java
@@ -1,0 +1,36 @@
+package jiras.surefire1036;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class TestSomeUnit
+{
+    @Test
+    public void thisIsJustAUnitTest()
+        throws Exception
+    {
+        String message = "This unit test will never pass";
+        System.out.println( message );
+        fail();
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/src/test/java/jiras/surefire1036/TestSomethingWithMockitoRunner.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1036-NonFilterableJUnitRunnerWithCategories/src/test/java/jiras/surefire1036/TestSomethingWithMockitoRunner.java
@@ -1,0 +1,52 @@
+package jiras.surefire1036;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith( MockitoJUnitRunner.class )
+public class TestSomethingWithMockitoRunner
+{
+    @Mock
+    private List<Integer> mTestList;
+
+    @Before
+    public void setUp()
+        throws Exception
+    {
+        when( mTestList.size() ).thenReturn( 5 );
+    }
+
+    @Test
+    public void thisTestUsesMockitoRunnerButIsPrettyUseless()
+        throws Exception
+    {
+        assertEquals( 5, mTestList.size() );
+    }
+}

--- a/surefire-providers/common-junit48/src/main/java/org/apache/maven/surefire/common/junit48/FilterFactory.java
+++ b/surefire-providers/common-junit48/src/main/java/org/apache/maven/surefire/common/junit48/FilterFactory.java
@@ -284,26 +284,29 @@ public class FilterFactory
                 cats.addAll( findSuperclassCategories( parentClass ) );
             }
 
+            Class<?> testClass = description.getTestClass();
+            if ( testClass != null )
+            {
+                cat = testClass.getAnnotation( Category.class );
+                if ( cat != null )
+                {
+                    cats.addAll( Arrays.asList( cat.value() ) );
+                }
+            }
+
             boolean result = matcher.enabled( cats.toArray( new Class<?>[] {} ) );
 
-            if ( parent == null )
+            if ( !result )
             {
-                if ( cats.size() == 0 )
+                ArrayList<Description> children = description.getChildren();
+                if ( children != null )
                 {
-                    result = true;
-                }
-                else if ( !result )
-                {
-                    ArrayList<Description> children = description.getChildren();
-                    if ( children != null )
+                    for ( Description child : children )
                     {
-                        for ( Description child : children )
+                        if ( shouldRun( child, description, null ) )
                         {
-                            if ( shouldRun( child, description, null ) )
-                            {
-                                result = true;
-                                break;
-                            }
+                            result = true;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Fix for Groups filter.
