### PR TITLE
SUREFIRE-1136 Current working directory propagation in forked mode

### DIFF
--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkConfigurationTest.java
@@ -21,11 +21,11 @@ package org.apache.maven.plugin.surefire.booterclient;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.maven.shared.utils.StringUtils;
 import org.apache.maven.shared.utils.cli.Commandline;
 import org.apache.maven.surefire.booter.Classpath;
@@ -67,7 +67,9 @@ public class ForkConfigurationTest
         throws IOException, SurefireBooterForkException
     {
         // SUREFIRE-1136
-        File baseDir = Files.createTempDirectory( "SUREFIRE-1136-" ).toFile();
+        File baseDir =
+            new File( FileUtils.getTempDirectory(), "SUREFIRE-1136-" + RandomStringUtils.randomAlphabetic( 3 ) );
+        baseDir.mkdirs();
         baseDir.deleteOnExit();
 
         File cwd = new File( baseDir, "fork_${surefire.forkNumber}" );
@@ -85,7 +87,9 @@ public class ForkConfigurationTest
         throws IOException, SurefireBooterForkException
     {
         // SUREFIRE-1136
-        File baseDir = Files.createTempDirectory( "SUREFIRE-1136-" ).toFile();
+        File baseDir =
+            new File( FileUtils.getTempDirectory(), "SUREFIRE-1136-" + RandomStringUtils.randomAlphabetic( 3 ) );
+        baseDir.mkdirs();
         baseDir.deleteOnExit();
 
         File cwd = new File( baseDir, "cwd.txt" );
@@ -113,10 +117,12 @@ public class ForkConfigurationTest
         throws IOException, SurefireBooterForkException
     {
         // SUREFIRE-1136
-        File baseDir = Files.createTempDirectory( "SUREFIRE-1136-" ).toFile();
+        File baseDir =
+            new File( FileUtils.getTempDirectory(), "SUREFIRE-1136-" + RandomStringUtils.randomAlphabetic( 3 ) );
+        baseDir.mkdirs();
         baseDir.deleteOnExit();
 
-        File cwd = new File( baseDir, "\0?InvalidDirectoryName" );
+        File cwd = new File( baseDir, "?\0InvalidDirectoryName" );
         ForkConfiguration config = getForkConfiguration( null, "java", cwd.getAbsoluteFile() );
 
         try

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
         </plugin>
+        <!-- NOTE: animal sniffer does not check test classes: https://jira.codehaus.org/browse/MANIMALSNIFFER-40 -->
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>

--- a/surefire-integration-tests/src/test/resources/surefire-1136-cwd-propagation-in-forked-mode/src/test/java/cwd/CurrentWorkingDirectoryInForkedModeTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1136-cwd-propagation-in-forked-mode/src/test/java/cwd/CurrentWorkingDirectoryInForkedModeTest.java
@@ -37,9 +37,13 @@ public class CurrentWorkingDirectoryInForkedModeTest
         File forkDirectory = new File( projectDirectory, "cwd_1" );
         forkDirectory.deleteOnExit();
 
+        // user.dir and current working directory must be aligned, base directory is not affected
         assertThat( System.getProperty( "basedir" ) ).isEqualTo( projectDirectory.getCanonicalPath() );
         assertThat( System.getProperty( "user.dir" ) ).isEqualTo( forkDirectory.getCanonicalPath() );
         assertThat( new File( "." ).getCanonicalPath() ).isEqualTo( forkDirectory.getCanonicalPath() );
+
+        // original working directory (before variable expansion) should not be created
+        assertThat( new File( "cwd_${surefire.forkNumber}" ) ).doesNotExist();
 
     }
 


### PR DESCRIPTION
remove JDK 1.7 API usages in tests, integration test extended to justify deferred directory creation in AbstractSurefireMojo.ensureWorkingDirectoryExists