### PR TITLE
Run individual methods with junit48

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMethodPatternIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMethodPatternIT.java
@@ -19,6 +19,7 @@ package org.apache.maven.surefire.its;
  * under the License.
  */
 
+import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.junit.Test;
 
@@ -30,9 +31,11 @@ import org.junit.Test;
 public class TestMethodPatternIT
     extends SurefireJUnit4IntegrationTestCase
 {
-    public void runMethodPattern( String projectName )
+    private static final String RUNNING_WITH_JUNIT48 = "parallel='none', perCoreThreadCount=true, threadCount=0";
+
+    public OutputValidator runMethodPattern( String projectName )
     {
-        unpack( projectName ).executeTest().assertTestSuiteResults( 2, 0, 0, 0 );
+        return unpack( projectName ).executeTest().assertTestSuiteResults( 2, 0, 0, 0 );
     }
 
     @Test
@@ -44,7 +47,7 @@ public class TestMethodPatternIT
     @Test
     public void testJUnit48()
     {
-        runMethodPattern( "junit48-method-pattern" );
+        runMethodPattern( "junit48-method-pattern" ).verifyTextInLog( RUNNING_WITH_JUNIT48 );
     }
 
     @Test

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodPatternsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodPatternsIT.java
@@ -25,9 +25,7 @@ import org.junit.Test;
 
 
 /**
- * Test project using -Dtest=mtClass#myMethod+myMethod2,secondClass#testMethod
- *
- * @author <a href="mailto:ytsolar@gmail.com">rainLee</a>
+ * Test project using multiple method patterns, including wildcards in class and method names.
  */
 public class TestMultipleMethodPatternsIT
     extends SurefireJUnit4IntegrationTestCase

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodPatternsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodPatternsIT.java
@@ -1,0 +1,51 @@
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * Test project using -Dtest=mtClass#myMethod+myMethod2,secondClass#testMethod
+ *
+ * @author <a href="mailto:ytsolar@gmail.com">rainLee</a>
+ */
+public class TestMultipleMethodPatternsIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+
+    private static final String RUNNING_WITH_JUNIT48 = "parallel='none', perCoreThreadCount=true, threadCount=0";
+
+    public OutputValidator multipleMethod( String projectName )
+        throws Exception
+    {
+        return unpack( projectName ).executeTest().verifyErrorFreeLog().assertTestSuiteResults( 7, 0, 0, 0 );
+    }
+
+
+    @Test
+    public void testJunit48()
+        throws Exception
+    {
+        multipleMethod( "junit48-multiple-method-patterns" ).verifyTextInLog( RUNNING_WITH_JUNIT48 );
+    }
+
+}

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodPatternsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodPatternsIT.java
@@ -1,8 +1,5 @@
 package org.apache.maven.surefire.its;
 
-import org.apache.maven.surefire.its.fixture.OutputValidator;
-import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
-import org.junit.Test;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,6 +18,10 @@ import org.junit.Test;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
 
 
 /**

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodsIT.java
@@ -1,8 +1,5 @@
 package org.apache.maven.surefire.its;
 
-import org.apache.maven.surefire.its.fixture.OutputValidator;
-import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
-import org.junit.Test;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,6 +18,10 @@ import org.junit.Test;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
 
 
 /**

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestMultipleMethodsIT.java
@@ -1,5 +1,6 @@
 package org.apache.maven.surefire.its;
 
+import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.junit.Test;
 /*
@@ -30,10 +31,13 @@ import org.junit.Test;
 public class TestMultipleMethodsIT
     extends SurefireJUnit4IntegrationTestCase
 {
-    public void multipleMethod( String projectName )
+
+    private static final String RUNNING_WITH_JUNIT48 = "parallel='none', perCoreThreadCount=true, threadCount=0";
+
+    public OutputValidator multipleMethod( String projectName )
         throws Exception
     {
-        unpack( projectName ).executeTest().verifyErrorFreeLog().assertTestSuiteResults( 3, 0, 0, 0 );
+        return unpack( projectName ).executeTest().verifyErrorFreeLog().assertTestSuiteResults( 3, 0, 0, 0 );
     }
 
     @Test
@@ -47,7 +51,7 @@ public class TestMultipleMethodsIT
     public void testJunit48()
         throws Exception
     {
-        multipleMethod( "junit48-multiple-methods" );
+        multipleMethod( "junit48-multiple-methods" ).verifyTextInLog( RUNNING_WITH_JUNIT48 );
     }
 
 }

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestSingleMethodIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/TestSingleMethodIT.java
@@ -19,6 +19,7 @@ package org.apache.maven.surefire.its;
  * under the License.
  */
 
