### PR TITLE
[SUREFIRE-855] Allow failsafe to use actual jar file instead of target/classes

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -161,13 +161,6 @@ public abstract class AbstractSurefireMojo
     protected File testClassesDirectory;
 
     /**
-     * The directory containing generated classes of the project being tested. This will be included after the test
-     * classes in the test classpath.
-     */
-    @Parameter( defaultValue = "${project.build.outputDirectory}" )
-    protected File classesDirectory;
-
-    /**
      * List of dependencies to exclude from the test classpath. Each dependency string must follow the format
      * <i>groupId:artifactId</i>. For example: <i>org.acme:project-a</i>
      *
@@ -947,7 +940,7 @@ public abstract class AbstractSurefireMojo
         TestSetFailedException
     {
         SurefireProperties effectiveProperties = setupProperties();
-        ClassLoaderConfiguration classLoaderConfiguration = getClassLoaderConfiguration( isForking() );
+        ClassLoaderConfiguration classLoaderConfiguration = getClassLoaderConfiguration();
         provider.addProviderProperties();
         RunOrderParameters runOrderParameters =
             new RunOrderParameters( getRunOrder(), getStatisticsFileName( getConfigChecksum() ) );
@@ -1330,7 +1323,7 @@ public abstract class AbstractSurefireMojo
         return ForkConfiguration.FORK_NEVER.equals( forkMode );
     }
 
-    boolean isForking()
+    protected boolean isForking()
     {
         return 0 < getEffectiveForkCount();
     }
@@ -1493,7 +1486,6 @@ public abstract class AbstractSurefireMojo
         {
             throw new MojoExecutionException( "Unable to generate classpath: " + e, e );
         }
-
     }
 
     private Artifact getCommonArtifact()
@@ -1986,9 +1978,9 @@ public abstract class AbstractSurefireMojo
         return false;
     }
 
-    protected ClassLoaderConfiguration getClassLoaderConfiguration( boolean isForking )
+    protected ClassLoaderConfiguration getClassLoaderConfiguration()
     {
-        return isForking
+        return isForking()
             ? new ClassLoaderConfiguration( isUseSystemClassLoader(), isUseManifestOnlyJar() )
             : new ClassLoaderConfiguration( false, false );
     }

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -44,6 +44,13 @@ public class SurefirePlugin
 {
 
     /**
+     * The directory containing generated classes of the project being tested. This will be included after the test
+     * classes in the test classpath.
+     */
+    @Parameter( defaultValue = "${project.build.outputDirectory}" )
+    private File classesDirectory;
+
+    /**
      * Set this to "true" to ignore a failure during testing. Its use is NOT RECOMMENDED, but quite convenient on
      * occasion.
      */

