### PR TITLE
[SUREFIRE-1128] Fix mvn 2.2.1 build process https://builds.apache.org/view/All/job/maven-surefire-mvn-2.2.1

### DIFF
--- a/maven-failsafe-plugin/src/it/jetty-war-test-failing/invoker.properties
+++ b/maven-failsafe-plugin/src/it/jetty-war-test-failing/invoker.properties
@@ -17,3 +17,6 @@
 # under the License.
 #
 invoker.buildResult=failure
+
+# build project if JRE version is 1.7 or higher
+invoker.java.version = 1.7+

--- a/maven-failsafe-plugin/src/it/jetty-war-test-passing/invoker.properties
+++ b/maven-failsafe-plugin/src/it/jetty-war-test-passing/invoker.properties
@@ -17,3 +17,6 @@
 # under the License.
 #
 invoker.buildResult=success
+
+# build project if JRE version is 1.7 or higher
+invoker.java.version = 1.7+

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -60,6 +60,7 @@ public class StatelessXmlReporterTest
     private final static String TEST_TWO = "bTestMethod";
     private final static String TEST_THREE = "cTestMethod";
 
+    @Override
     protected void setUp()
         throws Exception
     {
@@ -71,7 +72,8 @@ public class StatelessXmlReporterTest
         reporter.cleanTestHistoryMap();
     }
 
-    @Override protected void tearDown()
+    @Override
+    protected void tearDown()
         throws Exception
     {
         super.tearDown();

--- a/surefire-integration-tests/src/test/resources/surefire-1055-parallelTestCount/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1055-parallelTestCount/pom.xml
@@ -20,9 +20,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.apache.maven.surefire</groupId>
+        <artifactId>it-parent</artifactId>
+        <version>1.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <groupId>foo</groupId>
     <artifactId>foo</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <name>foo</name>
@@ -37,6 +44,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -45,17 +53,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.5</source>
+                    <target>1.5</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
                 <configuration>
+                    <forkMode>once</forkMode>
                     <parallel>classesAndMethods</parallel>
                     <perCoreThreadCount>false</perCoreThreadCount>
                     <useUnlimitedThreads>true</useUnlimitedThreads>

--- a/surefire-integration-tests/src/test/resources/testng-listeners/src/test/java/listeners/MarkAsFailureListener.java
+++ b/surefire-integration-tests/src/test/resources/testng-listeners/src/test/java/listeners/MarkAsFailureListener.java
@@ -31,12 +31,12 @@ import org.testng.ITestResult;
  */
 public class MarkAsFailureListener implements ITestListener, IInvokedMethodListener {
 
-    @Override
+    //todo add @Override in surefire 3.0 running on the top of JDK 6
     public void onTestStart(ITestResult result) {
 
     }
 
-    @Override
+    //todo add @Override in surefire 3.0 running on the top of JDK 6
     public void onTestSuccess(ITestResult result) {
 
     }
@@ -46,37 +46,37 @@ public class MarkAsFailureListener implements ITestListener, IInvokedMethodListe
      * I will be called twice in some condition!!!
      * @param result
      */
-    @Override
+    //todo add @Override in surefire 3.0 running on the top of JDK 6
     public void onTestFailure(ITestResult result) {
         System.out.println(++counter);
     }
 
-    @Override
+    //todo add @Override in surefire 3.0 running on the top of JDK 6
     public void onTestSkipped(ITestResult result) {
 
     }
 
-    @Override
+    //todo add @Override in surefire 3.0 running on the top of JDK 6
     public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
 
     }
 
-    @Override
+    //todo add @Override in surefire 3.0 running on the top of JDK 6
     public void onStart(ITestContext context) {
 
     }
 
-    @Override
+    //todo add @Override in surefire 3.0 running on the top of JDK 6
     public void onFinish(ITestContext context) {
 
     }
 
-    @Override
+    //todo add @Override in surefire 3.0 running on the top of JDK 6
     public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
 
     }
 
-    @Override
+    //todo add @Override in surefire 3.0 running on the top of JDK 6
     public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
         testResult.setStatus(ITestResult.FAILURE);
     }


### PR DESCRIPTION
Fixed annoying issue related to JDK5/7

mvn verify -pl maven-failsafe-plugin -P run-its

tested with java.home jdk5

[INFO] --- maven-invoker-plugin:1.9:run (integration-test) @ maven-failsafe-plugin ---
[INFO] Building: jetty-war-test-failing\pom.xml
[INFO] ..SKIPPED due to JRE version
[INFO] Building: jetty-war-test-passing\pom.xml
[INFO] ..SKIPPED due to JRE version
[INFO] Building: multiple-summaries\pom.xml
[INFO] ..SUCCESS (3.7 s)
[INFO] Building: multiple-summaries-failing\pom.xml
[INFO] ..SUCCESS (3.6 s)
[INFO] Building: working-directory\pom.xml
[INFO] ..SUCCESS (3.4 s)
[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO]   Passed: 3, Failed: 0, Errors: 0, Skipped: 2
[INFO] -------------------------------------------------

tested with java.home  jdk7

[INFO] --- maven-invoker-plugin:1.9:run (integration-test) @ maven-failsafe-plugin ---
[INFO] Building: jetty-war-test-failing\pom.xml
[INFO] run script verify.bsh.bsh
[INFO] ..SUCCESS (7.5 s)
[INFO] Building: jetty-war-test-passing\pom.xml
[INFO] run script verify.bsh.bsh
[INFO] ..SUCCESS (6.9 s)
[INFO] Building: multiple-summaries\pom.xml
[INFO] ..SUCCESS (3.6 s)
[INFO] Building: multiple-summaries-failing\pom.xml
[INFO] ..SUCCESS (3.7 s)
[INFO] Building: working-directory\pom.xml
[INFO] ..SUCCESS (3.4 s)
[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO]   Passed: 5, Failed: 0, Errors: 0, Skipped: 0
[INFO] -------------------------------------------------

Due to @Override cannot be applied on implemented interface method, I have commented out @Override on interfaces in MarkAsFailureListener.java. Later in Surefire-3.0 the annotation should be applied again, see SUREFIRE-1130.

Removed unnecessary javac 1.6 in IT test surefire-1055-parallelTestCount/pom.xml.
