### PR TITLE
[SUREFIRE-964] TEST-*.xml files generated by Surefire throw validation warnings in Eclipse for no grammer constraints (DTD or XML schema) referenced in the document

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -419,6 +419,10 @@ public class StatelessXmlReporter
     {
         ppw.startElement( "testsuite" );
 
+        ppw.addAttribute( "xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance" );
+
+        ppw.addAttribute( "xsi:schemaLocation", "https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd" );
+
         ppw.addAttribute( "name", report.getReportName( reportNameSuffix1 ) );
 
         if ( report.getGroup() != null )

--- a/maven-surefire-plugin/src/site/apt/index.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/index.apt.vm
@@ -79,7 +79,7 @@ mvn verify
 
   By default, these files are generated at <<<$\{basedir\}/target/${thisPlugin.toLowerCase()}-reports>>>.
 
-  The schema for the Surefire XML reports is available at {{{./xsd/surefire-test-report.xsd}Surefire XML Report Schema}}
+  The schema for the Surefire XML reports is available at {{{./xsd/surefire-test-report.xsd}Surefire XML Report Schema}}.
 
   For an HTML format of the report, please see the
   {{{http://maven.apache.org/plugins/maven-surefire-report-plugin/}Maven Surefire Report Plugin}}.

--- a/maven-surefire-plugin/src/site/apt/index.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/index.apt.vm
@@ -79,6 +79,8 @@ mvn verify
 
   By default, these files are generated at <<<$\{basedir\}/target/${thisPlugin.toLowerCase()}-reports>>>.
 
+  The schema for the Surefire XML reports is available at {{{./xsd/surefire-test-report.xsd}Surefire XML Report Schema}}
+
   For an HTML format of the report, please see the
   {{{http://maven.apache.org/plugins/maven-surefire-report-plugin/}Maven Surefire Report Plugin}}.
 

--- a/maven-surefire-plugin/src/site/apt/xsd/surefire-test-report.xsd
+++ b/maven-surefire-plugin/src/site/apt/xsd/surefire-test-report.xsd
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="testsuite">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="properties" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" />
+                  <xs:attribute name="value" type="xs:string" />
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="failure" nillable="true" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="type" type="xs:string" />
+                      <xs:attribute name="time" type="xs:string" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="rerunFailure" nillable="true" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="type" type="xs:string" />
+                      <xs:attribute name="time" type="xs:string" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" />
+            <xs:attribute name="classname" type="xs:string" />
+            <xs:attribute name="time" type="xs:string" />
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" />
+      <xs:attribute name="time" type="xs:string" />
+      <xs:attribute name="tests" type="xs:string" />
+      <xs:attribute name="errors" type="xs:string" />
+      <xs:attribute name="skipped" type="xs:string" />
+      <xs:attribute name="failures" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/maven-surefire-plugin/src/site/apt/xsd/surefire-test-report.xsd
+++ b/maven-surefire-plugin/src/site/apt/xsd/surefire-test-report.xsd
@@ -75,6 +75,7 @@
       <xs:attribute name="errors" type="xs:string" />
       <xs:attribute name="skipped" type="xs:string" />
       <xs:attribute name="failures" type="xs:string" />
+      <xs:attribute name="successrate" type="xs:string" />
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/maven-surefire-plugin/src/site/apt/xsd/surefire-test-report.xsd
+++ b/maven-surefire-plugin/src/site/apt/xsd/surefire-test-report.xsd
@@ -23,7 +23,13 @@
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
                       <xs:attribute name="type" type="xs:string" />
-                      <xs:attribute name="time" type="xs:string" />
+                      <xs:attribute name="time">
+			<xs:simpleType>
+			  <xs:restriction base="xs:string">
+			    <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})\\.[0-9]{0,3}" />
+			  </xs:restriction>
+			</xs:simpleType>
+		      </xs:attribute>
                     </xs:extension>
                   </xs:simpleContent>
                 </xs:complexType>
@@ -33,7 +39,13 @@
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
                       <xs:attribute name="type" type="xs:string" />
-                      <xs:attribute name="time" type="xs:string" />
+                      <xs:attribute name="time">
+			<xs:simpleType>
+			  <xs:restriction base="xs:string">
+			    <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*\.[0-9]{0,3}"/>
+			  </xs:restriction>
+			</xs:simpleType>
+		      </xs:attribute>
                     </xs:extension>
                   </xs:simpleContent>
                 </xs:complexType>
@@ -41,12 +53,24 @@
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" />
             <xs:attribute name="classname" type="xs:string" />
-            <xs:attribute name="time" type="xs:string" />
+	    <xs:attribute name="time">
+	      <xs:simpleType>
+		<xs:restriction base="xs:string">
+		  <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*\.[0-9]{0,3}"/>
+		</xs:restriction>
+	      </xs:simpleType>
+	    </xs:attribute>
           </xs:complexType>
         </xs:element>
       </xs:sequence>
       <xs:attribute name="name" type="xs:string" />
-      <xs:attribute name="time" type="xs:string" />
+      <xs:attribute name="time">
+	<xs:simpleType>
+	  <xs:restriction base="xs:string">
+	    <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*\.[0-9]{0,3}"/>
+	  </xs:restriction>
+	</xs:simpleType>
+      </xs:attribute>
       <xs:attribute name="tests" type="xs:string" />
       <xs:attribute name="errors" type="xs:string" />
       <xs:attribute name="skipped" type="xs:string" />

--- a/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd
+++ b/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd
@@ -22,6 +22,7 @@
                 <xs:complexType>
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
+                      <xs:attribute name="message" type="xs:string" />
                       <xs:attribute name="type" type="xs:string" />
                       <xs:attribute name="time">
 			<xs:simpleType>
@@ -38,6 +39,7 @@
                 <xs:complexType>
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
+                      <xs:attribute name="message" type="xs:string" />
                       <xs:attribute name="type" type="xs:string" />
                       <xs:attribute name="time">
 			<xs:simpleType>
@@ -50,9 +52,31 @@
                   </xs:simpleContent>
                 </xs:complexType>
               </xs:element>
+	      <xs:element name="skipped" nillable="true" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="message" type="xs:string" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+	      <xs:element name="error" nillable="true" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:simpleContent>
+                    <xs:extension base="xs:string">
+                      <xs:attribute name="message" type="xs:string" />
+                      <xs:attribute name="type" type="xs:string" />
+                    </xs:extension>
+                  </xs:simpleContent>
+                </xs:complexType>
+              </xs:element>
+	      <xs:element name="system-out" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+	      <xs:element name="system-err" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" />
             <xs:attribute name="classname" type="xs:string" />
+            <xs:attribute name="group" type="xs:string" />
 	    <xs:attribute name="time">
 	      <xs:simpleType>
 		<xs:restriction base="xs:string">
@@ -75,7 +99,7 @@
       <xs:attribute name="errors" type="xs:string" />
       <xs:attribute name="skipped" type="xs:string" />
       <xs:attribute name="failures" type="xs:string" />
-      <xs:attribute name="successrate" type="xs:string" />
+      <xs:attribute name="group" type="xs:string"/>
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd
+++ b/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd
@@ -26,7 +26,7 @@
                       <xs:attribute name="time">
 			<xs:simpleType>
 			  <xs:restriction base="xs:string">
-			    <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})\\.[0-9]{0,3}" />
+			    <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?" />
 			  </xs:restriction>
 			</xs:simpleType>
 		      </xs:attribute>
@@ -42,7 +42,7 @@
                       <xs:attribute name="time">
 			<xs:simpleType>
 			  <xs:restriction base="xs:string">
-			    <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*\.[0-9]{0,3}"/>
+			    <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?"/>
 			  </xs:restriction>
 			</xs:simpleType>
 		      </xs:attribute>
@@ -56,7 +56,7 @@
 	    <xs:attribute name="time">
 	      <xs:simpleType>
 		<xs:restriction base="xs:string">
-		  <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*\.[0-9]{0,3}"/>
+		  <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?"/>
 		</xs:restriction>
 	      </xs:simpleType>
 	    </xs:attribute>
@@ -67,7 +67,7 @@
       <xs:attribute name="time">
 	<xs:simpleType>
 	  <xs:restriction base="xs:string">
-	    <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*\.[0-9]{0,3}"/>
+	    <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?"/>
 	  </xs:restriction>
 	</xs:simpleType>
       </xs:attribute>

--- a/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd
+++ b/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd
@@ -8,8 +8,8 @@
             <xs:sequence>
               <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
-                  <xs:attribute name="name" type="xs:string" />
-                  <xs:attribute name="value" type="xs:string" />
+                  <xs:attribute name="name" type="xs:string" use="required"/>
+                  <xs:attribute name="value" type="xs:string" use="required"/>
                 </xs:complexType>
               </xs:element>
             </xs:sequence>
@@ -18,12 +18,12 @@
         <xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="failure" nillable="true" minOccurs="0" maxOccurs="1">
+              <xs:element name="failure" nillable="true" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
                       <xs:attribute name="message" type="xs:string" />
-                      <xs:attribute name="type" type="xs:string" />
+                      <xs:attribute name="type" type="xs:string" use="required" />
                       <xs:attribute name="time">
 			<xs:simpleType>
 			  <xs:restriction base="xs:string">
@@ -40,7 +40,7 @@
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
                       <xs:attribute name="message" type="xs:string" />
-                      <xs:attribute name="type" type="xs:string" />
+                      <xs:attribute name="type" type="xs:string" use="required" />
                       <xs:attribute name="time">
 			<xs:simpleType>
 			  <xs:restriction base="xs:string">
@@ -52,7 +52,7 @@
                   </xs:simpleContent>
                 </xs:complexType>
               </xs:element>
-	      <xs:element name="skipped" nillable="true" minOccurs="0" maxOccurs="unbounded">
+	      <xs:element name="skipped" nillable="true" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
@@ -61,23 +61,23 @@
                   </xs:simpleContent>
                 </xs:complexType>
               </xs:element>
-	      <xs:element name="error" nillable="true" minOccurs="0" maxOccurs="unbounded">
+	      <xs:element name="error" nillable="true" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                   <xs:simpleContent>
                     <xs:extension base="xs:string">
                       <xs:attribute name="message" type="xs:string" />
-                      <xs:attribute name="type" type="xs:string" />
+                      <xs:attribute name="type" type="xs:string" use="required" />
                     </xs:extension>
                   </xs:simpleContent>
                 </xs:complexType>
               </xs:element>
-	      <xs:element name="system-out" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
-	      <xs:element name="system-err" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+	      <xs:element name="system-out" nillable="true" minOccurs="0" maxOccurs="1"/>
+	      <xs:element name="system-err" nillable="true" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
-            <xs:attribute name="name" type="xs:string" />
+            <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="classname" type="xs:string" />
             <xs:attribute name="group" type="xs:string" />
-	    <xs:attribute name="time">
+	    <xs:attribute name="time" use="required">
 	      <xs:simpleType>
 		<xs:restriction base="xs:string">
 		  <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?"/>
@@ -87,7 +87,7 @@
           </xs:complexType>
         </xs:element>
       </xs:sequence>
-      <xs:attribute name="name" type="xs:string" />
+      <xs:attribute name="name" type="xs:string" use="required"/>
       <xs:attribute name="time">
 	<xs:simpleType>
 	  <xs:restriction base="xs:string">
@@ -95,10 +95,10 @@
 	  </xs:restriction>
 	</xs:simpleType>
       </xs:attribute>
-      <xs:attribute name="tests" type="xs:string" />
-      <xs:attribute name="errors" type="xs:string" />
-      <xs:attribute name="skipped" type="xs:string" />
-      <xs:attribute name="failures" type="xs:string" />
+      <xs:attribute name="tests" type="xs:string" use="required"/>
+      <xs:attribute name="errors" type="xs:string" use="required"/>
+      <xs:attribute name="skipped" type="xs:string" use="required"/>
+      <xs:attribute name="failures" type="xs:string" use="required"/>
       <xs:attribute name="group" type="xs:string"/>
     </xs:complexType>
   </xs:element>

--- a/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd
+++ b/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="testsuite">
     <xs:complexType>


### PR DESCRIPTION
This pull request adds an XSD schema for the surefire XML reports.
I added a link to the XSD in `index.apt.vm`.