### PR TITLE
[SUREFIRE-1153] Take includes into account when using test/it.test property

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1540,7 +1540,7 @@ public abstract class AbstractSurefireMojo
 
     private boolean isSpecificTestSpecified()
     {
-        return getTest() != null;
+        return StringUtils.isNotBlank( getTest() );
     }
 
     private boolean isValidSuiteXmlFileConfig()

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -54,8 +53,6 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -1634,39 +1631,39 @@ public abstract class AbstractSurefireMojo
     private List<String> getIncludeList()
         throws MojoFailureException
     {
-        List<String> actualIncludes = null;
-        if ( isSpecificTestSpecified() && !isMultipleExecutionBlocksDetected() )
+        List<String> includes = null;
+        if ( isSpecificTestSpecified() )
         {
-            actualIncludes = Collections.singletonList( "**/*" );
+            includes = Collections.singletonList( getTest() );
         }
         else
         {
             if ( getIncludesFile() != null )
             {
-                actualIncludes = readListFromFile( getIncludesFile() );
+                includes = readListFromFile( getIncludesFile() );
             }
 
             // If we have includesFile, and we have includes, then append includes to includesFile content
-            if ( actualIncludes == null )
+            if ( includes == null )
             {
-                actualIncludes = getIncludes();
+                includes = getIncludes();
             }
             else
             {
-                maybeAppendList( actualIncludes, getIncludes() );
+                maybeAppendList( includes, getIncludes() );
             }
 
-            checkMethodFilterInIncludesExcludes( actualIncludes );
+            checkMethodFilterInIncludesExcludes( includes );
 
             // defaults here, qdox doesn't like the end javadoc value
             // Have to wrap in an ArrayList as surefire expects an ArrayList instead of a List for some reason
-            if ( actualIncludes == null || actualIncludes.isEmpty() )
+            if ( includes == null || includes.isEmpty() )
             {
-                actualIncludes = Arrays.asList( getDefaultIncludes() );
+                includes = Arrays.asList( getDefaultIncludes() );
             }
         }
 
-        return filterNulls( actualIncludes );
+        return filterNulls( includes );
     }
 
     private void checkMethodFilterInIncludesExcludes( Iterable<String> patterns )
@@ -1718,22 +1715,6 @@ public abstract class AbstractSurefireMojo
         }
 
         return result;
