### PR TITLE
[SUREFIRE-1154] TestNG should be able to run its own tests

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1756,7 +1756,15 @@ public abstract class AbstractSurefireMojo
 
     private Artifact getJunitArtifact()
     {
-        return getProjectArtifactMap().get( getJunitArtifactName() );
+        Artifact artifact = getProjectArtifactMap().get( getJunitArtifactName() );
+
+        if ( artifact == null && getJunitArtifactName().equals(
+            project.getArtifact().getGroupId() + ":" + project.getArtifact().getArtifactId() ) )
+        {
+            return project.getArtifact();
+        }
+
+        return artifact;
     }
 
     private Artifact getJunitDepArtifact()

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1722,6 +1722,8 @@ public abstract class AbstractSurefireMojo
         throws MojoExecutionException
     {
         Artifact artifact = getProjectArtifactMap().get( getTestNGArtifactName() );
+        Artifact projectArtifact = project.getArtifact();
+        String projectArtifactName = projectArtifact.getGroupId() + ":" + projectArtifact.getArtifactId();
 
         if ( artifact != null )
         {
@@ -1733,11 +1735,11 @@ public abstract class AbstractSurefireMojo
                         + artifact.getVersion() );
             }
         }
-        else if ( getTestNGArtifactName().equals(
-            project.getArtifact().getGroupId() + ":" + project.getArtifact().getArtifactId() ) )
+        else if ( projectArtifactName.equals( getTestNGArtifactName() ) )
         {
-            return project.getArtifact();
+            artifact = projectArtifact;
         }
+
         return artifact;
 
     }
@@ -1757,11 +1759,12 @@ public abstract class AbstractSurefireMojo
     private Artifact getJunitArtifact()
     {
         Artifact artifact = getProjectArtifactMap().get( getJunitArtifactName() );
+        Artifact projectArtifact = project.getArtifact();
+        String projectArtifactName = projectArtifact.getGroupId() + ":" + projectArtifact.getArtifactId();
 
-        if ( artifact == null && getJunitArtifactName().equals(
-            project.getArtifact().getGroupId() + ":" + project.getArtifact().getArtifactId() ) )
+        if ( artifact == null && projectArtifactName.equals( getJunitArtifactName() ) )
         {
-            return project.getArtifact();
+            artifact = projectArtifact;
         }
 
         return artifact;

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1733,6 +1733,11 @@ public abstract class AbstractSurefireMojo
                         + artifact.getVersion() );
             }
         }
+        else if ( getTestNGArtifactName().equals(
+            project.getArtifact().getGroupId() + ":" + project.getArtifact().getArtifactId() ) )
+        {
+            return project.getArtifact();
+        }
         return artifact;
 
     }


### PR DESCRIPTION
Currently, TestNG could not run its own tests due to: 

```
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project testng: suiteXmlFiles is configured, but there is no TestNG dependency
```