### PR TITLE
[SUREFIRE-1024] "verify" goal ignores "dependenciesToScan" parameter when checking tests existence

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
@@ -157,7 +157,7 @@ public class VerifyMojo
             RunResult summary;
             try
             {
-                String encoding;
+                final String encoding;
                 if ( StringUtils.isEmpty( this.encoding ) )
                 {
                     getLog().warn(
@@ -171,19 +171,13 @@ public class VerifyMojo
                     encoding = this.encoding;
                 }
 
-                if ( !summaryFile.isFile() && summaryFiles != null )
+                summary = existsSummaryFile() ? readSummary( encoding, summaryFile ) : RunResult.noTestsRun();
+
+                if ( existsSummaryFiles() )
                 {
-                    summary = RunResult.noTestsRun();
-                }
-                else
-                {
-                    summary = readSummary( encoding, summaryFile );
-                }
-                if ( summaryFiles != null )
-                {
-                    for ( File file : summaryFiles )
+                    for ( final File summaryFile : summaryFiles )
                     {
-                        summary = summary.aggregate( readSummary( encoding, file ) );
+                        summary = summary.aggregate( readSummary( encoding, summaryFile ) );
                     }
                 }
             }
@@ -232,6 +226,10 @@ public class VerifyMojo
             {
                 throw new MojoFailureException( "No tests to run!" );
             }
+        }
+
+        if ( !existsSummary() )
+        {
             getLog().info( "No tests to run." );
             return false;
         }
@@ -339,6 +337,21 @@ public class VerifyMojo
     public void setFailIfNoTests( Boolean failIfNoTests )
     {
         this.failIfNoTests = failIfNoTests;
+    }
+
+    private boolean existsSummaryFile()
+    {
+        return summaryFile != null && summaryFile.isFile();
+    }
+
+    private boolean existsSummaryFiles()
+    {
+        return summaryFiles != null && summaryFiles.length != 0;
+    }
+
+    private boolean existsSummary()
+    {
+        return existsSummaryFile() || existsSummaryFiles();
     }
 
 }

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1024VerifyFailsafeIfTestedIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1024VerifyFailsafeIfTestedIT.java
@@ -1,0 +1,48 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Test;
+
+/**
+ * "verify" goal ignores "dependenciesToScan" parameter when checking tests existence
+ * <p>
+ * Found in Surefire 2.16.
+ *
+ * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
+ * @see {@linkplain https://jira.codehaus.org/browse/SUREFIRE-1024}
+ * @since 2.19
+ */
+public class Surefire1024VerifyFailsafeIfTestedIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+
+    @Test
+    public void shouldScanAndRunTestsInDependencyJars() throws Exception {
+        SurefireLauncher launcher = unpack( "surefire-1024" );
+        launcher.executeVerify()
+            .verifyTextInLog( "class jiras.surefire1024.A1IT#test() dependency to scan" );
+
+        launcher.getSubProjectValidator( "jiras-surefire-1024-it" )
+            .assertIntegrationTestSuiteResults( 1, 0, 0, 0 );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1024/jiras-surefire-1024-it/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1024/jiras-surefire-1024-it/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>jiras-surefire-1024</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>jiras-surefire-1024-it</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugins.surefire</groupId>
+      <artifactId>jiras-surefire-1024-testjar</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dependenciesToScan>
+            <dependency>org.apache.maven.plugins.surefire:jiras-surefire-1024-testjar</dependency>
+          </dependenciesToScan>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-1024/jiras-surefire-1024-testjar/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1024/jiras-surefire-1024-testjar/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>jiras-surefire-1024</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>jiras-surefire-1024-testjar</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.1</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-1024/jiras-surefire-1024-testjar/src/main/java/jiras/surefire1024/A1IT.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1024/jiras-surefire-1024-testjar/src/main/java/jiras/surefire1024/A1IT.java
@@ -1,0 +1,12 @@
+package jiras.surefire1024;
+
+import org.junit.Test;
+
+public class A1IT
+{
+    @Test
+    public void test()
+    {
+        System.out.println( getClass() + "#test() dependency to scan" );
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1024/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1024/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-1024</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <url>http://maven.apache.org</url>
+  <developers>
+    <developer>
+      <id>tibordigana</id>
+      <name>Tibor Digaňa (tibor17)</name>
+      <email>tibordigana@apache.org</email>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Bratislava</timezone>
+    </developer>
+  </developers>
+
+  <modules>
+    <module>jiras-surefire-1024-testjar</module>
+    <module>jiras-surefire-1024-it</module>
+  </modules>
+
+</project>


### PR DESCRIPTION
The problem of SUREFIRE-1024 was with failsafe plugin which however executed integration-test phase with making a report but did not execute verify phase on POM with packaging POM.

The plugin execution is avoided with printing "No tests to run." if `existsSummary()` returns false.
In the old code the execution was avoided if test-classes was not found, which was strange because the ITs were executed anyway without test-classes (surefire-1024 used dependenciesToScan). Nowadays no-reports means nothing to verify which looks more reasonable in `VerifyMojo.java`.
The old functionality still exists, so that in throwing `MojoFailureException( "No tests to run!" )` if test-classes do not exist AND FailIfNoTests==true.
Additionally improved branching in `execute()`.