### PR TITLE
Option to rerun failures at the end of test execution

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -242,6 +242,9 @@ public class IntegrationTestMojo
     @Parameter( property = "failsafe.rerunFailingTestsCount", defaultValue = "0" )
     protected int rerunFailingTestsCount;
 
+    @Parameter( property = "failsafe.rerunFailingTestsAtEndCount", defaultValue = "0" )
+    protected int rerunFailingTestsAtEndCount;
+
     /**
      * (TestNG) List of &lt;suiteXmlFile> elements specifying TestNG suite xml file locations. Note that
      * <code>suiteXmlFiles</code> is incompatible with several other parameters of this plugin, like
@@ -304,6 +307,11 @@ public class IntegrationTestMojo
     protected int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    protected int getRerunFailingTestsAtEndCount()
+    {
+        return rerunFailingTestsAtEndCount;
     }
 
     @SuppressWarnings( "unchecked" )

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -683,6 +683,8 @@ public abstract class AbstractSurefireMojo
 
     protected abstract int getRerunFailingTestsCount();
 
+    protected abstract int getRerunFailingTestsAtEndCount();
+
     private SurefireDependencyResolver dependencyResolver;
 
     private TestListResolver specificTests;
@@ -1404,7 +1406,8 @@ public abstract class AbstractSurefireMojo
             isTestNg ? new TestArtifactInfo( testNgArtifact.getVersion(), testNgArtifact.getClassifier() ) : null;
         List<File> testXml = getSuiteXmlFiles() != null ? Arrays.asList( getSuiteXmlFiles() ) : null;
         TestRequest testSuiteDefinition = new TestRequest( testXml, getTestSourceDirectory(), getSpecificTests(),
-                                                           getRerunFailingTestsCount() );
+                                                           getRerunFailingTestsCount(),
+                                                           getRerunFailingTestsAtEndCount() );
 
         final boolean actualFailIfNoTests;
 
@@ -1535,7 +1538,8 @@ public abstract class AbstractSurefireMojo
         return new StartupReportConfiguration( isUseFile(), isPrintSummary(), getReportFormat(),
                                                isRedirectTestOutputToFile(), isDisableXmlReport(),
                                                getReportsDirectory(), isTrimStackTrace(), getReportNameSuffix(),
-                                               configChecksum, requiresRunHistory(), getRerunFailingTestsCount() );
+                                               configChecksum, requiresRunHistory(), getRerunFailingTestsCount(),
+                                               getRerunFailingTestsAtEndCount() );
     }
 
     private boolean isSpecificTestSpecified()

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/CommonReflector.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/CommonReflector.java
@@ -66,14 +66,16 @@ public class CommonReflector
                                                                      new Class[]{ boolean.class, boolean.class,
                                                                          String.class, boolean.class, boolean.class,
                                                                          File.class, boolean.class, String.class,
-                                                                         String.class, boolean.class, int.class } );
+                                                                         String.class, boolean.class, int.class,
+                                                                         int.class } );
         //noinspection BooleanConstructorCall
         final Object[] params = { reporterConfiguration.isUseFile(), reporterConfiguration.isPrintSummary(),
             reporterConfiguration.getReportFormat(), reporterConfiguration.isRedirectTestOutputToFile(),
             reporterConfiguration.isDisableXmlReport(), reporterConfiguration.getReportsDirectory(),
             reporterConfiguration.isTrimStackTrace(), reporterConfiguration.getReportNameSuffix(),
             reporterConfiguration.getConfigurationHash(), reporterConfiguration.isRequiresRunHistory(),
-            reporterConfiguration.getRerunFailingTestsCount() };
+            reporterConfiguration.getRerunFailingTestsCount(),
+            reporterConfiguration.getRerunFailingTestsAtEndCount() };
         return ReflectionUtils.newInstance( constructor, params );
     }
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
@@ -72,6 +72,8 @@ public class StartupReportConfiguration
 
     private final int rerunFailingTestsCount;
 
+    private final int rerunFailingTestsAtEndCount;
+
     private final Properties testVmSystemProperties = new Properties();
 
     public static final String BRIEF_REPORT_FORMAT = ConsoleReporter.BRIEF;
@@ -85,7 +87,7 @@ public class StartupReportConfiguration
                                        boolean redirectTestOutputToFile, boolean disableXmlReport,
                                        @Nonnull File reportsDirectory, boolean trimStackTrace, String reportNameSuffix,
                                        String configurationHash, boolean requiresRunHistory,
-                                       int rerunFailingTestsCount )
+                                       int rerunFailingTestsCount, int rerunFailingTestsAtEndCount )
     {
         this.useFile = useFile;
         this.printSummary = printSummary;
@@ -100,6 +102,7 @@ public class StartupReportConfiguration
         this.originalSystemOut = System.out;
         this.originalSystemErr = System.err;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
+        this.rerunFailingTestsAtEndCount = rerunFailingTestsAtEndCount;
         this.testClassMethodRunHistoryMap =
                         Collections.synchronizedMap(
                              new HashMap<String, Map<String, List<WrappedReportEntry>>>() );
@@ -109,14 +112,14 @@ public class StartupReportConfiguration
     {
         File target = new File( "./target" );
         return new StartupReportConfiguration( true, true, "PLAIN", false, false, target, false, null, "TESTHASH",
-                                               false, 0 );
+                                               false, 0, 0 );
     }
 
     public static StartupReportConfiguration defaultNoXml()
     {
         File target = new File( "./target" );
         return new StartupReportConfiguration( true, true, "PLAIN", false, true, target, false, null, "TESTHASHxXML",
-                                               false, 0 );
+                                               false, 0, 0 );
     }
 
     public boolean isUseFile()
@@ -159,12 +162,18 @@ public class StartupReportConfiguration
         return rerunFailingTestsCount;
     }
 
+    public int getRerunFailingTestsAtEndCount()
+    {
+        return rerunFailingTestsAtEndCount;
+    }
+
     public StatelessXmlReporter instantiateStatelessXmlReporter()
     {
         if ( !isDisableXmlReport() )
         {
             return new StatelessXmlReporter( reportsDirectory, reportNameSuffix, trimStackTrace,
-                                             rerunFailingTestsCount, testClassMethodRunHistoryMap );
+                                             rerunFailingTestsCount, rerunFailingTestsAtEndCount,
+                                             testClassMethodRunHistoryMap );
         }
         return null;
     }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
@@ -103,6 +103,8 @@ class BooterSerializer
             properties.setNullableProperty( REQUESTEDTEST, requestedTest );
             properties.setNullableProperty( RERUN_FAILING_TESTS_COUNT,
                                             String.valueOf( testSuiteDefinition.getRerunFailingTestsCount() ) );
+            properties.setNullableProperty( RERUN_FAILING_TESTS_AT_END_COUNT,
+                                            String.valueOf( testSuiteDefinition.getRerunFailingTestsAtEndCount() ) );
         }
 
         DirectoryScannerParameters directoryScannerParameters = booterConfiguration.getDirScannerParams();

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
@@ -167,10 +167,12 @@ public class DefaultReporterFactory
      *
      * @param reportEntryList the list of test run report type for a given test
      * @param rerunFailingTestsCount configured rerun count for failing tests
+     * @param rerunFailingTestsAtEndCount configured rerun at end count for failing tests
      * @return the type of test result
      */
     // Use default visibility for testing