-    }
-
-    private boolean isMultipleExecutionBlocksDetected()
-    {
-        MavenProject project = getProject();
-        if ( project != null )
-        {
-            String key = getPluginDescriptor().getPluginLookupKey();
-            Plugin plugin = (Plugin) project.getBuild().getPluginsAsMap().get( key );
-            if ( plugin != null )
-            {
-                Collection<PluginExecution> executions = plugin.getExecutions();
-                return executions != null && executions.size() > 1;
-            }
-        }
-        return false;
     }
 
     private Artifact getTestNgArtifact()

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1634,39 +1634,39 @@ public abstract class AbstractSurefireMojo
     private List<String> getIncludeList()
         throws MojoFailureException
     {
-        List<String> includes = null;
+        List<String> actualIncludes = null;
         if ( isSpecificTestSpecified() && !isMultipleExecutionBlocksDetected() )
         {
-            includes = Collections.singletonList( getTest() );
+            actualIncludes = Collections.singletonList( "**/*" );
         }
         else
         {
             if ( getIncludesFile() != null )
             {
-                includes = readListFromFile( getIncludesFile() );
+                actualIncludes = readListFromFile( getIncludesFile() );
             }
 
             // If we have includesFile, and we have includes, then append includes to includesFile content
-            if ( includes == null )
+            if ( actualIncludes == null )
             {
-                includes = getIncludes();
+                actualIncludes = getIncludes();
             }
             else
             {
-                maybeAppendList( includes, getIncludes() );
+                maybeAppendList( actualIncludes, getIncludes() );
             }
 
-            checkMethodFilterInIncludesExcludes( includes );
+            checkMethodFilterInIncludesExcludes( actualIncludes );
+
+            // defaults here, qdox doesn't like the end javadoc value
+            // Have to wrap in an ArrayList as surefire expects an ArrayList instead of a List for some reason
+            if ( actualIncludes == null || actualIncludes.isEmpty() )
+            {
+                actualIncludes = Arrays.asList( getDefaultIncludes() );
+            }
         }
 
-        // defaults here, qdox doesn't like the end javadoc value
-        // Have to wrap in an ArrayList as surefire expects an ArrayList instead of a List for some reason
-        if ( includes == null || includes.isEmpty() )
-        {
-            includes = Arrays.asList( getDefaultIncludes() );
-        }
-
-        return filterNulls( includes );
+        return filterNulls( actualIncludes );
     }
 
     private void checkMethodFilterInIncludesExcludes( Iterable<String> patterns )

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1153IncludesAndSpecifiedTestIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1153IncludesAndSpecifiedTestIT.java
@@ -29,12 +29,18 @@ public class Surefire1153IncludesAndSpecifiedTestIT
     @Test
     public void testSpecifiedTestInIncludes()
     {
-        unpack( "/surefire-1153-includesAndSpecifiedTest" ).setTestToRun( "#testIncluded" ).executeTest().verifyErrorFree( 1 );
+        unpack( "/surefire-1153-includesAndSpecifiedTest" )
+            .setTestToRun( "#testIncluded" )
+            .executeTest()
+            .verifyErrorFree( 1 );
     }
 
     @Test
     public void testSpecifiedTestNotInIncludes()
     {
-        unpack( "/surefire-1153-includesAndSpecifiedTest" ).setTestToRun( "#testNotIncluded" ).executeTest().verifyErrorFree( 1 );
+        unpack( "/surefire-1153-includesAndSpecifiedTest" )
+            .setTestToRun( "#testNotIncluded" )
+            .executeTest()
+            .verifyErrorFree( 1 );
     }
 }

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1153IncludesAndSpecifiedTestIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1153IncludesAndSpecifiedTestIT.java
@@ -1,0 +1,40 @@
+package org.apache.maven.surefire.its.jiras;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+
+import org.junit.Test;
+
+public class Surefire1153IncludesAndSpecifiedTestIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+
+    @Test
+    public void testSpecifiedTestInIncludes()
+    {
+        unpack( "/surefire-1153-includesAndSpecifiedTest" ).setTestToRun( "#testIncluded" ).executeTest().verifyErrorFree( 1 );
+    }
+
+    @Test
+    public void testSpecifiedTestNotInIncludes()
+    {
+        unpack( "/surefire-1153-includesAndSpecifiedTest" ).setTestToRun( "#testNotIncluded" ).executeTest().verifyErrorFree( 1 );
+    }
+}

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire806SpecifiedTestControlsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire806SpecifiedTestControlsIT.java
@@ -21,6 +21,7 @@ package org.apache.maven.surefire.its.jiras;
 import org.apache.maven.surefire.its.Not2xCompatible;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -30,6 +31,7 @@ public class Surefire806SpecifiedTestControlsIT
 {
 
     @Test
+    @Ignore( "since SUREFIRE-1153 the includes/excludes are overridden by -Dtest or it.test for whatever execution" )
     public void singleTestInOneExecutionOfMultiExecutionProject()
     {
         unpack( "/surefire-806-specifiedTests-multi" ).setTestToRun( "FirstTest" ).failIfNoSpecifiedTests(
@@ -37,6 +39,7 @@ public class Surefire806SpecifiedTestControlsIT
     }
 
     @Test
+    @Ignore( "since SUREFIRE-1153 the includes/excludes are overridden by -Dtest or it.test for whatever execution" )
     public void twoSpecifiedTestExecutionsInCorrectExecutionBlocks()
     {
         unpack( "/surefire-806-specifiedTests-multi" ).setTestToRun(

--- a/surefire-integration-tests/src/test/resources/surefire-1153-includesAndSpecifiedTest/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1153-includesAndSpecifiedTest/pom.xml
@@ -17,27 +17,24 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.maven.surefire</groupId>
     <artifactId>it-parent</artifactId>
     <version>1.0</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.apache.maven.plugins.surefire</groupId>
   <artifactId>jiras-surefire-1153</artifactId>
   <version>1.0</version>
   <url>http://maven.apache.org</url>
-  <properties>
-    <version.junit>4.12</version.junit>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -57,6 +54,13 @@
             <include>**/*UT.java</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/surefire-integration-tests/src/test/resources/surefire-1153-includesAndSpecifiedTest/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1153-includesAndSpecifiedTest/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>jiras-surefire-1153</artifactId>
+  <version>1.0</version>
+  <url>http://maven.apache.org</url>
+  <properties>
+    <version.junit>4.12</version.junit>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${version.junit}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*UT.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-1153-includesAndSpecifiedTest/src/test/java/jiras/surefire1153/IncludedUT.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1153-includesAndSpecifiedTest/src/test/java/jiras/surefire1153/IncludedUT.java
@@ -1,0 +1,30 @@
+package jiras.surefire1153;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+public class IncludedUT
+{
+    @Test
+    public void testIncluded()
+    {
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1153-includesAndSpecifiedTest/src/test/java/jiras/surefire1153/NotIncludedTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1153-includesAndSpecifiedTest/src/test/java/jiras/surefire1153/NotIncludedTest.java
@@ -1,0 +1,30 @@
+package jiras.surefire1153;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+public class NotIncludedTest
+{
+    @Test
+    public void testNotIncluded()
+    {
+    }
+}


### PR DESCRIPTION
As discussed we Andreas we agreed on SUREFIRE-1153 acceptance where the includes/excludes list is ignored as soon as test or it.test (sys.property) is specified whatever execution phase runs.