+import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.junit.Test;
 
@@ -30,10 +31,12 @@ import org.junit.Test;
 public class TestSingleMethodIT
     extends SurefireJUnit4IntegrationTestCase
 {
-    public void singleMethod( String projectName )
+    private static final String RUNNING_WITH_JUNIT48 = "parallel='none', perCoreThreadCount=true, threadCount=0";
+
+    public OutputValidator singleMethod( String projectName )
         throws Exception
     {
-        unpack( projectName ).executeTest().verifyErrorFreeLog().assertTestSuiteResults( 1, 0, 0, 0 );
+        return unpack( projectName ).executeTest().verifyErrorFreeLog().assertTestSuiteResults( 1, 0, 0, 0 );
     }
 
     @Test
@@ -47,7 +50,7 @@ public class TestSingleMethodIT
     public void testJunit48()
         throws Exception
     {
-        singleMethod( "junit48-single-method" );
+        singleMethod( "junit48-single-method" ).verifyTextInLog( RUNNING_WITH_JUNIT48 );
     }
 
     @Test

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/pom.xml
@@ -57,7 +57,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire.version}</version>
         <configuration>
-          <test>junit4.BasicTest#testSuccessOne+testFailOne,junit4.TestThree#testSuccess*,junit4.TestFour#testSuccess???,junit4.*Five#test*One</test>
+          <test>junit4.BasicTest#testSuccessOne+testSuccessTwo,junit4.TestThree#testSuccess*,junit4.TestFour#testSuccess???,junit4.*Five#test*One</test>
         </configuration>
         <dependencies>
           <dependency>

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>junit4</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test for JUnit 4.8.1</name>
+
+
+  <properties>
+    <junitVersion>4.8.1</junitVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junitVersion}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <test>junit4.BasicTest#testSuccessOne+testFailOne,junit4.TestThree#testSuccess*,junit4.TestFour#testSuccess???,junit4.*Five#test*One</test>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>${surefire.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/BasicTest.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/BasicTest.java
@@ -1,0 +1,83 @@
+package junit4;
+
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class BasicTest
+{
+
+    private boolean setUpCalled = false;
+
+    private static boolean tearDownCalled = false;
+    
+    @Before
+    public void setUp()
+    {
+        setUpCalled = true;
+        tearDownCalled = false;
+        System.out.println( "Called setUp" );
+    }
+
+    @After
+    public void tearDown()
+    {
+        setUpCalled = false;
+        tearDownCalled = true;
+        System.out.println( "Called tearDown" );
+    }
+
+    @Test
+    public void testSetUp()
+    {
+        Assert.assertTrue( "setUp was not called", setUpCalled );
+    }
+    
+    
+    @Test
+    public void testSuccessOne()
+    {
+        Assert.assertTrue( true );
+    }    
+    
+    @Test
+    public void testSuccessTwo()
+    {
+        Assert.assertTrue( true );
+    }   
+    
+    @Test
+    public void testFailOne()
+    {
+        Assert.assertFalse( false );
+    } 
+
+    @AfterClass
+    public static void oneTimeTearDown()
+    {
+        
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/BasicTest.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/BasicTest.java
@@ -19,65 +19,28 @@ package junit4;
  * specific language governing permissions and limitations
  * under the License.
  */
-import org.junit.After;
-import org.junit.AfterClass;
+
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 
 public class BasicTest
 {
 
-    private boolean setUpCalled = false;
-
-    private static boolean tearDownCalled = false;
-    
-    @Before
-    public void setUp()
-    {
-        setUpCalled = true;
-        tearDownCalled = false;
-        System.out.println( "Called setUp" );
-    }
-
-    @After
-    public void tearDown()
-    {
-        setUpCalled = false;
-        tearDownCalled = true;
-        System.out.println( "Called tearDown" );
-    }
-
-    @Test
-    public void testSetUp()
-    {
-        Assert.assertTrue( "setUp was not called", setUpCalled );
-    }
-    
-    
     @Test
     public void testSuccessOne()
     {
-        Assert.assertTrue( true );
-    }    
-    
+    }
+
     @Test
     public void testSuccessTwo()
     {
-        Assert.assertTrue( true );
-    }   
-    
+    }
+
     @Test
     public void testFailOne()
     {
-        Assert.assertFalse( false );
-    } 
-
-    @AfterClass
-    public static void oneTimeTearDown()
-    {
-        
+        Assert.fail( );
     }
 
 }

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestFive.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestFive.java
@@ -19,61 +19,25 @@ package junit4;
  * under the License.
  */
 