-    static TestResultType getTestResultType( List<ReportEntryType> reportEntryList, int rerunFailingTestsCount  )
+    static TestResultType getTestResultType( List<ReportEntryType> reportEntryList, int rerunFailingTestsCount,
+                                             int rerunFailingTestsAtEndCount  )
     {
         if ( reportEntryList == null || reportEntryList.isEmpty() )
         {
@@ -196,7 +198,7 @@ public class DefaultReporterFactory
 
         if ( seenFailure || seenError )
         {
-            if ( seenSuccess && rerunFailingTestsCount > 0 )
+            if ( seenSuccess && ( rerunFailingTestsCount > 0 || rerunFailingTestsAtEndCount > 0 ) )
             {
                 return TestResultType.flake;
             }
@@ -271,7 +273,8 @@ public class DefaultReporterFactory
             }
 
             TestResultType resultType = getTestResultType( resultTypeList,
-                                                           reportConfiguration.getRerunFailingTestsCount() );
+                                                           reportConfiguration.getRerunFailingTestsCount(),
+                                                           reportConfiguration.getRerunFailingTestsAtEndCount() );
 
             switch ( resultType )
             {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -93,18 +93,21 @@ public class StatelessXmlReporter
 
     private final int rerunFailingTestsCount;
 
+    private final int rerunFailingTestsAtEndCount;
+
     // Map between test class name and a map between test method name
     // and the list of runs for each test method
     private final Map<String, Map<String, List<WrappedReportEntry>>> testClassMethodRunHistoryMap;
 
     public StatelessXmlReporter( File reportsDirectory, String reportNameSuffix, boolean trimStackTrace,
-                                 int rerunFailingTestsCount,
+                                 int rerunFailingTestsCount, int rerunFailingTestsAtEndCount,
                                  Map<String, Map<String, List<WrappedReportEntry>>> testClassMethodRunHistoryMap )
     {
         this.reportsDirectory = reportsDirectory;
         this.reportNameSuffix = reportNameSuffix;
         this.trimStackTrace = trimStackTrace;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
+        this.rerunFailingTestsAtEndCount = rerunFailingTestsAtEndCount;
         this.testClassMethodRunHistoryMap = testClassMethodRunHistoryMap;
     }
 
@@ -146,7 +149,7 @@ public class StatelessXmlReporter
                     continue;
                 }
 
-                if ( rerunFailingTestsCount > 0 )
+                if ( rerunFailingTestsCount > 0 || rerunFailingTestsAtEndCount > 0 )
                 {
                     TestResultType resultType = getTestResultType( methodEntryList );
                     switch ( resultType )
@@ -266,7 +269,7 @@ public class StatelessXmlReporter
             testResultTypeList.add( singleRunEntry.getReportEntryType() );
         }
 
-        return DefaultReporterFactory.getTestResultType( testResultTypeList, rerunFailingTestsCount );
+        return DefaultReporterFactory.getTestResultType( testResultTypeList, rerunFailingTestsCount, rerunFailingTestsAtEndCount );
     }
 
     /**

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
@@ -53,6 +53,8 @@ public class BooterDeserializerProviderConfigurationTest
 
     private static final int rerunFailingTestsCount = 3;
 
+    private static final int rerunFailingTestsAtEndCount = 3;
+
     private final List<CommandLineOption> cli =
         Arrays.asList( LOGGING_LEVEL_DEBUG, SHOW_ERRORS, REACTOR_FAIL_FAST );
 
@@ -136,6 +138,7 @@ public class BooterDeserializerProviderConfigurationTest
         Assert.assertEquals( "**/" + aUserRequestedTest, filter.getTestClassPattern() );
         Assert.assertEquals( aUserRequestedTestMethod, filter.getTestMethodPattern() );
         Assert.assertEquals( rerunFailingTestsCount, testSuiteDefinition.getRerunFailingTestsCount() );
