### PR TITLE
Start stream capture before loading tests

### DIFF
--- a/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
+++ b/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
@@ -121,22 +121,6 @@ public class JUnit4Provider
             throw new TestSetFailedException( "don't enable parameters rerunFailingTestsCount, skipAfterFailureCount" );
         }
 
-        if ( testsToRun == null )
-        {
-            if ( forkTestSet instanceof TestsToRun )
-            {
-                testsToRun = (TestsToRun) forkTestSet;
-            }
-            else if ( forkTestSet instanceof Class )
-            {
-                testsToRun = fromClass( (Class<?>) forkTestSet );
-            }
-            else
-            {
-                testsToRun = scanClassPath();
-            }
-        }
-
         upgradeCheck();
 
         ReporterFactory reporterFactory = providerParameters.getReporterFactory();
@@ -164,6 +148,22 @@ public class JUnit4Provider
 
             try
             {
+                if ( testsToRun == null )
+                {
+                    if ( forkTestSet instanceof TestsToRun )
+                    {
+                        testsToRun = (TestsToRun) forkTestSet;
+                    }
+                    else if ( forkTestSet instanceof Class )
+                    {
+                        testsToRun = fromClass( (Class<?>) forkTestSet );
+                    }
+                    else
+                    {
+                        testsToRun = scanClassPath();
+                    }
+                }
+
                 notifier.fireTestRunStarted( testsToRun.allowEagerReading()
                                                  ? createTestsDescription( testsToRun )
                                                  : createDescription( UNDETERMINED_TESTS_DESCRIPTION ) );


### PR DESCRIPTION
If, when `scanClassPath()` runs, a class is loaded and that loading process produces a log (via log4j in our case), the logging framework creates its console appender around the current `stdout` stream, before the stream is replaced to start the redirection of `stdout` and `stderr` to a file (when `redirectTestOutputToFile` is used). The consequences are that `stdout` gets flooded with logs (i.e. `redirectTestOutputToFile` doesn't work).

Scanning the classpath after the capture is started, fixed the issue.

I believe that other providers have the same issue.