### PR TITLE
Get tests to run from external source via socket connection

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -662,6 +662,37 @@ public abstract class AbstractSurefireMojo
     private String[] dependenciesToScan;
 
     /**
+     * Read tests list from external source provided in externalSourceUrl parameter instead of using
+     * test class discovery mechanisms.
+     * <p/>
+     * Works only in fork mode.
+     *
+     * @since 2.19
+     */
+    @Parameter( property = "testsFromExternalSource" )
+    private boolean testsFromExternalSource;
+
+    /**
+     * External source URL to read test class names during execution.
+     * <p/>
+     * Supported protocols:
+     * <ul>
+     *     <li>socket - fetch test class names from external system via simple socket protocol.<br/>
+     *         URL format - socket://[host]:[port]<br/>
+     *         Messaging:
+     *         <ul>
+     *             <li>client sends <code>78,0,want more!</code> terminated by new line</li>
+     *             <li>server returns test class name terminated by new line or empty string if no more tests</li>
+     *         </ul>
+     *         Client is requesting data lazily, just before executing next test.
+     *     </li>
+     * </ul>
+     * @since 2.19
+     */
+    @Parameter( property = "testExternalSourceUrl" )
+    private String externalSourceUrl;
+
+    /**
      *
      */
     @Component
@@ -1441,7 +1472,7 @@ public abstract class AbstractSurefireMojo
 
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, actualFailIfNoTests,
                                           reporterConfiguration, testNg, testSuiteDefinition, providerProperties, null,
-                                          false );
+                                          false, testsFromExternalSource, externalSourceUrl );
     }
 
     public String getStatisticsFileName( String configurationHash )

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
@@ -135,6 +135,15 @@ class BooterSerializer
                                 String.valueOf( booterConfiguration.isFailIfNoTests() ) );
         properties.setProperty( BooterConstants.PROVIDER_CONFIGURATION, providerConfiguration.getProviderClassName() );
 
+        properties.setProperty( BooterConstants.RUN_TESTS_FROM_EXTERNAL_SOURCE,
+                                booterConfiguration.isTestsFromExternalSource() );
+        String externalSourceUrl = booterConfiguration.getExternalSourceUrl();
+        if ( externalSourceUrl != null )
+        {
+            properties.setProperty( BooterConstants.TESTS_FROM_EXTERNAL_SOURCE_URL,
+                                    externalSourceUrl );
+        }
+
         return SystemPropertyManager.writePropertiesFile( properties,
                                                           forkConfiguration.getTempDirectory(), "surefire",
                                                           forkConfiguration.isDebug() );

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
@@ -227,7 +227,8 @@ public class BooterDeserializerProviderConfigurationTest
         RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                                           new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new Properties(),
-                                          aTestTyped, readTestsFromInStream );
+                                          aTestTyped, readTestsFromInStream, false,
+                                          null );
     }
 
     private StartupConfiguration getTestStartupConfiguration( ClassLoaderConfiguration classLoaderConfiguration )

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
@@ -146,7 +146,8 @@ public class BooterDeserializerStartupConfigurationTest
         RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                                           new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new Properties(),
-                                          BooterDeserializerProviderConfigurationTest.aTestTyped, true );
+                                          BooterDeserializerProviderConfigurationTest.aTestTyped, true,
+                                          false, null );
     }
 
     private StartupConfiguration getTestStartupConfiguration( ClassLoaderConfiguration classLoaderConfiguration )

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
@@ -52,4 +52,6 @@ public final class BooterConstants
     public static final String FORKTESTSET = "forkTestSet";
     public static final String FORKTESTSET_PREFER_TESTS_FROM_IN_STREAM = "preferTestsFromInStream";
     public static final String RERUN_FAILING_TESTS_COUNT = "rerunFailingTestsCount";
+    public static final String RUN_TESTS_FROM_EXTERNAL_SOURCE = "testsFromExternalSource";
+    public static final String TESTS_FROM_EXTERNAL_SOURCE_URL = "externalSourceUrl";
 }

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
@@ -82,6 +82,9 @@ public class BooterDeserializer
 
         final int rerunFailingTestsCount = properties.getIntProperty( RERUN_FAILING_TESTS_COUNT );
 