+	Assert.assertEquals( rerunFailingTestsAtEndCount, testSuiteDefinition.getRerunFailingTestsAtEndCount() );
         assertEquals( cli, reloaded.getMainCliOptions() );
     }
 
@@ -233,7 +236,7 @@ public class BooterDeserializerProviderConfigurationTest
         TestRequest testSuiteDefinition =
             new TestRequest( getSuiteXmlFileStrings(), getTestSourceDirectory(),
                              new TestListResolver( aUserRequestedTest + "#aUserRequestedTestMethod" ),
-                             rerunFailingTestsCount );
+                             rerunFailingTestsCount, rerunFailingTestsAtEndCount );
         RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(), aTestTyped,

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
@@ -62,7 +62,7 @@ public class DefaultReporterFactoryTest
     public void testMergeTestHistoryResult()
     {
         StartupReportConfiguration reportConfig = new StartupReportConfiguration( true, true, "PLAIN", false, false, new File("target"), false, null, "TESTHASH",
-                                                                                                 false, 1 );
+                                                                                                 false, 1, 0 );
 
         DefaultReporterFactory factory = new DefaultReporterFactory( reportConfig );
 
@@ -161,41 +161,49 @@ public class DefaultReporterFactoryTest
     public void testGetTestResultType()
     {
         List<ReportEntryType> emptyList = new ArrayList<ReportEntryType>();
-        assertEquals( unknown, DefaultReporterFactory.getTestResultType( emptyList, 1 ) );
+        assertEquals( unknown, DefaultReporterFactory.getTestResultType( emptyList, 1, 1 ) );
 
         List<ReportEntryType> successList = new ArrayList<ReportEntryType>();
         successList.add( ReportEntryType.SUCCESS );
         successList.add( ReportEntryType.SUCCESS );
-        assertEquals( success, DefaultReporterFactory.getTestResultType( successList, 1 ) );
+        assertEquals( success, DefaultReporterFactory.getTestResultType( successList, 1, 1 ) );
 
         List<ReportEntryType> failureErrorList = new ArrayList<ReportEntryType>();
         failureErrorList.add( ReportEntryType.FAILURE );
         failureErrorList.add( ReportEntryType.ERROR );
-        assertEquals( error, DefaultReporterFactory.getTestResultType( failureErrorList, 1 ) );
+        assertEquals( error, DefaultReporterFactory.getTestResultType( failureErrorList, 1, 1 ) );
 
         List<ReportEntryType> errorFailureList = new ArrayList<ReportEntryType>();
         errorFailureList.add( ReportEntryType.ERROR );
         errorFailureList.add( ReportEntryType.FAILURE );
-        assertEquals( error, DefaultReporterFactory.getTestResultType( errorFailureList, 1 ) );
+        assertEquals( error, DefaultReporterFactory.getTestResultType( errorFailureList, 1, 1 ) );
 
         List<ReportEntryType> flakeList = new ArrayList<ReportEntryType>();
         flakeList.add( ReportEntryType.SUCCESS );
         flakeList.add( ReportEntryType.FAILURE );
-        assertEquals( flake, DefaultReporterFactory.getTestResultType( flakeList, 1 ) );
+        assertEquals( flake, DefaultReporterFactory.getTestResultType( flakeList, 1, 0 ) );
 
-        assertEquals( failure, DefaultReporterFactory.getTestResultType( flakeList, 0 ) );
+        assertEquals( flake, DefaultReporterFactory.getTestResultType( flakeList, 0, 1 ) );
+
+        assertEquals( flake, DefaultReporterFactory.getTestResultType( flakeList, 1, 1 ) );
+
+        assertEquals( failure, DefaultReporterFactory.getTestResultType( flakeList, 0, 0 ) );
 
         flakeList = new ArrayList<ReportEntryType>();
         flakeList.add( ReportEntryType.ERROR );
         flakeList.add( ReportEntryType.SUCCESS );
         flakeList.add( ReportEntryType.FAILURE );
-        assertEquals( flake, DefaultReporterFactory.getTestResultType( flakeList, 1 ) );
+        assertEquals( flake, DefaultReporterFactory.getTestResultType( flakeList, 1, 0 ) );
 
-        assertEquals( error, DefaultReporterFactory.getTestResultType( flakeList, 0 ) );
+        assertEquals( flake, DefaultReporterFactory.getTestResultType( flakeList, 0, 1 ) );
+
+        assertEquals( flake, DefaultReporterFactory.getTestResultType( flakeList, 1, 1 ) );
+
+        assertEquals( error, DefaultReporterFactory.getTestResultType( flakeList, 0, 0 ) );
 
         List<ReportEntryType> skippedList = new ArrayList<ReportEntryType>();
         skippedList.add( ReportEntryType.SKIPPED );
-        assertEquals( skipped, DefaultReporterFactory.getTestResultType( skippedList, 1 ) );
+        assertEquals( skipped, DefaultReporterFactory.getTestResultType( skippedList, 1, 0 ) );
     }
 
     static class DummyStackTraceWriter

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -45,7 +45,7 @@ public class StatelessXmlReporterTest
     extends TestCase
 {
 
-    private StatelessXmlReporter reporter = new StatelessXmlReporter( new File( "." ), null, false, 0,
+    private StatelessXmlReporter reporter = new StatelessXmlReporter( new File( "." ), null, false, 0, 0,
                     Collections.synchronizedMap( new HashMap<String, Map<String, List<WrappedReportEntry>>>() ) );
 
     private ReportEntry reportEntry;
@@ -139,7 +139,7 @@ public class StatelessXmlReporterTest
                                     ReportEntryType.ERROR, 13, stdOut, stdErr );
 
         stats.testSucceeded( t2 );
-        StatelessXmlReporter reporter = new StatelessXmlReporter( new File( "." ), null, false, 0,
+        StatelessXmlReporter reporter = new StatelessXmlReporter( new File( "." ), null, false, 0, 0,
                         Collections.synchronizedMap( new HashMap<String, Map<String, List<WrappedReportEntry>>>() ) );
         reporter.testSetCompleted( testSetReportEntry, stats );
 
@@ -224,7 +224,7 @@ public class StatelessXmlReporterTest
                                       new File( "." ),
                                       null,
                                       false,
-                                      1,
+                                      1, 0,
                                       new HashMap<String, Map<String, List<WrappedReportEntry>>>() );
 
         reporter.testSetCompleted( testSetReportEntry, stats );

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -220,6 +220,9 @@ public class SurefirePlugin
     @Parameter( property = "surefire.rerunFailingTestsCount", defaultValue = "0" )
     protected int rerunFailingTestsCount;
 
+    @Parameter( property = "surefire.rerunFailingTestsAtEndCount", defaultValue = "0" )
+    protected int rerunFailingTestsAtEndCount;
+
     /**
      * (TestNG) List of &lt;suiteXmlFile> elements specifying TestNG suite xml file locations. Note that
      * <code>suiteXmlFiles</code> is incompatible with several other parameters of this plugin, like
@@ -282,6 +285,11 @@ public class SurefirePlugin
     protected int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    protected int getRerunFailingTestsAtEndCount()
+    {
+        return rerunFailingTestsAtEndCount;
     }
 
     protected void handleSummary( RunResult summary, Exception firstForkException )

--- a/surefire-api/src/main/java/org/apache/maven/surefire/booter/SurefireReflector.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/booter/SurefireReflector.java
@@ -159,10 +159,11 @@ public class SurefireReflector
         else
         {
             Object resolver = createTestListResolver( suiteDefinition.getTestListResolver() );
-            Class[] arguments = { List.class, File.class, testListResolver, int.class };
+            Class[] arguments = { List.class, File.class, testListResolver, int.class, int.class };
             Constructor constructor = ReflectionUtils.getConstructor( testRequest, arguments );
             return ReflectionUtils.newInstance( constructor, new Object[]{ suiteDefinition.getSuiteXmlFiles(),
-                suiteDefinition.getTestSourceDirectory(), resolver, suiteDefinition.getRerunFailingTestsCount() } );
+                suiteDefinition.getTestSourceDirectory(), resolver,
+                suiteDefinition.getRerunFailingTestsCount(), suiteDefinition.getRerunFailingTestsAtEndCount() } );
         }
     }
 

--- a/surefire-api/src/main/java/org/apache/maven/surefire/testset/TestRequest.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/testset/TestRequest.java
@@ -38,18 +38,21 @@ public class TestRequest
 
     private final int rerunFailingTestsCount;
 
+    private final int rerunFailingTestsAtEndCount;
+
     public TestRequest( List suiteXmlFiles, File testSourceDirectory, TestListResolver requestedTests )
     {
-        this( createFiles( suiteXmlFiles ), testSourceDirectory, requestedTests, 0 );
+        this( createFiles( suiteXmlFiles ), testSourceDirectory, requestedTests, 0, 0 );
     }
 
     public TestRequest( List suiteXmlFiles, File testSourceDirectory, TestListResolver requestedTests,
-                        int rerunFailingTestsCount )
+                        int rerunFailingTestsCount, int rerunFailingTestsAtEndCount )
     {
         this.suiteXmlFiles = createFiles( suiteXmlFiles );
         this.testSourceDirectory = testSourceDirectory;
         this.requestedTests = requestedTests;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
+        this.rerunFailingTestsAtEndCount = rerunFailingTestsAtEndCount;
     }
 
     /**
@@ -88,6 +91,19 @@ public class TestRequest
     public int getRerunFailingTestsCount()
     {
         return this.rerunFailingTestsCount;
+    }
+
+    /**
+     * How many times to rerun failing tests at the end of test suite
+     * execution, issued with -Dsurefire.rerunFailingTestsAtEndCount
+     * from the command line.
+     *
+     * @return The int parameter to indicate how many times to rerun
+     * failing tests at the end of the test suite execution
+     */
+    public int getRerunFailingTestsAtEndCount()
+    {
+        return this.rerunFailingTestsAtEndCount;
     }
 
     private static List<File> createFiles( List suiteXmlFiles )

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
@@ -52,5 +52,6 @@ public final class BooterConstants
     public static final String FORKTESTSET = "forkTestSet";
     public static final String FORKTESTSET_PREFER_TESTS_FROM_IN_STREAM = "preferTestsFromInStream";
     public static final String RERUN_FAILING_TESTS_COUNT = "rerunFailingTestsCount";
+    public static final String RERUN_FAILING_TESTS_AT_END_COUNT = "rerunFailingTestsAtEndCount";
     public static final String MAIN_CLI_OPTIONS = "mainCliOptions";
 }

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
@@ -84,6 +84,8 @@ public class BooterDeserializer
 
         final int rerunFailingTestsCount = properties.getIntProperty( RERUN_FAILING_TESTS_COUNT );
 
