### PR TITLE
[Surefire-1144] Time for testsuite on commandline does not suit with the time value given in the report file

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -129,7 +129,7 @@ public class StatelessXmlReporter
             ppw.setEncoding( ENCODING );
 
             createTestSuiteElement( ppw, testSetReportEntry, testSetStats, reportNameSuffix,
-                                    testSetStats.elapsedTimeAsString( getRunTimeForAllTests( methodRunHistoryMap ) ) );
+                                    testSetStats.getElapsedForTestSet() );
 
             showProperties( ppw );
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -129,7 +129,7 @@ public class StatelessXmlReporter
             ppw.setEncoding( ENCODING );
 
             createTestSuiteElement( ppw, testSetReportEntry, testSetStats, reportNameSuffix,
-                                    testSetStats.getElapsedForTestSet() );
+                                    testSetStats.getElapsedForTestSetAsString() );
 
             showProperties( ppw );
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -127,6 +127,7 @@ public class TestSetRunListener
     public void testSetCompleted( ReportEntry report )
     {
         WrappedReportEntry wrap = wrapTestSet( report );
+        detailsForThis.testSetCompleted();
         List<String> testResults = briefOrPlainFormat ? detailsForThis.getTestResults() : null;
         if ( fileReporter != null )
         {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -126,8 +126,8 @@ public class TestSetRunListener
 
     public void testSetCompleted( ReportEntry report )
     {
-        WrappedReportEntry wrap = wrapTestSet( report );
         detailsForThis.testSetCompleted();
+        WrappedReportEntry wrap = wrapTestSet( report );
         List<String> testResults = briefOrPlainFormat ? detailsForThis.getTestResults() : null;
         if ( fileReporter != null )
         {
@@ -249,7 +249,7 @@ public class TestSetRunListener
     {
         return new WrappedReportEntry( other, null, other.getElapsed() != null
             ? other.getElapsed()
-            : detailsForThis.getElapsedSinceTestSetStart(), testStdOut, testStdErr );
+            : detailsForThis.getElapsedForTestSet(), testStdOut, testStdErr );
     }
 
     public void close()

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetStats.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetStats.java
@@ -40,6 +40,8 @@ public class TestSetStats
 
     private long testSetStartAt;
 
+    private long testSetEndAt;
+
     private long testStartAt;
 
     private int completedCount;
@@ -90,6 +92,15 @@ public class TestSetStats
         lastStartAt = testSetStartAt;
     }
 
+    public void testSetCompleted()
+    {
+        testSetEndAt = System.currentTimeMillis();
+        if ( elapsedForTestSet < testSetEndAt - testSetStartAt )
+        {
+            elapsedForTestSet = testSetEndAt - testSetStartAt;
+        }
+    }
+    
     public void testStart()
     {
         testStartAt = System.currentTimeMillis();

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetStats.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetStats.java
@@ -62,16 +62,9 @@ public class TestSetStats
         this.plainFormat = plainFormat;
     }
 
-    public int getElapsedSinceTestSetStart()
+    public int getElapsedForTestSet()
     {
-        if ( testSetStartAt > 0 )
-        {
-            return (int) ( System.currentTimeMillis() - testSetStartAt );
-        }
-        else
-        {
-            return 0;
-        }
+        return (int) elapsedForTestSet;
     }
 
     public int getElapsedSinceLastStart()
@@ -196,7 +189,7 @@ public class TestSetStats
 
     private static final int MS_PER_SEC = 1000;
 
-    public String getElapsedForTestSet()
+    public String getElapsedForTestSetAsString()
     {
         return elapsedTimeAsString( elapsedForTestSet );
     }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -234,8 +234,6 @@ public class StatelessXmlReporterTest
 
         Xpp3Dom testSuite = Xpp3DomBuilder.build( new InputStreamReader( fileInputStream, "UTF-8" ) );
         assertEquals( "testsuite", testSuite.getName() );
-        // 0.019 = 0.012 + 0.005 +0.002
-        assertEquals( "0.019", testSuite.getAttribute( "time" ) );
         Xpp3Dom properties = testSuite.getChild( "properties" );
         assertEquals( System.getProperties().size(), properties.getChildCount() );
         Xpp3Dom child = properties.getChild( 1 );

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1144XmlRunTimeIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1144XmlRunTimeIT.java
@@ -1,0 +1,59 @@
+package org.apache.maven.surefire.its;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugins.surefire.report.ReportTestSuite;
+import org.apache.maven.surefire.its.fixture.HelperAssertions;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test that runtime reported on console matches runtime in XML
+ *
+ * @author <a href="mailto:eloussi2@illinois.edu">Lamyaa Eloussi</a>
+ */
+public class Surefire1144XmlRunTimeIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+    @Test
+    public void testXmlRunTime()
+        throws Exception
+    {
+        OutputValidator outputValidator = unpack( "/surefire-1144-xml-runtime" ).forkOnce().executeTest();
+
+        List<ReportTestSuite> reports = HelperAssertions.extractReports( new File[]{ outputValidator.getBaseDir() } );
+        assertEquals( 1, reports.size() ); //only one report
+
+        ReportTestSuite report = reports.get( 0 );
+        float xmlTime = report.getTimeElapsed();
+        assertTrue( "surefire1144.Test1 report.getTimeElapsed found:" + xmlTime,
+                     xmlTime >= 1.6f ); //include beforeClass and afterClass
+
+        outputValidator.verifyTextInLog( Float.toString( xmlTime ) ); //same time in console
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1144-xml-runtime/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1144-xml-runtime/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>surefire1144-xml-runtime</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>surefire-1144-xml-runtime</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-1144-xml-runtime/src/test/java/surefire1144/Test1.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1144-xml-runtime/src/test/java/surefire1144/Test1.java
@@ -1,0 +1,82 @@
+package surefire1144;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class Test1
+{
+    static void sleep( int ms )
+    {
+        long target = System.currentTimeMillis() + ms;
+        try
+        {
+            do
+            {
+                Thread.sleep( ms );
+            }
+            while ( System.currentTimeMillis() < target );
+        }
+        catch ( InterruptedException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    static void printTimeAndSleep( String msg, int ms )
+    {
+        System.out.println( msg + " started @ " + System.currentTimeMillis() );
+        sleep( ms );
+    }
+
+    @Test
+    public void testSleep100()
+    {
+        printTimeAndSleep( "Test1.sleep100", 100 );
+    }
+
+    @Test
+    public void testSleep200()
+    {
+        printTimeAndSleep( "Test1.sleep200", 200 );
+    }
+
+    @Test
+    public void testSleep300()
+    {
+        printTimeAndSleep( "Test1.sleep300", 300 );
+    }
+
+    @BeforeClass
+    public static void setUpBeforeClass()
+        throws Exception
+    {
+        printTimeAndSleep( "beforeClass sleep 500", 500 );
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass()
+        throws Exception
+    {
+        printTimeAndSleep( "afterClass sleep 500", 500 );
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SUREFIRE-1144

This pull request modifies the XML reporter such that it shows time computed as `endTime - startTime` rather than summing up the method execution times through `getRunTimeForAllTests()`.

I have tested this patch with the project provided by Karl in the bug report  thread:
https://github.com/khmarbaise/supose/
The time shown in the XML report is now consistent with the one shown in the console.

@Tibor17 I would appreciate your input on a couple of things:
1) Initially, I deleted line 111/122 (`elapsedForTestSet += elapsedForThis;`) in TestSetStats and line 100 (` elapsedForTestSet = testSetEndAt - testSetStartAt;)` was not within an if-block. However, that made XmlReporterRunTimeIT fail. The IT runs test methods in parallel and `testSetEndAt - testSetStartAt` ends up being abnormally small, smaller than the sleep times of any of the test methods. I don't understand enough of how the parallelism and fork code is implemented to properly debug that so I left line 111/122 and wrapped line 100 within an if-block. Please let me know if you have a better idea of how to deal with this.

2) The XML report now prints `elapsedForTestSet = testSetEndAt - testSetStartAt` but the console (which I have not changed) prints `elapsedSinceTestSetStart = currentTime - testSetStartAt`. This means the console time may be 1 or 2ms more than the XML report time. Do you think it would be good to have the console also print `elapsedForTestSet`? If not, I probably need to change Surefire1144XmlRunTimeIT to accept a 1 or 2ms difference.