+        final boolean testsFromExternalSource = properties.getBooleanProperty( RUN_TESTS_FROM_EXTERNAL_SOURCE );
+        final String externalSourceUrl = properties.getProperty( TESTS_FROM_EXTERNAL_SOURCE_URL );
+
         DirectoryScannerParameters dirScannerParams =
             new DirectoryScannerParameters( testClassesDirectory, includesList, excludesList, specificTestsList,
                                             properties.getBooleanObjectProperty( FAILIFNOTESTS ), runOrder );
@@ -99,7 +102,7 @@ public class BooterDeserializer
         return new ProviderConfiguration( dirScannerParams, runOrderParameters,
                                           properties.getBooleanProperty( FAILIFNOTESTS ), reporterConfiguration, testNg,
                                           testSuiteDefinition, properties.getProperties(), typeEncodedTestForFork,
-                                          preferTestsFromInStream );
+                                          preferTestsFromInStream, testsFromExternalSource, externalSourceUrl );
     }
 
     public StartupConfiguration getProviderConfiguration()

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ExternalTestToRunFactory.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ExternalTestToRunFactory.java
@@ -1,0 +1,62 @@
+package org.apache.maven.surefire.booter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.util.TestsToRun;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Produces external TestToRun providers based on URL passed in
+ *
+ * @author Marek Piechut
+ */
+public class ExternalTestToRunFactory
+{
+
+    public static final String SOCKET = "socket";
+
+    static TestsToRun createTestToRun ( String sourceUrl )
+                    throws MalformedURLException
+    {
+        URI url = null;
+        try
+        {
+            url = new URI( sourceUrl );
+
+            if ( SOCKET.equals( url.getScheme() ) )
+            {
+                return new LazySocketTestToRun( url, 3 );
+            }
+            else
+            {
+                throw new IllegalArgumentException( "No support for external test provider with URL: " + url );
+            }
+        }
+        catch ( URISyntaxException e )
+        {
+
+            throw new IllegalArgumentException( "No support for external test provider with URL: " + url );
+        }
+    }
+
+}

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
@@ -73,6 +73,7 @@ public class ForkedBooter
 
             TypeEncodedValue forkedTestSet = providerConfiguration.getTestForFork();
             boolean readTestsFromInputStream = providerConfiguration.isReadTestsFromInStream();
+            boolean readTestsFromExternalSource = providerConfiguration.isTestsFromExternalSource();
 
             final ClasspathConfiguration classpathConfiguration = startupConfiguration.getClasspathConfiguration();
             if ( startupConfiguration.isManifestOnlyJarRequestedAndUsable() )