-import org.junit.*;
+import org.junit.Test;
 
 
 public class TestFive
 {
 
-    private boolean setUpCalled = false;
-
-    private static boolean tearDownCalled = false;
-
-    @Before
-    public void setUp()
-    {
-        setUpCalled = true;
-        tearDownCalled = false;
-        System.out.println( "Called setUp" );
-    }
-
-    @After
-    public void tearDown()
-    {
-        setUpCalled = false;
-        tearDownCalled = true;
-        System.out.println( "Called tearDown" );
-    }
-
-    @Test
-    public void testSetUp()
-    {
-        Assert.assertTrue( "setUp was not called", setUpCalled );
-    }
-
-
     @Test
     public void testSuccessOne()
     {
-        Assert.assertTrue( true );
     }
 
     @Test
     public void testSuccessTwo()
     {
-        Assert.assertTrue( true );
     }
 
     @Test
     public void testSuccessThree()
     {
-        Assert.assertTrue( true );
-    }
-
-    @AfterClass
-    public static void oneTimeTearDown()
-    {
-
     }
 
 }

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestFive.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestFive.java
@@ -1,0 +1,79 @@
+package junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.*;
+
+
+public class TestFive
+{
+
+    private boolean setUpCalled = false;
+
+    private static boolean tearDownCalled = false;
+
+    @Before
+    public void setUp()
+    {
+        setUpCalled = true;
+        tearDownCalled = false;
+        System.out.println( "Called setUp" );
+    }
+
+    @After
+    public void tearDown()
+    {
+        setUpCalled = false;
+        tearDownCalled = true;
+        System.out.println( "Called tearDown" );
+    }
+
+    @Test
+    public void testSetUp()
+    {
+        Assert.assertTrue( "setUp was not called", setUpCalled );
+    }
+
+
+    @Test
+    public void testSuccessOne()
+    {
+        Assert.assertTrue( true );
+    }
+
+    @Test
+    public void testSuccessTwo()
+    {
+        Assert.assertTrue( true );
+    }
+
+    @Test
+    public void testSuccessThree()
+    {
+        Assert.assertTrue( true );
+    }
+
+    @AfterClass
+    public static void oneTimeTearDown()
+    {
+
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestFour.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestFour.java
@@ -1,0 +1,79 @@
+package junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.*;
+
+
+public class TestFour
+{
+
+    private boolean setUpCalled = false;
+
+    private static boolean tearDownCalled = false;
+
+    @Before
+    public void setUp()
+    {
+        setUpCalled = true;
+        tearDownCalled = false;
+        System.out.println( "Called setUp" );
+    }
+
+    @After
+    public void tearDown()
+    {
+        setUpCalled = false;
+        tearDownCalled = true;
+        System.out.println( "Called tearDown" );
+    }
+
+    @Test
+    public void testSetUp()
+    {
+        Assert.assertTrue( "setUp was not called", setUpCalled );
+    }
+
+
+    @Test
+    public void testSuccessOne()
+    {
+        Assert.assertTrue( true );
+    }
+
+    @Test
+    public void testSuccessTwo()
+    {
+        Assert.assertTrue( true );
+    }
+
+    @Test
+    public void testSuccessThree()
+    {
+        Assert.assertTrue( true );
+    }
+
+    @AfterClass
+    public static void oneTimeTearDown()
+    {
+
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestFour.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestFour.java
@@ -19,61 +19,25 @@ package junit4;
  * under the License.
  */
 
-import org.junit.*;
+import org.junit.Test;
 
 
 public class TestFour
 {
 
-    private boolean setUpCalled = false;
-
-    private static boolean tearDownCalled = false;
-
-    @Before
-    public void setUp()
-    {
-        setUpCalled = true;
-        tearDownCalled = false;
-        System.out.println( "Called setUp" );
-    }
-
-    @After
-    public void tearDown()
-    {
-        setUpCalled = false;
-        tearDownCalled = true;
-        System.out.println( "Called tearDown" );
-    }
-
-    @Test
-    public void testSetUp()
-    {
-        Assert.assertTrue( "setUp was not called", setUpCalled );
-    }
-
-
     @Test
     public void testSuccessOne()
     {
-        Assert.assertTrue( true );
     }
 
     @Test
     public void testSuccessTwo()
     {
-        Assert.assertTrue( true );
     }
 
     @Test
     public void testSuccessThree()
     {
-        Assert.assertTrue( true );
-    }
-
-    @AfterClass
-    public static void oneTimeTearDown()
-    {
-
     }
 
 }

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestThree.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestThree.java
@@ -19,65 +19,27 @@ package junit4;
  * under the License.
  */
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 
 public class TestThree
 {
 
-    private boolean setUpCalled = false;
-
-    private static boolean tearDownCalled = false;
-
-    @Before
-    public void setUp()
-    {
-        setUpCalled = true;
-        tearDownCalled = false;
-        System.out.println( "Called setUp" );
-    }
-
-    @After
-    public void tearDown()
-    {
-        setUpCalled = false;
-        tearDownCalled = true;
-        System.out.println( "Called tearDown" );
-    }
-
-    @Test
-    public void testSetUp()
-    {
-        Assert.assertTrue( "setUp was not called", setUpCalled );
-    }
-
-
     @Test
     public void testSuccessOne()
     {
-        Assert.assertTrue( true );
     }
 
     @Test
     public void testSuccessTwo()
     {
-        Assert.assertTrue( true );
     }
 
     @Test
     public void testFailOne()
     {
-        Assert.assertFalse( false );
-    }
-
-    @AfterClass
-    public static void oneTimeTearDown()
-    {
-
+        Assert.fail();
     }
 
 }

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestThree.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestThree.java
@@ -1,0 +1,83 @@
+package junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class TestThree
+{
+
+    private boolean setUpCalled = false;
+
+    private static boolean tearDownCalled = false;
+
+    @Before
+    public void setUp()
+    {
+        setUpCalled = true;
+        tearDownCalled = false;
+        System.out.println( "Called setUp" );
+    }
+
+    @After
+    public void tearDown()
+    {
+        setUpCalled = false;
+        tearDownCalled = true;
+        System.out.println( "Called tearDown" );
+    }
+
+    @Test
+    public void testSetUp()
+    {
+        Assert.assertTrue( "setUp was not called", setUpCalled );
+    }
+
+
+    @Test
+    public void testSuccessOne()
+    {
+        Assert.assertTrue( true );
+    }
+
+    @Test
+    public void testSuccessTwo()
+    {
+        Assert.assertTrue( true );
+    }
+
+    @Test
+    public void testFailOne()
+    {
+        Assert.assertFalse( false );
+    }
+
+    @AfterClass
+    public static void oneTimeTearDown()
+    {
+
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestTwo.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestTwo.java
@@ -1,0 +1,76 @@
+package junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class TestTwo
+{
+
+    private boolean setUpCalled = false;
+
+    private static boolean tearDownCalled = false;
+    
+    @Before
+    public void setUp()
+    {
+        setUpCalled = true;
+        tearDownCalled = false;
+        System.out.println( "Called setUp" );
+    }
+
+    @After
+    public void tearDown()
+    {
+        setUpCalled = false;
+        tearDownCalled = true;
+        System.out.println( "Called tearDown" );
+    }
+
+    @Test
+    public void testSetUp()
+    {
+        Assert.assertTrue( "setUp was not called", setUpCalled );
+    }
+    
+    
+    @Test
+    public void testSuccessOne()
+    {
+        Assert.assertTrue( true );
+    } 
+    
+    @Test
+    public void testSuccessTwo()
+    {
+        Assert.assertTrue( true );
+    }    
+
+    @AfterClass
+    public static void oneTimeTearDown()
+    {
+        
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestTwo.java
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-method-patterns/src/test/java/junit4/TestTwo.java
@@ -18,59 +18,24 @@ package junit4;
  * specific language governing permissions and limitations
  * under the License.
  */
-import org.junit.After;
-import org.junit.AfterClass;
+
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 
 public class TestTwo
 {
 
-    private boolean setUpCalled = false;
-
-    private static boolean tearDownCalled = false;
-    
-    @Before
-    public void setUp()
-    {
-        setUpCalled = true;
-        tearDownCalled = false;
-        System.out.println( "Called setUp" );
-    }
-
-    @After
-    public void tearDown()
-    {
-        setUpCalled = false;
-        tearDownCalled = true;
-        System.out.println( "Called tearDown" );
-    }
-
-    @Test
-    public void testSetUp()
-    {
-        Assert.assertTrue( "setUp was not called", setUpCalled );
-    }
-    
-    
     @Test
     public void testSuccessOne()
     {
         Assert.assertTrue( true );
-    } 
-    
+    }
+
     @Test
     public void testSuccessTwo()
     {
         Assert.assertTrue( true );
-    }    
-
-    @AfterClass
-    public static void oneTimeTearDown()
-    {
-        
     }
 
 }

--- a/surefire-integration-tests/src/test/resources/junit48-multiple-methods/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit48-multiple-methods/pom.xml
@@ -41,7 +41,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -59,6 +59,13 @@
         <configuration>
           <test>junit4.BasicTest#testSuccessOne+testFailOne,junit4.TestThree#testSuccessTwo</test>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>${surefire.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/surefire-integration-tests/src/test/resources/junit48-single-method/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit48-single-method/pom.xml
@@ -41,7 +41,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -59,6 +59,13 @@
         <configuration>
           <test>BasicTest#testSuccessOne</test>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>${surefire.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/surefire-providers/common-junit48/src/main/java/org/apache/maven/surefire/common/junit48/FilterFactory.java
+++ b/surefire-providers/common-junit48/src/main/java/org/apache/maven/surefire/common/junit48/FilterFactory.java
@@ -131,10 +131,6 @@ public class FilterFactory
                 String describedClassName = description.getClassName();
                 String describedMethodName = description.getMethodName();
 
-                System.out.println( "current description " + describedClassName + " " + describedMethodName );
-                System.out.println( "trying to match against " + this.className + " "
-                        + this.methodName );
-
                 if ( describedClassName != null )
                 {
                     if ( this.className.indexOf( '*' ) < 0 && this.className.indexOf( '?' ) < 0 )
@@ -198,8 +194,6 @@ public class FilterFactory
                     }
                 }
             }
-            System.out.println( requestString );
-
             this.requestString = requestString;
             this.requestedTestMethods = requestedTestMethods;
         }

--- a/surefire-providers/common-junit48/src/test/java/org/apache/maven/surefire/common/junit48/FilterFactoryTest.java
+++ b/surefire-providers/common-junit48/src/test/java/org/apache/maven/surefire/common/junit48/FilterFactoryTest.java
@@ -112,17 +112,9 @@ public class FilterFactoryTest
     }
 
     @Test
-    public void shouldMatchEndOfClassNameWithMethod()
+    public void shouldMatchSimpleClassNameWithMethod()
     {
-        Filter exactFilter = createMethodFilter( "FirstClass#testMethod" );
-        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
-        assertFalse( "other method should not match", exactFilter.shouldRun( otherMethod ) );
-    }
-
-    @Test
-    public void shouldMatchPartialClassNameWithMethod()
-    {
-        Filter exactFilter = createMethodFilter( "FirstClass#testMethod" );
+        Filter exactFilter = createMethodFilter( "FilterFactoryTest$FirstClass#testMethod" );
         assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
         assertFalse( "other method should not match", exactFilter.shouldRun( otherMethod ) );
     }

--- a/surefire-providers/common-junit48/src/test/java/org/apache/maven/surefire/common/junit48/FilterFactoryTest.java
+++ b/surefire-providers/common-junit48/src/test/java/org/apache/maven/surefire/common/junit48/FilterFactoryTest.java
@@ -1,0 +1,208 @@
+package org.apache.maven.surefire.common.junit48;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.runner.Description.createTestDescription;
+
+public class FilterFactoryTest
+{
+    static class Suite
+    {
+
+    }
+
+    static class FirstClass
+    {
+
+    }
+
+    static class SecondClass {
+
+    }
+
+    private final Description testMethod = createTestDescription( FirstClass.class, "testMethod" );
+    private final Description secondTestMethod = createTestDescription( FirstClass.class, "secondTestMethod" );
+    private final Description otherMethod = createTestDescription( FirstClass.class, "otherMethod" );
+    private final Description testMethodInSecondClass = createTestDescription( SecondClass.class, "testMethod" );
+    private final Description secondTestMethodInSecondClass = createTestDescription( SecondClass.class,
+            "secondTestMethod" );
+
+    private final String firstClassName = FirstClass.class.getName();
+    private final String secondClassName = SecondClass.class.getName();
+
+    private Filter createMethodFilter( String requestString )
+    {
+        return new FilterFactory( getClass().getClassLoader() ).createMethodFilter( requestString );
+    }
+
+    @Test
+    public void shouldMatchExactMethodName()
+    {
+        Filter exactFilter = createMethodFilter( "testMethod" );
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
+    }
+
+    @Test
+    public void shouldMatchExactMethodNameWithHash()
+    {
+        Filter exactFilter = createMethodFilter( "#testMethod" );
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
+    }
+
+    @Test
+    public void shouldNotMatchExactOnOtherMethod()
+    {
+        Filter exactFilter = createMethodFilter( "testMethod" );
+        assertFalse( "should not run other methods", exactFilter.shouldRun( otherMethod ) );
+    }
+
+    @Test
+    public void shouldMatchWildCardsInMethodName()
+    {
+        Filter starAtEnd = createMethodFilter( "test*" );
+        assertTrue( "match ending with star should run", starAtEnd.shouldRun( testMethod ) );
+
+        Filter starAtBeginning = createMethodFilter( "*Method" );
+        assertTrue( "match starting with star should run", starAtBeginning.shouldRun( testMethod ) );
+
+        Filter starInMiddle = createMethodFilter( "test*thod" );
+        assertTrue( "match containing star should run", starInMiddle.shouldRun( testMethod ) );
+
+        Filter questionAtEnd = createMethodFilter( "testMetho?" );
+        assertTrue( "match ending with question mark should run", questionAtEnd.shouldRun( testMethod ) );
+
+        Filter questionAtBeginning = createMethodFilter( "????Method" );
+        assertTrue( "match starting with question mark should run", questionAtBeginning.shouldRun( testMethod ) );
+
+        Filter questionInMiddle = createMethodFilter( "testM?thod" );
+        assertTrue( "match containing question mark should run", questionInMiddle.shouldRun( testMethod ) );
+
+        Filter starAndQuestion = createMethodFilter( "t?st*thod" );
+        assertTrue( "match containing star and question mark should run", starAndQuestion.shouldRun( testMethod ) );
+    }
+
+    @Test
+    public void shouldMatchExactClassAndMethod()
+    {
+        Filter exactFilter = createMethodFilter( firstClassName + "#testMethod" );
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
+    }
+
+    @Test
+    public void shouldMatchEndOfClassNameWithMethod()
+    {
+        Filter exactFilter = createMethodFilter( "FirstClass#testMethod" );
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
+        assertFalse( "other method should not match", exactFilter.shouldRun( otherMethod ) );
+    }
+
+    @Test
+    public void shouldMatchPartialClassNameWithMethod()
+    {
+        Filter exactFilter = createMethodFilter( "FirstClass#testMethod" );
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
+        assertFalse( "other method should not match", exactFilter.shouldRun( otherMethod ) );
+    }
+
+    @Test
+    public void shouldMatchClassNameWithWildcardAndMethod()
+    {
+        Filter exactFilter = createMethodFilter( "*First*#testMethod" );
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
+        assertFalse( "other method should not match", exactFilter.shouldRun( otherMethod ) );
+    }
+
+    @Test
+    public void shouldMatchClassNameWithWildcardCompletely()
+    {
+        Filter exactFilter = createMethodFilter( "First*#testMethod" );
+        assertFalse( "other method should not match", exactFilter.shouldRun( testMethod ) );
+        assertFalse( "other method should not match", exactFilter.shouldRun( otherMethod ) );
+    }
+
+
+    @Test
+    public void shouldMatchMultipleMethodsSeparatedByComman()
+    {
+        Filter exactFilter = createMethodFilter( firstClassName + "#testMethod,#secondTestMethod" );
+
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( secondTestMethod ) );
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( secondTestMethodInSecondClass ) );
+
+        assertFalse( "other method should not match", exactFilter.shouldRun( otherMethod ) );
+    }
+
+    @Test
+    public void shouldMatchMultipleMethodsInSameClassSeparatedByPlus() {
+        Filter exactFilter = createMethodFilter( FirstClass.class.getName() + "#testMethod+secondTestMethod" );
+
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( secondTestMethod ) );
+
+        assertFalse( "method in another class should not match", exactFilter.shouldRun( secondTestMethodInSecondClass ) );
+
+        assertFalse( "other method should not match", exactFilter.shouldRun( otherMethod ) );
+    }
+
+    @Test
+    public void shouldRunCompleteClassWhenSeparatedByCommaWithoutHash() {
+        Filter exactFilter = createMethodFilter( firstClassName + "#testMethod," + secondClassName );
+
+        assertTrue( "exact match on name should run", exactFilter.shouldRun( testMethod ) );
+
+        assertFalse( "other method should not match", exactFilter.shouldRun( secondTestMethod ) );
+        assertFalse( "other method should not match", exactFilter.shouldRun( otherMethod ) );
+
+        assertTrue( "should run complete second class", exactFilter.shouldRun( testMethodInSecondClass ) );
+        assertTrue( "should run complete second class", exactFilter.shouldRun( secondTestMethodInSecondClass ) );
+    }
+
+    @Test
+    public void shouldRunSuitesContainingExactMethodName()
+    {
+        Description suite = Description.createSuiteDescription( Suite.class );
+        suite.addChild( testMethod );
+        suite.addChild( secondTestMethod );
+
+        Filter exactFilter = createMethodFilter( "testMethod" );
+        assertTrue( "should run suites containing matching method", exactFilter.shouldRun( suite ) );
+    }
+
+    @Test
+    public void shouldSkipSuitesNotContainingExactMethodName()
+    {
+        Description suite = Description.createSuiteDescription( Suite.class );
+        suite.addChild( testMethod );
+        suite.addChild( secondTestMethod );
+
+        Filter exactFilter = createMethodFilter( "otherMethod" );
+        assertFalse( "should not run method", exactFilter.shouldRun( testMethod ) );
+        assertFalse( "should not run method", exactFilter.shouldRun( secondTestMethod ) );
+        assertFalse( "should not run suites containing no matches", exactFilter.shouldRun( suite ) );
+    }
+
+}


### PR DESCRIPTION
This implements a method filter for the junit 4.8 provider that supports the same syntax as discussed in <https://jira.codehaus.org/browse/SUREFIRE-745> and documented in <http://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html#Running_a_Set_of_Methods_in_a_Single_Test_Class>. That ticket apparently only contained an implementation for the junit 4.0 provider and only handled one or two methodss per class.

I still have to add tests for this functionality. Would unit tests just for the method filter, using mocked Descriptions, be enough or do you also require integration tests? If so I would need some pointers to how the setup of integration tests inside surefire itself would work.

Let me know what you think of this approach.