--- a/maven-surefire-plugin/src/site/apt/examples/configuring-classpath.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/configuring-classpath.apt.vm
@@ -38,12 +38,18 @@ The Default Classpath
 #{else}
   [[1]] The {{{../integration-test-mojo.html#testClassesDirectory}test-classes}} directory
 
-  [[2]] The {{{../integration-test-mojo.html#classesDirectory}classes}} directory
+  [[2]] The {{{../integration-test-mojo.html#classesDirectory}classes}} jar archive or directory
 
 #{end}
   [[3]] The project dependencies
 
   [[4]] Additional classpath elements
+
+
+#{if}(${project.artifactId}=="maven-failsafe-plugin")
+  Notice that loading jar archive is preferable over the output classes directory in the maven-failsafe-plugin.
+#{end}
+
 
 Additional Classpath Elements
 

--- a/surefire-integration-tests/pom.xml
+++ b/surefire-integration-tests/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/fixture/OutputValidator.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/fixture/OutputValidator.java
@@ -44,7 +44,6 @@ public class OutputValidator
     {
         this.verifier = verifier;
         this.baseDir = new File( verifier.getBasedir() );
-
     }
 
     public OutputValidator verifyTextInLog( String text )
@@ -107,8 +106,6 @@ public class OutputValidator
         }
     }
 
-
-
     public String getBasedir()
     {
         return verifier.getBasedir();
@@ -167,7 +164,6 @@ public class OutputValidator
         return new TestFile( new File( targetDir, fileName ), this );
     }
 
-
     public TestFile getSurefireReportsFile( String fileName )
     {
         File targetDir = getSubFile( "target/surefire-reports" );
@@ -186,24 +182,16 @@ public class OutputValidator
         return new TestFile( new File( targetDir, fileName ), this );
     }
 
-
     public File getBaseDir()
     {
         return baseDir;
-    }
-
-    @SuppressWarnings( "unchecked" )
-    private List<String> getLog()
-        throws VerificationException
-    {
-        return verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
     }
 
     public boolean stringsAppearInSpecificOrderInLog( String[] strings )
         throws VerificationException
     {
         int i = 0;
-        for ( String line : getLog() )
+        for ( String line : loadLogLines() )
         {
             if ( line.startsWith( strings[i] ) )
             {

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire855AllowFailsafeUseArtifactFileIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire855AllowFailsafeUseArtifactFileIT.java
@@ -1,0 +1,58 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
+ * @see {@linkplain https://jira.codehaus.org/browse/SUREFIRE-855}
+ * @since 2.19
+ */
+public class Surefire855AllowFailsafeUseArtifactFileIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+    @Test
+    public void warShouldUseClasses()
+    {
+        unpack( "surefire-855-failsafe-use-war" ).maven().executeVerify().verifyErrorFree( 2 );
+    }
+
+    @Test
+    public void jarShouldUseFile()
+    {
+        unpack( "surefire-855-failsafe-use-jar" )
+            .maven().sysProp( "forkMode", "once" ).executeVerify().assertIntegrationTestSuiteResults( 3, 0, 0, 1 );
+    }
+
+    @Test
+    public void jarNotForkingShouldUseFile()
+    {
+        unpack( "surefire-855-failsafe-use-jar" )
+            .maven().sysProp( "forkMode", "never" ).executeVerify().assertIntegrationTestSuiteResults( 3, 0, 0, 1 );
+    }
+
+    @Test
+    public void osgiBundleShouldUseFile()
+    {
+        unpack( "surefire-855-failsafe-use-bundle" ).maven().executeVerify().verifyErrorFree( 2 );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-855-bundle</artifactId>
+  <version>1.0</version>
+  <packaging>bundle</packaging>
+  <url>http://maven.apache.org</url>
+  <developers>
+    <developer>
+      <id>tibordigana</id>
+      <name>Tibor Digaňa (tibor17)</name>
+      <email>tibordigana@apache.org</email>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Bratislava</timezone>
+    </developer>
+  </developers>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easytesting</groupId>
+      <artifactId>fest-assert-core</artifactId>
+      <version>2.0M9</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.3</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadoc</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.surefire.its.${project.artifactId}</Bundle-SymbolicName>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <forkMode>always</forkMode>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/src/main/java/pkg/AClassInOSGiBundle.java
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/src/main/java/pkg/AClassInOSGiBundle.java
@@ -1,0 +1,24 @@
+package pkg;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class AClassInOSGiBundle
+{
+}

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/src/main/resources/main/surefire855.properties
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/src/main/resources/main/surefire855.properties
@@ -1,0 +1,1 @@
+issue=SUREFIRE-855

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/src/test/java/jiras/surefre855/bundle/FooIT.java
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/src/test/java/jiras/surefre855/bundle/FooIT.java
@@ -1,0 +1,146 @@
+package jiras.surefire855.bundle;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.Properties;
+import java.util.jar.Manifest;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.contentOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class FooIT
+{
+    private static final String ARTIFACT_FILE_NAME = "jiras-surefire-855-bundle-1.0.jar";
+
+    private static final String MAIN_RESOURCE = "/main/surefire855.properties";
+
+    private static final String TEST_RESOURCE = "/jiras/surefire855/bundle/properties/surefire855.properties";
+
+    private static File[] surefireProviderProperties()
+        throws IOException
+    {
+        final File surefireDir = new File( "target/surefire" ).getCanonicalFile();
+        return surefireDir.listFiles( new FileFilter()
+        {
+            public boolean accept( File pathname )
+            {
+                try
+                {
+                    return isSurefireProviderProperties( pathname );
+                }
+                catch ( IOException e )
+                {
+                    return false;
+                }
+            }
+        } );
+    }
+
+    /**
+     * See BooterSerializer#serialize().
+     */
+    private static boolean isSurefireProviderProperties( File pathname )
+        throws IOException
+    {
+        pathname = pathname.getCanonicalFile();
+        String fileName = pathname.getName();
+        return pathname.isFile() && fileName.startsWith( "surefire" ) && !fileName.startsWith( "surefire_" )
+            && fileName.endsWith( "tmp" );
+    }
+
+    private static String manifestClassPath( Class clazz )
+        throws IOException
+    {
+        Manifest manifest = new Manifest( clazz.getResourceAsStream( "/META-INF/MANIFEST.MF" ) );
+        return manifest.getMainAttributes().getValue( "Class-Path" );
+    }
+
+    private static Properties loadProperties( Class clazz, String resourcePath )
+        throws IOException
+    {
+        InputStream is = clazz.getResourceAsStream( resourcePath );
+        Properties prop = new Properties();
+        prop.load( is );
+        is.close();
+        return prop;
+    }
+
+    private static Properties loadMainProperties( Class clazz )
+        throws IOException
+    {
+        return loadProperties( clazz, MAIN_RESOURCE );
+    }
+
+    private static Properties loadTestProperties( Class clazz )
+        throws IOException
+    {
+        return loadProperties( clazz, TEST_RESOURCE );
+    }
+
+    @Test
+    public void test()
+        throws IOException
+    {
+        String classPath = manifestClassPath( getClass() );
+        System.out.println( "CLASS PATH:" );
+        System.out.println( classPath );
+
+        assertThat( classPath, not( containsString( "/target/classes" ) ) );
+        assertThat( classPath, containsString( "/target/" + ARTIFACT_FILE_NAME ) );
+
+        File surefireDir = new File( "target/surefire" ).getCanonicalFile();
+        System.out.println( "SUREFIRE DIR:" );
+        System.out.println( surefireDir );
+
+        File[] descriptors = surefireProviderProperties();
+        assertThat( descriptors ).hasSize( 1 );
+        assertThat( descriptors ).doesNotContainNull();
+        assertThat( descriptors[0] ).isFile();
+
+        String surefireProperties = contentOf( descriptors[0] );
+        Properties properties = new Properties();
+        properties.load( new StringReader( surefireProperties ) );
+        System.out.println( properties.toString() );
+        File actualArtifact = new File( properties.getProperty( "classPathUrl.1" ) ).getCanonicalFile();
+        File expectedArtifact = new File( "target/" + ARTIFACT_FILE_NAME ).getCanonicalFile();
+        assertThat( actualArtifact ).isFile();
+        assertThat( expectedArtifact ).isFile();
+        assertThat( actualArtifact ).isEqualTo( expectedArtifact );
+    }
+
+    @Test
+    public void shouldAlwaysHaveResources()
+        throws IOException
+    {
+        assertThat( loadTestProperties( getClass() ).getProperty( "issue" ), is( "SUREFIRE-855" ) );
+        assertThat( loadMainProperties( getClass() ).getProperty( "issue" ), is( "SUREFIRE-855" ) );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/src/test/resources/jiras/surefire855/bundle/properties/surefire855.properties
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-bundle/src/test/resources/jiras/surefire855/bundle/properties/surefire855.properties
@@ -1,0 +1,1 @@
+issue=SUREFIRE-855

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-855-jar</artifactId>
+  <version>1.0</version>
+  <url>http://maven.apache.org</url>
+  <developers>
+    <developer>
+      <id>tibordigana</id>
+      <name>Tibor Digaňa (tibor17)</name>
+      <email>tibordigana@apache.org</email>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Bratislava</timezone>
+    </developer>
+  </developers>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easytesting</groupId>
+      <artifactId>fest-assert-core</artifactId>
+      <version>2.0M9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.3</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadoc</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <forkMode>${forkMode}</forkMode>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/src/main/java/pkg/ToRunJavadoc.java
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/src/main/java/pkg/ToRunJavadoc.java
@@ -1,0 +1,8 @@
+package pkg;
+
+public class ToRunJavadoc
+{
+    public void x()
+    {
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/src/main/resources/main/surefire855.properties
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/src/main/resources/main/surefire855.properties
@@ -1,0 +1,1 @@
+issue=SUREFIRE-855

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/src/test/java/jiras/surefire855/jar/FooIT.java
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/src/test/java/jiras/surefire855/jar/FooIT.java
@@ -1,0 +1,162 @@
+package jiras.surefire855.jar;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.Properties;
+import java.util.jar.Manifest;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.contentOf;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+public final class FooIT
+{
+    private static final String ARTIFACT_FILE_NAME = "jiras-surefire-855-jar-1.0.jar";
+
+    private static final String MAIN_RESOURCE = "/main/surefire855.properties";
+
+    private static final String TEST_RESOURCE = "/jiras/surefire855/jar/properties/surefire855.properties";
+
+    private static File surefireDir()
+        throws IOException
+    {
+        return new File( "target/surefire" ).getCanonicalFile();
+    }
+
+    private static File[] surefireProviderProperties()
+        throws IOException
+    {
+        return surefireDir().listFiles( new FileFilter()
+        {
+            public boolean accept( File pathname )
+            {
+                try
+                {
+                    return isSurefireProviderProperties( pathname );
+                }
+                catch ( IOException e )
+                {
+                    return false;
+                }
+            }
+        } );
+    }
+
+    /**
+     * See BooterSerializer#serialize().
+     */
+    private static boolean isSurefireProviderProperties( File pathname )
+        throws IOException
+    {
+        pathname = pathname.getCanonicalFile();
+        String fileName = pathname.getName();
+        return pathname.isFile() && fileName.startsWith( "surefire" ) && !fileName.startsWith( "surefire_" )
+            && fileName.endsWith( "tmp" );
+    }
+
+    private static String manifestClassPath( Class clazz )
+        throws IOException
+    {
+        Manifest manifest = new Manifest( clazz.getResourceAsStream( "/META-INF/MANIFEST.MF" ) );
+        return manifest.getMainAttributes().getValue( "Class-Path" );
+    }
+
+    private static Properties loadProperties( Class clazz, String resourcePath )
+        throws IOException
+    {
+        InputStream is = clazz.getResourceAsStream( resourcePath );
+        Properties prop = new Properties();
+        prop.load( is );
+        is.close();
+        return prop;
+    }
+
+    private static Properties loadMainProperties( Class clazz )
+        throws IOException
+    {
+        return loadProperties( clazz, MAIN_RESOURCE );
+    }
+
+    private static Properties loadTestProperties( Class clazz )
+        throws IOException
+    {
+        return loadProperties( clazz, TEST_RESOURCE );
+    }
+
+    @Test
+    public void shouldBeJarWithForking()
+        throws IOException
+    {
+        assumeThat( System.getProperty( "forkMode" ), is( not( "never" ) ) );
+
+        String classPath = manifestClassPath( getClass() );
+        System.out.println( "CLASS PATH:" );
+        System.out.println( classPath );
+
+        assertThat( classPath, not( containsString( "/target/classes" ) ) );
+        assertThat( classPath, containsString( "/target/" + ARTIFACT_FILE_NAME ) );
+
+        File surefireDir = new File( "target/surefire" ).getCanonicalFile();
+        System.out.println( "SUREFIRE DIR:" );
+        System.out.println( surefireDir );
+
+        File[] descriptors = surefireProviderProperties();
+        assertThat( descriptors ).hasSize( 1 );
+        assertThat( descriptors ).doesNotContainNull();
+        assertThat( descriptors[0] ).isFile();
+
+        String surefireProperties = contentOf( descriptors[0] );
+        Properties properties = new Properties();
+        properties.load( new StringReader( surefireProperties ) );
+        System.out.println( properties.toString() );
+        File actualArtifact = new File( properties.getProperty( "classPathUrl.1" ) ).getCanonicalFile();
+        File expectedArtifact = new File( "target/" + ARTIFACT_FILE_NAME ).getCanonicalFile();
+        assertThat( actualArtifact ).isFile();
+        assertThat( expectedArtifact ).isFile();
+        assertThat( actualArtifact ).isEqualTo( expectedArtifact );
+    }
+
+    @Test
+    public void jarShouldExistWhenNotForking()
+        throws Exception
+    {
+        assumeThat( System.getProperty( "forkMode" ), is( "never" ) );
+
+        assertThat( surefireDir() ).doesNotExist();
+        assertThat( new File( "target/" + ARTIFACT_FILE_NAME ).getCanonicalFile() ).isFile();
+    }
+
+    @Test
+    public void shouldAlwaysHaveResources()
+        throws IOException
+    {
+        assertThat( loadTestProperties( getClass() ).getProperty( "issue" ), is( "SUREFIRE-855" ) );
+        assertThat( loadMainProperties( getClass() ).getProperty( "issue" ), is( "SUREFIRE-855" ) );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/src/test/resources/jiras/surefire855/jar/properties/surefire855.properties
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-jar/src/test/resources/jiras/surefire855/jar/properties/surefire855.properties
@@ -1,0 +1,1 @@
+issue=SUREFIRE-855

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-855-war</artifactId>
+  <version>1.0</version>
+  <packaging>war</packaging>
+  <url>http://maven.apache.org</url>
+  <developers>
+    <developer>
+      <id>tibordigana</id>
+      <name>Tibor Digaňa (tibor17)</name>
+      <email>tibordigana@apache.org</email>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Bratislava</timezone>
+    </developer>
+  </developers>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easytesting</groupId>
+      <artifactId>fest-assert-core</artifactId>
+      <version>2.0M9</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.3</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadoc</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <forkMode>always</forkMode>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/src/main/java/pkg/ToCreateClassesDirectory.java
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/src/main/java/pkg/ToCreateClassesDirectory.java
@@ -1,0 +1,24 @@
+package pkg;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class ToCreateClassesDirectory
+{
+}

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/src/main/resources/main/surefire855.properties
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/src/main/resources/main/surefire855.properties
@@ -1,0 +1,1 @@
+issue=SUREFIRE-855

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/src/test/java/jiras/surefire855/war/FooIT.java
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/src/test/java/jiras/surefire855/war/FooIT.java
@@ -1,0 +1,142 @@
+package jiras.surefire855.war;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.Properties;
+import java.util.jar.Manifest;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.contentOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class FooIT
+{
+    private static final String MAIN_RESOURCE = "/main/surefire855.properties";
+
+    private static final String TEST_RESOURCE = "/jiras/surefire855/war/properties/surefire855.properties";
+
+    private static File[] surefireProviderProperties()
+        throws IOException
+    {
+        final File surefireDir = new File( "target/surefire" ).getCanonicalFile();
+        return surefireDir.listFiles( new FileFilter()
+        {
+            public boolean accept( File pathname )
+            {
+                try
+                {
+                    return isSurefireProviderProperties( pathname );
+                }
+                catch ( IOException e )
+                {
+                    return false;
+                }
+            }
+        } );
+    }
+
+    /**
+     * See BooterSerializer#serialize().
+     */
+    private static boolean isSurefireProviderProperties( File pathname )
+        throws IOException
+    {
+        pathname = pathname.getCanonicalFile();
+        String fileName = pathname.getName();
+        return pathname.isFile() && fileName.startsWith( "surefire" ) && !fileName.startsWith( "surefire_" )
+            && fileName.endsWith( "tmp" );
+    }
+
+    private static String manifestClassPath( Class clazz )
+        throws IOException
+    {
+        Manifest manifest = new Manifest( clazz.getResourceAsStream( "/META-INF/MANIFEST.MF" ) );
+        return manifest.getMainAttributes().getValue( "Class-Path" );
+    }
+
+    private static Properties loadProperties( Class clazz, String resourcePath )
+        throws IOException
+    {
+        InputStream is = clazz.getResourceAsStream( resourcePath );
+        Properties prop = new Properties();
+        prop.load( is );
+        is.close();
+        return prop;
+    }
+
+    private static Properties loadMainProperties( Class clazz )
+        throws IOException
+    {
+        return loadProperties( clazz, MAIN_RESOURCE );
+    }
+
+    private static Properties loadTestProperties( Class clazz )
+        throws IOException
+    {
+        return loadProperties( clazz, TEST_RESOURCE );
+    }
+
+    @Test
+    public void test()
+        throws IOException
+    {
+        String classPath = manifestClassPath( getClass() );
+        System.out.println( "CLASS PATH:" );
+        System.out.println( classPath );
+
+        assertThat( classPath, containsString( "/target/classes" ) );
+
+        File surefireDir = new File( "target/surefire" ).getCanonicalFile();
+        System.out.println( "SUREFIRE DIR:" );
+        System.out.println( surefireDir );
+
+        File[] descriptors = surefireProviderProperties();
+        assertThat( descriptors ).hasSize( 1 );
+        assertThat( descriptors ).doesNotContainNull();
+        assertThat( descriptors[0] ).isFile();
+
+        String surefireProperties = contentOf( descriptors[0] );
+        Properties properties = new Properties();
+        properties.load( new StringReader( surefireProperties ) );
+        System.out.println( properties.toString() );
+        File actualArtifact = new File( properties.getProperty( "classPathUrl.1" ) ).getCanonicalFile();
+        File expectedArtifact = new File( "target/classes" ).getCanonicalFile();
+        assertThat( actualArtifact ).isDirectory();
+        assertThat( expectedArtifact ).isDirectory();
+        assertThat( actualArtifact ).isEqualTo( expectedArtifact );
+    }
+
+    @Test
+    public void shouldAlwaysHaveResources()
+        throws IOException
+    {
+        assertThat( loadTestProperties( getClass() ).getProperty( "issue" ), is( "SUREFIRE-855" ) );
+        assertThat( loadMainProperties( getClass() ).getProperty( "issue" ), is( "SUREFIRE-855" ) );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/src/test/resources/jiras/surefire855/war/properties/surefire855.properties
+++ b/surefire-integration-tests/src/test/resources/surefire-855-failsafe-use-war/src/test/resources/jiras/surefire855/war/properties/surefire855.properties
@@ -1,0 +1,1 @@
+issue=SUREFIRE-855


### PR DESCRIPTION
The failsafe-plugin using artifact file instead of target/classes.