@@ -92,6 +93,10 @@ public class ForkedBooter
             else if ( readTestsFromInputStream )
             {
                 testSet = new LazyTestsToRun( System.in, originalOut );
+            }
+            else if ( readTestsFromExternalSource )
+            {
+                testSet = ExternalTestToRunFactory.createTestToRun( providerConfiguration.getExternalSourceUrl() );
             }
             else
             {

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/LazySocketTestToRun.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/LazySocketTestToRun.java
@@ -1,0 +1,243 @@
+package org.apache.maven.surefire.booter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.util.ReflectionUtils;
+import org.apache.maven.surefire.util.TestsToRun;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * TestToRun implementation that lazily request tests from external service via socket
+ *
+ * @author Marek Piechut
+ */
+public class LazySocketTestToRun
+                extends TestsToRun
+{
+
+    private static final String WANT_MORE = "" + ForkingRunListener.BOOTERCODE_NEXT_TEST + ",0,want more!\n";
+
+    public static final int PAUSE_BETWEEN_RETRIES = 1000;
+
+    private final List<Class> workQueue = new ArrayList<Class>();
+
+    private boolean finished = false;
+
+    private final URI url;
+
+    private final int retries;
+
+    public LazySocketTestToRun ( URI url )
+    {
+        this( url, 0 );
+    }
+
+    public LazySocketTestToRun ( URI url, int retries )
+    {
+        super( Collections.<Class>emptyList() );
+        this.url = url;
+        this.retries = retries;
+    }
+
+    private boolean hasNextTextClass ( int pos )
+                    throws IOException
+    {
+        synchronized ( workQueue )
+        {
+            if ( !finished )
+            {
+                String nextTestName = tryToGetNextTestName();
+                if ( !nothingMoreToProcess( nextTestName ) )
+                {
+                    Class testClass = loadTestClass( nextTestName );
+                    workQueue.add( testClass );
+                }
+                else
+                {
+                    finished = true;
+                }
+            }
+            return workQueue.size() > pos;
+        }
+    }
+
+    private boolean nothingMoreToProcess ( String nextTestName )
+    {
+        return nextTestName == null || nextTestName.trim().length() == 0
+                        || nextTestName.trim().equalsIgnoreCase( "null" );
+    }
+
+    private String tryToGetNextTestName ()
+                    throws IOException
+    {
+        String nextTestName;
+        int tries = 0;
+        while ( true )
+        {
+            try
+            {
+                nextTestName = fetchNextTestName();
+                break;
+            }
+            catch ( IOException e )
+            {
+                if ( tries < retries )
+                {
+                    tries++;
+                    System.out.println( "Error connecting to external test source. Retry in 1 second." );
+                    sleep( PAUSE_BETWEEN_RETRIES );
+                }
+                else
+                {
+                    throw e;
+                }
+            }
+        }
+        return nextTestName;
+    }
+
+    private void sleep ( int time )
+    {
+        try
+        {
+            Thread.sleep( time );
+        }
+        catch ( InterruptedException e1 )
+        {
+            throw new RuntimeException( e1 );
+        }
+    }
+
+    private String fetchNextTestName ()
+                    throws IOException
+    {
+        String testName = null;
+        Socket socket = new Socket( url.getHost(), url.getPort() );
+        BufferedWriter out = null;
+        BufferedReader in = null;
+        try
+        {
+            out = new BufferedWriter( new OutputStreamWriter( socket.getOutputStream() ) );
+            out.write( WANT_MORE );
+            out.flush();
+            in = new BufferedReader( new InputStreamReader( socket.getInputStream() ) );
+            testName = in.readLine();
+            socket.shutdownInput();
+        }
+        finally
+        {
+            try
+            {
+                if ( out != null )
+                {
+                    out.close();
+                }
+
+                if ( in != null )
+                {
+                    in.close();
+                }
+            }
+            finally
+            {
+                socket.close();
+            }
+        }
+
+        return testName;
+    }
+
+    private Class getItem ( int pos )
+    {
+        synchronized ( workQueue )
+        {
+            return workQueue.get( pos );
+        }
+    }
+
+    private Class loadTestClass ( String name )
+    {
+        return ReflectionUtils.loadClass( Thread.currentThread().getContextClassLoader(), name );
+    }
+
+    @Override
+    public String toString ()
+    {
+        StringBuilder sb = new StringBuilder( "LazySocketTestsToRun: " );
+        sb.append( '(' ).append( url ).append( "):" );
+        synchronized ( workQueue )
+        {
+            sb.append( workQueue );
+        }
+
+        return sb.toString();
+    }
+
+    @Override
+    public Iterator<Class> iterator ()
+    {
+        return new NextExternalTestIterator();
+    }
+
+    @Override
+    public boolean allowEagerReading ()
+    {
+        return false;
+    }
+
+    private class NextExternalTestIterator
+                    implements Iterator<Class>
+    {
+        private int pos = -1;
+
+        public boolean hasNext ()
+        {
+            try
+            {
+                return hasNextTextClass( pos + 1 );
+            }
+            catch ( IOException e )
+            {
+                throw new RuntimeException( "Error receiving next test class from external source", e );
+            }
+        }
+
+        public Class next ()
+        {
+            return getItem( ++pos );
+        }
+
+        public void remove ()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProviderConfiguration.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProviderConfiguration.java
@@ -62,12 +62,17 @@ public class ProviderConfiguration
 
     private final boolean readTestsFromInStream;
 
+    private final boolean testsFromExternalSource;
+
+    private final String externalSourceUrl;
+
     @SuppressWarnings( "checkstyle:parameternumber" )
-    public ProviderConfiguration( DirectoryScannerParameters directoryScannerParameters,
-                                  RunOrderParameters runOrderParameters, boolean failIfNoTests,
-                                  ReporterConfiguration reporterConfiguration, TestArtifactInfo testArtifact,
-                                  TestRequest testSuiteDefinition, Properties providerProperties,
-                                  TypeEncodedValue typeEncodedTestSet, boolean readTestsFromInStream )
+    public ProviderConfiguration ( DirectoryScannerParameters directoryScannerParameters,
+                                   RunOrderParameters runOrderParameters, boolean failIfNoTests,
+                                   ReporterConfiguration reporterConfiguration, TestArtifactInfo testArtifact,
+                                   TestRequest testSuiteDefinition, Properties providerProperties,
+                                   TypeEncodedValue typeEncodedTestSet, boolean readTestsFromInStream,
+                                   boolean testsFromExternalSource, String externalSourceUrl )
     {
         this.runOrderParameters = runOrderParameters;
         this.providerProperties = providerProperties;
@@ -78,6 +83,8 @@ public class ProviderConfiguration
         this.failIfNoTests = failIfNoTests;
         this.forkTestSet = typeEncodedTestSet;
         this.readTestsFromInStream = readTestsFromInStream;
+        this.testsFromExternalSource = testsFromExternalSource;
+        this.externalSourceUrl = externalSourceUrl;
     }
 
 
@@ -142,5 +149,15 @@ public class ProviderConfiguration
     public boolean isReadTestsFromInStream()
     {
         return readTestsFromInStream;
+    }
+
+    public boolean isTestsFromExternalSource ()
+    {
+        return testsFromExternalSource;
+    }
+
+    public String getExternalSourceUrl ()
+    {
+        return externalSourceUrl;
     }
 }

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/SocketServedTestsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/SocketServedTestsIT.java
@@ -1,0 +1,177 @@
+package org.apache.maven.surefire.its;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Random;
+
+/**
+ * Basic test for test name server over socket
+ *
+ * @author Marek Piechut
+ */
+public class SocketServedTestsIT
+                extends SurefireJUnit4IntegrationTestCase
+{
+    private static final int PORT_RANGE_START = 26001;
+
+    private static final int PORT_SEARCH_TRIES = 5;
+
+    private Thread serverThread;
+
+    private Collection<String> tests = Arrays.asList( "testsOverSocket.Test1", "testsOverSocket.Test2" );
+
+    @Test
+    public void shouldExecuteOnlyTestsFromServer ()
+    {
+
+        int port = findSocketPort();
+        String url = "socket://localhost:" + port;
+
+        startServer( port, tests );
+        try
+        {
+            final OutputValidator outputValidator =
+                            unpack( "/testsOverSocket" )
+                                            .redirectToFile( true )
+                                            .setJUnitVersion( "4.7" )
+                                            .useTestsFromExternalSource()
+                                            .externalSourceUrl( url )
+                                            .executeTest();
+            outputValidator.getSurefireReportsFile( "testsOverSocket.Test1-output.txt" ).assertContainsText( "Test1" );
+            outputValidator.getSurefireReportsFile( "testsOverSocket.Test2-output.txt" ).assertContainsText( "Test2" );
+            outputValidator.getSurefireReportsFile( "testsOverSocket.Test3-output.txt" ).assertFileNotExists();
+        }
+        finally
+        {
+            stopServer();
+        }
+    }
+
+    private void startServer ( final int port, final Collection<String> tests )
+    {
+        final Queue<String> serverTests = new LinkedList<String>( tests );
+        serverThread = new Thread()
+        {
+            @Override
+            public void run ()
+            {
+                ServerSocket socket = null;
+                try
+                {
+                    System.out.println( "Starting test server on port " + port );
+                    socket = new ServerSocket( port );
+                    while ( true )
+                    {
+                        Socket client = socket.accept();
+                        try
+                        {
+                            PrintWriter out = new PrintWriter( client.getOutputStream() );
+                            String testName = serverTests.poll();
+                            out.write( testName + '\n' );
+                            out.flush();
+                            out.close();
+                            if ( testName == null )
+                            {
+                                break;
+                            }
+                        }
+                        finally
+                        {
+                            client.close();
+                        }
+                    }
+
+                }
+                catch ( Exception e )
+                {
+                    throw new RuntimeException( "Error starting tests socket server", e );
+                }
+                finally
+                {
+                    try
+                    {
+                        System.out.println( "Closing test server" );
+                        socket.close();
+                    }
+                    catch ( IOException e )
+                    {
+                        throw new RuntimeException( "Error closing test server socket", e );
+                    }
+
+                }
+
+            }
+        };
+
+        serverThread.start();
+    }
+
+    private void stopServer ()
+    {
+        serverThread.interrupt();
+    }
+
+    private int findSocketPort ()
+    {
+        Random random = new Random();
+        for ( int i = 1; i < PORT_SEARCH_TRIES; i++ )
+        {
+            int port = PORT_RANGE_START + random.nextInt( 1000 );
+            ServerSocket socket = null;
+            try
+            {
+                socket = new ServerSocket( port );
+                return port;
+            }
+            catch ( IOException e )
+            {
+                //Socket busy. Let's try another one.
+            }
+            finally
+            {
+                if ( socket != null )
+                {
+                    try
+                    {
+                        socket.close();
+                    }
+                    catch ( IOException e )
+                    {
+                        throw new RuntimeException( "Error closing socket", e );
+                    }
+                }
+            }
+        }
+
+        throw new RuntimeException( "Could not find free socket in " + PORT_SEARCH_TRIES + " tries." );
+    }
+}

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/fixture/SurefireLauncher.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/fixture/SurefireLauncher.java
@@ -475,4 +475,16 @@ public class SurefireLauncher
         mavenLauncher.setForkJvm( true );
         return this;
     }
+
+    public SurefireLauncher useTestsFromExternalSource ()
+    {
+        mavenLauncher.sysProp( "testsFromExternalSource", true );
+        return this;
+    }
+
+    public SurefireLauncher externalSourceUrl ( String url )
+    {
+        mavenLauncher.sysProp( "testExternalSourceUrl", url );
+        return this;
+    }
 }

