### PR TITLE
[SUREFIRE-1120] Improved Warning message "File encoding has not been set, ..."

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -307,7 +307,8 @@ public class IntegrationTestMojo
         if ( StringUtils.isEmpty( encoding ) )
         {
             getLog().warn( "File encoding has not been set, using platform encoding " + ReaderFactory.FILE_ENCODING
-                           + ", i.e. build is platform dependent!" );
+                           + ", i.e. build is platform dependent! The character encoding for reports output files "
+                               + "should be referenced by POM property ${project.reporting.outputEncoding}." );
             return ReaderFactory.FILE_ENCODING;
         }
         else

--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
@@ -162,7 +162,8 @@ public class VerifyMojo
                 {
                     getLog().warn(
                         "File encoding has not been set, using platform encoding " + ReaderFactory.FILE_ENCODING
-                            + ", i.e. build is platform dependent!" );
+                            + ", i.e. build is platform dependent! The character encoding for reports output files "
+                            + "should be referenced by POM property ${project.reporting.outputEncoding}." );
                     encoding = ReaderFactory.FILE_ENCODING;
                 }
                 else


### PR DESCRIPTION
Only added a hint to setup property referenced by ${project.reporting.outputEncoding}.