+        final int rerunFailingTestsAtEndCount = properties.getIntProperty( RERUN_FAILING_TESTS_AT_END_COUNT );
+
         DirectoryScannerParameters dirScannerParams =
             new DirectoryScannerParameters( testClassesDirectory, includes, excludes, specificTests,
                                             properties.getBooleanObjectProperty( FAILIFNOTESTS ), runOrder );
@@ -93,7 +95,7 @@ public class BooterDeserializer
         TestArtifactInfo testNg = new TestArtifactInfo( testNgVersion, testArtifactClassifier );
         TestRequest testSuiteDefinition =
             new TestRequest( testSuiteXmlFiles, sourceDirectory, new TestListResolver( requestedTest ),
-                             rerunFailingTestsCount );
+                             rerunFailingTestsCount, rerunFailingTestsAtEndCount );
 
         ReporterConfiguration reporterConfiguration =
             new ReporterConfiguration( reportsDirectory, properties.getBooleanObjectProperty( ISTRIMSTACKTRACE ) );

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4RerunFailingTestsAtEndIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4RerunFailingTestsAtEndIT.java
@@ -1,0 +1,272 @@
+package org.apache.maven.surefire.its;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Test;
+
+public class JUnit4RerunFailingTestsAtEndIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+    private SurefireLauncher unpack()
+    {
+        return unpack( "/junit4-rerun-failing-tests" );
+    }
+
+    @Test
+    public void testRerunFailingErrorTestsWithOneRetry()
+        throws Exception
+    {
+        OutputValidator outputValidator =
+            unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+                "-Dsurefire.rerunFailingTestsAtEndCount=1" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0,
+                                                                                                            0 );
+        verifyFailuresOneRetryAllClasses( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal(
+            "-DforkCount=2" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+        verifyFailuresOneRetryAllClasses( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal( "-Dparallel=methods" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+        verifyFailuresOneRetryAllClasses( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal( "-Dparallel=classes" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+        verifyFailuresOneRetryAllClasses( outputValidator );
+    }
+
+    @Test
+    public void testRerunFailingErrorTestsTwoRetry()
+        throws Exception
+    {
+        OutputValidator outputValidator =
+            unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+                "-Dsurefire.rerunFailingTestsAtEndCount=2" ).executeTest().assertTestSuiteResults( 5, 0, 0, 0, 4 );
+
+        verifyFailuresTwoRetryAllClasses( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=2" ).addGoal( "-DforkCount=3" ).executeTest()
+            .assertTestSuiteResults( 5, 0, 0, 0, 4 );
+
+        verifyFailuresTwoRetryAllClasses( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=2" ).addGoal( "-Dparallel=methods" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).executeTest().assertTestSuiteResults( 5, 0, 0, 0, 4 );
+
+        verifyFailuresTwoRetryAllClasses( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=2" ).addGoal( "-Dparallel=classes" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).executeTest().assertTestSuiteResults( 5, 0, 0, 0, 4 );
+
+        verifyFailuresTwoRetryAllClasses( outputValidator );
+    }
+
+    @Test
+    public void testRerunFailingErrorTestsFalse()
+        throws Exception
+    {
+        OutputValidator outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion(
+            "4.7" ).maven().withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+
+        verifyFailuresNoRetryAllClasses( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-DforkCount=3" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+
+        verifyFailuresNoRetryAllClasses( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dparallel=methods" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+
+        verifyFailuresNoRetryAllClasses( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dparallel=classes" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+
+        verifyFailuresNoRetryAllClasses( outputValidator );
+    }
+
+    @Test
+    public void testRerunOneTestClass()
+        throws Exception
+    {
+        OutputValidator outputValidator =
+            unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+                "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal(
+                "-Dtest=FlakyFirstTimeTest" ).withFailure().executeTest().assertTestSuiteResults( 3, 1, 1, 0, 0 );
+
+        verifyFailuresOneRetryOneClass( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal( "-DforkCount=3" ).addGoal(
+            "-Dtest=FlakyFirstTimeTest" ).withFailure().executeTest().assertTestSuiteResults( 3, 1, 1, 0, 0 );
+
+        verifyFailuresOneRetryOneClass( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal( "-Dparallel=methods" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).addGoal(
+            "-Dtest=FlakyFirstTimeTest" ).withFailure().executeTest().assertTestSuiteResults( 3, 1, 1, 0, 0 );
+
+        verifyFailuresOneRetryOneClass( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal( "-Dparallel=classes" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).addGoal(
+            "-Dtest=FlakyFirstTimeTest" ).withFailure().executeTest().assertTestSuiteResults( 3, 1, 1, 0, 0 );
+
+        verifyFailuresOneRetryOneClass( outputValidator );
+    }
+
+    @Test
+    public void testRerunOneTestMethod()
+        throws Exception
+    {
+        OutputValidator outputValidator =
+            unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+                "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal(
+                "-Dtest=FlakyFirstTimeTest#testFailing*" ).withFailure().executeTest().assertTestSuiteResults( 1, 0, 1,
+                                                                                                               0, 0 );
+
+        verifyFailuresOneRetryOneMethod( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal( "-DforkCount=3" ).addGoal(
+            "-Dtest=FlakyFirstTimeTest#testFailing*" ).withFailure().executeTest().assertTestSuiteResults( 1, 0, 1, 0,
+                                                                                                           0 );
+
+        verifyFailuresOneRetryOneMethod( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal( "-Dparallel=methods" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).addGoal(
+            "-Dtest=FlakyFirstTimeTest#testFailing*" ).withFailure().executeTest().assertTestSuiteResults( 1, 0, 1, 0,
+                                                                                                           0 );
+
+        verifyFailuresOneRetryOneMethod( outputValidator );
+
+        outputValidator = unpack().addGoal( "-Dprovider=surefire-junit4" ).setJUnitVersion( "4.7" ).maven().addGoal(
+            "-Dsurefire.rerunFailingTestsAtEndCount=1" ).addGoal( "-Dparallel=classes" ).addGoal(
+            "-DuseUnlimitedThreads=true" ).addGoal(
+            "-Dtest=FlakyFirstTimeTest#testFailing*" ).withFailure().executeTest().assertTestSuiteResults( 1, 0, 1, 0,
+                                                                                                           0 );
+
+        verifyFailuresOneRetryOneMethod( outputValidator );
+    }
+
+    private void verifyFailuresOneRetryAllClasses( OutputValidator outputValidator )
+    {
+        verifyFailuresOneRetry( outputValidator, 5, 1, 1, 0 );
+    }
+
+    private void verifyFailuresTwoRetryAllClasses( OutputValidator outputValidator )
+    {
+        verifyFailuresTwoRetry( outputValidator, 5, 0, 0, 2 );
+    }
+
+    private void verifyFailuresNoRetryAllClasses( OutputValidator outputValidator )
+    {
+        verifyFailuresNoRetry( outputValidator, 5, 1, 1, 0 );
+    }
+
+    private void verifyFailuresOneRetryOneClass( OutputValidator outputValidator )
+    {
+        verifyFailuresOneRetry( outputValidator, 3, 1, 1, 0 );
+    }
+
+    private void verifyFailuresOneRetryOneMethod( OutputValidator outputValidator )
+    {
+        verifyOnlyFailuresOneRetry( outputValidator, 1, 1, 0, 0 );
+    }
+
+    private void verifyFailuresOneRetry( OutputValidator outputValidator, int run, int failures, int errors,
+                                         int flakes )
+    {
+        outputValidator.verifyTextInLog( "Failed tests" );
+        outputValidator.verifyTextInLog( "Run 1: FlakyFirstTimeTest.testFailingTestOne" );
+        outputValidator.verifyTextInLog( "Run 2: FlakyFirstTimeTest.testFailingTestOne" );
+
+        outputValidator.verifyTextInLog( "Tests in error" );
+        outputValidator.verifyTextInLog( "Run 1: FlakyFirstTimeTest.testErrorTestOne" );
+        outputValidator.verifyTextInLog( "Run 2: FlakyFirstTimeTest.testErrorTestOne" );
+
+        verifyStatistics( outputValidator, run, failures, errors, flakes );
+    }
+
+    private void verifyOnlyFailuresOneRetry( OutputValidator outputValidator, int run, int failures, int errors,
+                                             int flakes )
+    {
+        outputValidator.verifyTextInLog( "Failed tests" );
+        outputValidator.verifyTextInLog( "Run 1: FlakyFirstTimeTest.testFailingTestOne" );
+        outputValidator.verifyTextInLog( "Run 2: FlakyFirstTimeTest.testFailingTestOne" );
+
+        verifyStatistics( outputValidator, run, failures, errors, flakes );
+    }
+
+    private void verifyFailuresTwoRetry( OutputValidator outputValidator, int run, int failures, int errors,
+                                         int flakes )
+    {
+        outputValidator.verifyTextInLog( "Flaked tests" );
+        outputValidator.verifyTextInLog( "Run 1: FlakyFirstTimeTest.testFailingTestOne" );
+        outputValidator.verifyTextInLog( "Run 2: FlakyFirstTimeTest.testFailingTestOne" );
+        outputValidator.verifyTextInLog( "Run 3: PASS" );
+
+        outputValidator.verifyTextInLog( "Run 1: FlakyFirstTimeTest.testErrorTestOne" );
+        outputValidator.verifyTextInLog( "Run 2: FlakyFirstTimeTest.testErrorTestOne" );
+
+        verifyStatistics( outputValidator, run, failures, errors, flakes );
+    }
+
+    private void verifyFailuresNoRetry( OutputValidator outputValidator, int run, int failures, int errors, int flakes )
+    {
+        outputValidator.verifyTextInLog( "Failed tests" );
+        outputValidator.verifyTextInLog( "testFailingTestOne(junit4.FlakyFirstTimeTest)" );
+        outputValidator.verifyTextInLog( "ERROR" );
+        outputValidator.verifyTextInLog( "testErrorTestOne(junit4.FlakyFirstTimeTest)" );
+
+        verifyStatistics( outputValidator, run, failures, errors, flakes );
+    }
+
+    private void verifyStatistics( OutputValidator outputValidator, int run, int failures, int errors, int flakes )
+    {
+        if ( flakes > 0 )
+        {
+            outputValidator.verifyTextInLog(
+                "Tests run: " + run + ", Failures: " + failures + ", Errors: " + errors + ", Skipped: 0, Flakes: "
+                    + flakes );
+        }
+        else
+        {
+            outputValidator.verifyTextInLog(
+                "Tests run: " + run + ", Failures: " + failures + ", Errors: " + errors + ", Skipped: 0" );
+        }
+    }
+}

--- a/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
+++ b/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.surefire.common.junit4.ClassMethod;
@@ -53,6 +54,7 @@ import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.Runner;
 import org.junit.runner.manipulation.Filter;
+import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
 import static org.apache.maven.surefire.testset.TestListResolver.toClassFileName;
@@ -81,6 +83,8 @@ public class JUnit4Provider
 
     private final int rerunFailingTestsCount;
 
+    private final int rerunFailingTestsAtEndCount;
+
     private TestsToRun testsToRun;
 
     public JUnit4Provider( ProviderParameters booterParameters )
@@ -95,6 +99,7 @@ public class JUnit4Provider
         TestRequest testRequest = booterParameters.getTestRequest();
         testResolver = testRequest.getTestListResolver();
         rerunFailingTestsCount = testRequest.getRerunFailingTestsCount();
+        rerunFailingTestsAtEndCount = testRequest.getRerunFailingTestsAtEndCount();
     }
 
     public RunResult invoke( Object forkTestSet )
@@ -141,6 +146,8 @@ public class JUnit4Provider
         runNotifier.fireTestRunFinished( result );
 
         JUnit4RunListener.rethrowAnyTestMechanismFailures( result );
+
+        rerunAtEnd( reporterFactory, result.getFailures() );
 
         closeRunNotifier( jUnit4TestSetReporter, customRunListeners );
         return reporterFactory.close();
@@ -189,6 +196,60 @@ public class JUnit4Provider
             }
         }
     }
+
+    private void rerunFailedMethods( Class<?> clazz, RunListener reporter, RunNotifier listeners,
+                                 Set<String> failingTestMethods )
+    {
+
+        final ReportEntry report = new SimpleReportEntry( getClass().getName(), clazz.getName() );
+        reporter.testSetStarting( report );
+        try
+        {
+             for ( int i = 0; i < rerunFailingTestsAtEndCount; i++ )
+            {
+                executeFailedMethod( clazz, listeners, failingTestMethods );
+            }
+        }
+        catch ( Throwable e )
+        {
+            String reportName = report.getName();
+            String reportSourceName = report.getSourceName();
+            PojoStackTraceWriter stackWriter = new PojoStackTraceWriter( reportSourceName, reportName, e );
+            reporter.testError( SimpleReportEntry.withException( reportSourceName, reportName, stackWriter ) );
+        }
+        finally
+        {
+            reporter.testSetCompleted( report );
+        }
+
+    }
+
+    private void rerunAtEnd( ReporterFactory reporterFactory, List<Failure> allFailures ) throws TestSetFailedException
+    {
+        if ( allFailures.size() == 0 || rerunFailingTestsAtEndCount == 0 )
+        {
+            return;
+        }
+
+        RunListener reporter = reporterFactory.createReporter();
+        ConsoleOutputCapture.startCapture( (ConsoleOutputReceiver) reporter );
+        JUnit4RunListener jUnit4TestSetReporter = new JUnit4RunListener( reporter );
+
+        Result result = new Result();
+        RunNotifier runNotifer = getRunNotifier( jUnit4TestSetReporter, result, customRunListeners );
+        runNotifer.fireTestRunStarted( null );
+
+        Map<Class<?>, Set<String>> testClassMethods =
+            JUnit4ProviderUtil.generateFailingTests( allFailures, testClassLoader );
+
+        for ( Map.Entry<Class<?>, Set<String>> failingClassMethodsPair : testClassMethods.entrySet() )
+        {
+            rerunFailedMethods( failingClassMethodsPair.getKey(), reporter, runNotifer,
+                                failingClassMethodsPair.getValue() );
+        }
+        runNotifer.fireTestRunFinished( result );
+    }
+
 
     private static RunNotifier getRunNotifier( org.junit.runner.notification.RunListener main, Result result,
                                         List<org.junit.runner.notification.RunListener> others )
@@ -277,6 +338,14 @@ public class JUnit4Provider
                 runner.run( notifier );
             }
         }
+    }
+
+    private static void executeFailedMethod( Class<?> testClass, RunNotifier notifier, Set<String> failedMethods )
+    {
+        for ( String failedMethod : failedMethods )
+            {
+                Request.method( testClass, failedMethod ).getRunner().run( notifier );
+            }
     }
 
     private void executeFailedMethod( RunNotifier notifier, Set<ClassMethod> failedMethods )


### PR DESCRIPTION
This PR introduces an option to rerun failing tests at the end of a test suite execution. 

The current option (`rerunFailingTestsCount`) reruns the failing tests immediately after failure. There are several scenarios in which developers may want the failing tests to be rerun later. For example, consider a flaky test that tries to access a resource over a network. The test may fail whenever the network is down and rerunning it a bit later may be more helpful than rerunning it immediately (the network may recover later while it remains down immediately).

Note that the two options can be combined. For example, if a developer wants to rerun each failing test at most twice, the developer could choose to rerun the failing test once immediately, and if it still fails, rerun it once more at the end of the test suite. This strategy can be much better than rerunning a failing test twice immediately.