--- a/surefire-integration-tests/src/test/resources/testsOverSocket/pom.xml
+++ b/surefire-integration-tests/src/test/resources/testsOverSocket/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>testsOverSocket</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>testsOverSocket</name>
+  <url>http://maven.apache.org</url>
+
+  <dependencies>
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>${junit.version}</version>
+      </dependency>
+  </dependencies>
+  <build>
+     <plugins>
+        <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-surefire-plugin</artifactId>
+           <configuration>
+             <forkMode>${forkMode}</forkMode>
+             <printSummary>${printSummary}</printSummary>
+             <reportFormat>${reportFormat}</reportFormat>
+             <includes>
+                <include>**/Test*.java</include>
+             </includes>
+           </configuration>
+        </plugin>
+     </plugins>
+
+  </build>
+
+    <properties>
+      <junit.version>4.8.1</junit.version>
+      <forkMode>once</forkMode>
+      <printSummary>true</printSummary>
+      <reportFormat>brief</reportFormat>
+    </properties>
+
+</project>

--- a/surefire-integration-tests/src/test/resources/testsOverSocket/src/test/java/testsOverSocket/Test1.java
+++ b/surefire-integration-tests/src/test/resources/testsOverSocket/src/test/java/testsOverSocket/Test1.java
@@ -1,0 +1,33 @@
+package testsOverSocket;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class Test1
+{
+    @Test
+    public void test1()
+    {
+        System.out.println( "Test1" );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/testsOverSocket/src/test/java/testsOverSocket/Test2.java
+++ b/surefire-integration-tests/src/test/resources/testsOverSocket/src/test/java/testsOverSocket/Test2.java
@@ -1,0 +1,33 @@
+package testsOverSocket;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class Test2
+{
+    @Test
+    public void test2()
+    {
+        System.out.println( "Test2" );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/testsOverSocket/src/test/java/testsOverSocket/Test3.java
+++ b/surefire-integration-tests/src/test/resources/testsOverSocket/src/test/java/testsOverSocket/Test3.java
@@ -1,0 +1,33 @@
+package testsOverSocket;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class Test3
+{
+    @Test
+    public void test3()
+    {
+        System.out.println( "Dont Run Me!!!" );
+    }
+}

--- a/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
+++ b/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
@@ -121,7 +121,10 @@ public class JUnit4Provider
         Result result = new Result();
         RunNotifier runNotifier = getRunNotifier( jUnit4TestSetReporter, result, customRunListeners );
 
-        runNotifier.fireTestRunStarted( createTestsDescription() );
+        if ( testsToRun.allowEagerReading() )
+        {
+            runNotifier.fireTestRunStarted( createTestsDescription() );
+        }
 
         for ( Class aTestsToRun : testsToRun )
         {


### PR DESCRIPTION
Added functionality to lazily read test class names to run from some external socket server.

After starting test phase Surefire will connect over tcp socket and ask for next test to run. All tests are considered finished after service returns empty message or null.

We use this functionality in my company to have fair balancing of tests for our integration testing cluster.
We have 6 slave machines launched by Jenkins that are executing our quite large test suite. We used manual test balancing before (using JUnit categories), but it was not really fair (some machines were processing tests for 20 minutes and some for more than hour).
