### PR TITLE
Add missing slash in closing tag of 'use argLine' error message

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -908,7 +908,7 @@ public abstract class AbstractSurefireMojo
                 if ( getArgLine() == null || !getArgLine().contains( "-D" + o + "=" ) )
                 {
                     getLog().warn( o + " cannot be set as system property, use <argLine>-D"
-                                       + o + "=...<argLine> instead" );
+                                       + o + "=...</argLine> instead" );
                 }
             }
             for ( Object systemPropertyMatchingArgLine : systemPropertiesMatchingArgLine( result ) )

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1053SystemPropertiesIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1053SystemPropertiesIT.java
@@ -41,7 +41,7 @@ public class Surefire1053SystemPropertiesIT
             .executeTest()
             .verifyErrorFree( 1 )
             .verifyTextInLog( "file.encoding cannot be set as system property, use <argLine>-D"
-                                  + "file.encoding=...<argLine> instead" );
+                                  + "file.encoding=...</argLine> instead" );
     }
     @Test
     public void checkWarningsSysPropTwice() throws Exception


### PR DESCRIPTION
When you try to set `java.library.path` as a system property in the configuration the plugin emits the warning `java.library.path cannot be set as system property, use <argLine>-Djava.library.path=...<argLine> instead`. This change adds the missing slash in the closing tag which is `<argLine>` but should be `</argLine>`.