### PR TITLE
Adding support for externally passed random seed and printing used seed on console

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -290,6 +290,17 @@ public class IntegrationTestMojo
      * on odd hours), {@code failedfirst}, {@code balanced} and {@code filesystem}.
      * <br>
      * <br>
+     * When using {@code random} mode, actual <i>seed</i> used to randomize execution order will be printed on
+     * console. If the tests do not pass because they are bounded to the order in which they are executed,
+     * the <i>seed</i> number can be used to reproduce that erroneous execution. To do that pass
+     * {@code random:seed} as a value of {@code runOrder} parameter. This would effectively execute tests
+     * in same exact order as they where executed when they failed. It's most useful to pass it as a
+     * command line parameter:
+     * <br>
+     * <br>
+     * {@code -Dfailsafe.runOrder=random:325119}
+     * <br>
+     * <br>
      * Odd/Even for hourly is determined at the time the of scanning the classpath, meaning it could change during a
      * multi-module build.
      * <br>

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
@@ -31,6 +31,7 @@ import org.apache.maven.surefire.extensions.ConsoleOutputReportEventListener;
 import org.apache.maven.surefire.extensions.StatelessReportEventListener;
 import org.apache.maven.surefire.extensions.StatelessTestsetInfoConsoleReportEventListener;
 import org.apache.maven.surefire.extensions.StatelessTestsetInfoFileReportEventListener;
+import org.apache.maven.surefire.testset.RunOrderParameters;
 
 import javax.annotation.Nonnull;
 import java.io.File;
@@ -54,6 +55,8 @@ import static org.apache.maven.plugin.surefire.report.ConsoleReporter.PLAIN;
  */
 public final class StartupReportConfiguration
 {
+    public static final String DEFAULT_PLUGIN_NAME = "surefire";
+
     private final PrintStream originalSystemOut;
 
     private final PrintStream originalSystemErr;
@@ -80,7 +83,8 @@ public final class StartupReportConfiguration
 
     private final String xsdSchemaLocation;
 
-    private final Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory = new ConcurrentHashMap<>();
+    private final Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory
+        = new ConcurrentHashMap<>();
 
     private final Charset encoding;
 
@@ -92,6 +96,10 @@ public final class StartupReportConfiguration
 
     private final SurefireStatelessTestsetInfoReporter testsetReporter;
 
+    private final String pluginName;
+
+    private final RunOrderParameters runOrderParameters;
+
     private StatisticsReporter statisticsReporter;
 
     @SuppressWarnings( "checkstyle:parameternumber" )
@@ -101,7 +109,8 @@ public final class StartupReportConfiguration
                File statisticsFile, boolean requiresRunHistory, int rerunFailingTestsCount,
                String xsdSchemaLocation, String encoding, boolean isForkMode,
                SurefireStatelessReporter xmlReporter, SurefireConsoleOutputReporter consoleOutputReporter,
-               SurefireStatelessTestsetInfoReporter testsetReporter )
+               SurefireStatelessTestsetInfoReporter testsetReporter,
+               String pluginName, RunOrderParameters runOrderParameters )
     {
         this.useFile = useFile;
         this.printSummary = printSummary;
@@ -122,6 +131,8 @@ public final class StartupReportConfiguration
         this.xmlReporter = xmlReporter;
         this.consoleOutputReporter = consoleOutputReporter;
         this.testsetReporter = testsetReporter;
+        this.pluginName = pluginName;
+        this.runOrderParameters = runOrderParameters;
     }
 
     public boolean isUseFile()
@@ -271,5 +282,15 @@ public final class StartupReportConfiguration
     private boolean shouldReportToConsole()
     {
         return isUseFile() ? isPrintSummary() : isRedirectTestOutputToFile() || isBriefOrPlainFormat();
+    }
+
+    public String getPluginName()
+    {
+        return pluginName;
+    }
+
+    public RunOrderParameters getRunOrderParameters()
+    {
+        return runOrderParameters;
     }
 }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
@@ -32,7 +32,9 @@ import org.apache.maven.surefire.testset.RunOrderParameters;
 import org.apache.maven.surefire.testset.TestArtifactInfo;
 import org.apache.maven.surefire.testset.TestListResolver;
 import org.apache.maven.surefire.testset.TestRequest;
-import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.Randomizer;
+import org.apache.maven.surefire.util.RunOrderMapper;
+import org.apache.maven.surefire.util.internal.RandomizerSerializer;
 
 import java.io.File;
 import java.io.IOException;
@@ -54,6 +56,7 @@ import static org.apache.maven.surefire.booter.BooterConstants.ISTRIMSTACKTRACE;
 import static org.apache.maven.surefire.booter.BooterConstants.MAIN_CLI_OPTIONS;
 import static org.apache.maven.surefire.booter.BooterConstants.PLUGIN_PID;
 import static org.apache.maven.surefire.booter.BooterConstants.PROVIDER_CONFIGURATION;
+import static org.apache.maven.surefire.booter.BooterConstants.RANDOM_SEED;
 import static org.apache.maven.surefire.booter.BooterConstants.REPORTSDIRECTORY;
 import static org.apache.maven.surefire.booter.BooterConstants.REQUESTEDTEST;
 import static org.apache.maven.surefire.booter.BooterConstants.RERUN_FAILING_TESTS_COUNT;
@@ -89,6 +92,7 @@ import static org.apache.maven.surefire.booter.SystemPropertyManager.writeProper
 class BooterSerializer
 {
     private final ForkConfiguration forkConfiguration;
+    private final RunOrderMapper runOrderMapper = new RunOrderMapper();
 
     BooterSerializer( ForkConfiguration forkConfiguration )
     {
@@ -154,7 +158,12 @@ class BooterSerializer
         final RunOrderParameters runOrderParameters = booterConfiguration.getRunOrderParameters();
         if ( runOrderParameters != null )
         {
-            properties.setProperty( RUN_ORDER, RunOrder.asString( runOrderParameters.getRunOrder() ) );
+            properties.setProperty( RUN_ORDER, runOrderMapper.asString( runOrderParameters.getRunOrders() ) );
+            Randomizer randomizer = runOrderParameters.getRandomizer();
+            String seed = randomizer != null
+                    ? RandomizerSerializer.serialize( randomizer )
+                    : Randomizer.DEFAULT_SEED;
+            properties.setProperty( RANDOM_SEED, seed );
             properties.setProperty( RUN_STATISTICS_FILE, runOrderParameters.getRunStatisticsFile() );
         }
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
@@ -33,6 +33,7 @@ import org.apache.maven.surefire.report.RunListener;
 import org.apache.maven.surefire.report.RunStatistics;
 import org.apache.maven.surefire.report.StackTraceWriter;
 import org.apache.maven.surefire.suite.RunResult;
+import org.apache.maven.surefire.util.Randomizer;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -169,6 +170,7 @@ public class DefaultReporterFactory
     {
         mergeTestHistoryResult();
         runCompleted();
+        displayRandomization();
         for ( TestSetRunListener listener : listeners )
         {
             listener.close();
@@ -184,6 +186,30 @@ public class DefaultReporterFactory
             log( "-------------------------------------------------------" );
             log( " T E S T S" );
             log( "-------------------------------------------------------" );
+            displayRandomization();
+        }
+    }
+
+    private boolean isRandomized()
+    {
+        return reportConfiguration.getRunOrderParameters() != null
+                && reportConfiguration.getRunOrderParameters().isRandomized();
+    }
+
+    private void displayRandomization()
+    {
+        if ( isRandomized() )
+        {
+            final Randomizer randomizer = reportConfiguration.getRunOrderParameters().getRandomizer();
+            final String pluginName = reportConfiguration.getPluginName();
+            final String message = String.format(
+                    "Tests are randomly ordered. Re-run the same execution order"
+                            + " with -D%s.runOrder=random:%d",
+                    pluginName, randomizer.getSeed()
+            );
+            log( "" );
+            log( message );
+            log( "" );
         }
     }
 
@@ -200,7 +226,7 @@ public class DefaultReporterFactory
         boolean printedFlakes = printTestFailures( flake );
         if ( reportConfiguration.isPrintSummary() )
         {
-            if ( printedFailures | printedErrors | printedFlakes )
+            if ( printedFailures || printedErrors || printedFlakes )
             {
                 log( "" );
             }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/runorder/RunOrderProcessor.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/runorder/RunOrderProcessor.java
@@ -1,0 +1,79 @@
+package org.apache.maven.plugin.surefire.runorder;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.testset.RunOrderParameters;
+import org.apache.maven.surefire.util.Randomizer;
+import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.RunOrderArguments;
+import org.apache.maven.surefire.util.RunOrderMapper;
+import org.apache.maven.surefire.util.RunOrders;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
+
+/**
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2018-05-24
+ */
+@ParametersAreNonnullByDefault
+public final class RunOrderProcessor
+{
+    private final RunOrderMapper runOrderMapper = new RunOrderMapper();
+
+    public RunOrderParameters createRunOrderParameters( RunOrders runOrders,
+                                                        File statisticsFile )
+    {
+        @Nullable String seed = extractSeedFromRunOrders( runOrders );
+        Randomizer randomizer = new Randomizer( seed );
+        return new RunOrderParameters(
+                runOrders,
+                randomizer,
+                statisticsFile
+        );
+    }
+
+    public RunOrders readRunOrders( String runOrder )
+    {
+        return runOrderMapper.fromString( runOrder );
+    }
+
+    @Nullable
+    private String extractSeedFromRunOrders( RunOrders runOrders )
+    {
+
+        if ( !runOrders.contains( RunOrder.RANDOM ) )
+        {
+            return null;
+        }
+        else
+        {
+            StringBuilder sb = new StringBuilder();
+            RunOrderArguments args = runOrders.getArguments( RunOrder.RANDOM );
+            for ( String arg : args.getPositional() )
+            {
+                sb.append( arg );
+            }
+            return sb.toString();
+        }
+    }
+
+}

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
@@ -24,6 +24,10 @@ import org.apache.maven.plugin.surefire.extensions.SurefireStatelessReporter;
 import org.apache.maven.plugin.surefire.extensions.SurefireStatelessTestsetInfoReporter;
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
+import org.apache.maven.surefire.testset.RunOrderParameters;
+import org.apache.maven.surefire.util.Randomizer;
+import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.RunOrders;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,6 +47,11 @@ public class CommonReflectorTest
     private SurefireStatelessReporter xmlReporter;
     private SurefireConsoleOutputReporter consoleOutputReporter = new SurefireConsoleOutputReporter();
     private SurefireStatelessTestsetInfoReporter infoReporter = new SurefireStatelessTestsetInfoReporter();
+    private RunOrderParameters runOrderParameters = new RunOrderParameters(
+            new RunOrders( RunOrder.RANDOM ),
+            new Randomizer( "seed1234" ),
+            null
+    );
 
     @Before
     public void setup()
@@ -55,7 +64,9 @@ public class CommonReflectorTest
 
         startupReportConfiguration = new StartupReportConfiguration( true, true, "PLAIN", false, reportsDirectory,
                 false, null, statistics, false, 1, null, null, false,
-                xmlReporter, consoleOutputReporter, infoReporter);
+                xmlReporter, consoleOutputReporter, infoReporter,
+                "surefire", runOrderParameters
+        );
 
         consoleLogger = mock( ConsoleLogger.class );
     }
@@ -92,5 +103,8 @@ public class CommonReflectorTest
                 .isEqualTo( infoReporter.toString() );
         assertThat( reportConfiguration.getConsoleOutputReporter().toString() )
                 .isEqualTo( consoleOutputReporter.toString() );
+        assertThat( reportConfiguration.getPluginName() ).isEqualTo( "surefire" );
+        assertThat( reportConfiguration.getRunOrderParameters().getRandomizer().getGivenSeed() )
+                .isEqualTo( "seed1234" );
     }
 }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
@@ -29,7 +29,11 @@ import org.apache.maven.plugin.surefire.extensions.SurefireConsoleOutputReporter
 import org.apache.maven.plugin.surefire.extensions.SurefireStatelessReporter;
 import org.apache.maven.plugin.surefire.extensions.SurefireStatelessTestsetInfoReporter;
 import org.apache.maven.surefire.suite.RunResult;
+import org.apache.maven.surefire.testset.RunOrderParameters;
 import org.apache.maven.surefire.util.DefaultScanResult;
+import org.apache.maven.surefire.util.Randomizer;
+import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.RunOrders;
 import org.apache.maven.toolchain.Toolchain;
 import org.junit.Test;
 
@@ -52,7 +56,13 @@ public class MojoMocklessTest
     public void testGetStartupReportConfiguration() throws Exception
     {
         AbstractSurefireMojo surefirePlugin = new Mojo( null, null );
-        StartupReportConfiguration config = invokeMethod( surefirePlugin, "getStartupReportConfiguration", "", false );
+        RunOrderParameters runOrderParameters = new RunOrderParameters(
+                new RunOrders( RunOrder.RANDOM ), new Randomizer( "123" ), null
+        );
+        StartupReportConfiguration config = invokeMethod(
+                surefirePlugin, "getStartupReportConfiguration",
+                "", false, runOrderParameters
+        );
 
         assertThat( config.getXmlReporter() )
                 .isNotNull()
@@ -78,7 +88,13 @@ public class MojoMocklessTest
         setInternalState( surefirePlugin, "consoleOutputReporter", consoleReporter );
         setInternalState( surefirePlugin, "statelessTestsetInfoReporter", testsetInfoReporter );
 
-        StartupReportConfiguration config = invokeMethod( surefirePlugin, "getStartupReportConfiguration", "", false );
+        RunOrderParameters runOrderParameters = new RunOrderParameters(
+                new RunOrders( RunOrder.DEFAULT ), null, null
+        );
+        StartupReportConfiguration config = invokeMethod(
+                surefirePlugin, "getStartupReportConfiguration",
+                "", false, runOrderParameters
+        );
 
         assertThat( config.getXmlReporter() )
                 .isNotNull()

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
@@ -21,16 +21,33 @@ package org.apache.maven.plugin.surefire.booterclient;
 
 import junit.framework.Assert;
 import junit.framework.TestCase;
-import org.apache.maven.surefire.booter.*;
+import org.apache.maven.surefire.booter.BooterDeserializer;
+import org.apache.maven.surefire.booter.ClassLoaderConfiguration;
+import org.apache.maven.surefire.booter.ClasspathConfiguration;
+import org.apache.maven.surefire.booter.PropertiesWrapper;
+import org.apache.maven.surefire.booter.ProviderConfiguration;
+import org.apache.maven.surefire.booter.Shutdown;
+import org.apache.maven.surefire.booter.StartupConfiguration;
+import org.apache.maven.surefire.booter.TypeEncodedValue;
 import org.apache.maven.surefire.cli.CommandLineOption;
 import org.apache.maven.surefire.report.ReporterConfiguration;
-import org.apache.maven.surefire.testset.*;
+import org.apache.maven.surefire.testset.DirectoryScannerParameters;
+import org.apache.maven.surefire.testset.ResolvedTest;
+import org.apache.maven.surefire.testset.RunOrderParameters;
+import org.apache.maven.surefire.testset.TestArtifactInfo;
+import org.apache.maven.surefire.testset.TestListResolver;
+import org.apache.maven.surefire.testset.TestRequest;
 import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.RunOrders;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 
 import static org.apache.maven.surefire.cli.CommandLineOption.LOGGING_LEVEL_DEBUG;
 import static org.apache.maven.surefire.cli.CommandLineOption.REACTOR_FAIL_FAST;
@@ -198,8 +215,14 @@ public class BooterDeserializerProviderConfigurationTest
         excludes.add( "xx1" );
         excludes.add( "xx2" );
 
-        return new DirectoryScannerParameters( aDir, includes, excludes, Collections.<String>emptyList(), true,
-                                               RunOrder.asString( RunOrder.DEFAULT ) );
+        return new DirectoryScannerParameters(
+                aDir,
+                includes,
+                excludes,
+                Collections.<String>emptyList(),
+                true,
+                new RunOrders( RunOrder.DEFAULT )
+        );
     }
 
     private ProviderConfiguration saveAndReload( ProviderConfiguration booterConfiguration,
@@ -235,7 +258,11 @@ public class BooterDeserializerProviderConfigurationTest
             new TestRequest( getSuiteXmlFileStrings(), getTestSourceDirectory(),
                              new TestListResolver( aUserRequestedTest + "#aUserRequestedTestMethod" ),
                              rerunFailingTestsCount );
-        RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
+        RunOrderParameters runOrderParameters = new RunOrderParameters(
+                new RunOrders( RunOrder.DEFAULT ),
+                null,
+                null
+        );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(), aTestTyped,
                 readTestsFromInStream, cli, 0, Shutdown.DEFAULT, 0 );

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
@@ -25,6 +25,7 @@ import org.apache.maven.surefire.cli.CommandLineOption;
 import org.apache.maven.surefire.report.ReporterConfiguration;
 import org.apache.maven.surefire.testset.*;
 import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.RunOrders;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -138,13 +139,16 @@ public class BooterDeserializerStartupConfigurationTest
         File cwd = new File( "." );
         DirectoryScannerParameters directoryScannerParameters =
             new DirectoryScannerParameters( cwd, new ArrayList<String>(), new ArrayList<String>(),
-                                            new ArrayList<String>(), true, "hourly" );
+                                            new ArrayList<String>(), true,
+                                            new RunOrders( RunOrder.HOURLY ) );
         ReporterConfiguration reporterConfiguration = new ReporterConfiguration( cwd, true );
         TestRequest testSuiteDefinition =
             new TestRequest( Arrays.asList( getSuiteXmlFileStrings() ), getTestSourceDirectory(),
                              new TestListResolver( "aUserRequestedTest#aUserRequestedTestMethod" ));
 
-        RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
+        RunOrderParameters runOrderParameters = new RunOrderParameters(
+                new RunOrders( RunOrder.DEFAULT ), null, null
+        );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(),
                 BooterDeserializerProviderConfigurationTest.aTestTyped, true, cli, 0, Shutdown.DEFAULT, 0 );

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
@@ -23,9 +23,12 @@ import org.apache.maven.plugin.surefire.StartupReportConfiguration;
 import org.apache.maven.plugin.surefire.extensions.SurefireConsoleOutputReporter;
 import org.apache.maven.plugin.surefire.extensions.SurefireStatelessReporter;
 import org.apache.maven.plugin.surefire.extensions.SurefireStatelessTestsetInfoReporter;
-import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
 import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
 import org.apache.maven.surefire.report.RunListener;
+import org.apache.maven.surefire.testset.RunOrderParameters;
+import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.RunOrders;
 
 import java.io.File;
 
@@ -58,8 +61,29 @@ public class TestSetMockReporterFactory
     {
         File target = new File( "./target" );
         File statisticsFile = new File( target, "TESTHASH" );
-        return new StartupReportConfiguration( true, true, "PLAIN", false, target, false, null, statisticsFile,
-                false, 0, null, null, true, new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                new SurefireStatelessTestsetInfoReporter() );
+        RunOrderParameters runOrderParameters = new RunOrderParameters(
+                new RunOrders( RunOrder.DEFAULT ),
+                null, statisticsFile
+        );
+        return new StartupReportConfiguration(
+                true,
+                true,
+                "PLAIN",
+                false,
+                target,
+                false,
+                null,
+                statisticsFile,
+                false,
+                0,
+                null,
+                null,
+                true,
+                new SurefireStatelessReporter(),
+                new SurefireConsoleOutputReporter(),
+                new SurefireStatelessTestsetInfoReporter(),
+                StartupReportConfiguration.DEFAULT_PLUGIN_NAME,
+                runOrderParameters
+        );
     }
 }

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -19,10 +19,6 @@ package org.apache.maven.plugin.surefire;
  * under the License.
  */
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -30,6 +26,11 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.surefire.suite.RunResult;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.apache.maven.plugin.surefire.SurefireHelper.reportExecution;
 
@@ -269,6 +270,17 @@ public class SurefirePlugin
      * Defines the order the tests will be run in. Supported values are {@code alphabetical},
      * {@code reversealphabetical}, {@code random}, {@code hourly} (alphabetical on even hours, reverse alphabetical
      * on odd hours), {@code failedfirst}, {@code balanced} and {@code filesystem}.
+     * <br>
+     * <br>
+     * When using {@code random} mode, actual <i>seed</i> used to randomize execution order will be printed on
+     * console. If the tests do not pass because they are bounded to the order in which they are executed,
+     * the <i>seed</i> number can be used to reproduce that erroneous execution. To do that pass
+     * {@code random:seed} as a value of {@code runOrder} parameter. This would effectively execute tests
+     * in same exact order as they where executed when they failed. It's most useful to pass it as a
+     * command line parameter:
+     * <br>
+     * <br>
+     * {@code -Dsurefire.runOrder=random:325119}
      * <br>
      * <br>
      * Odd/Even for hourly is determined at the time the of scanning the classpath, meaning it could change during a

--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>

--- a/surefire-api/src/main/java/org/apache/maven/surefire/testset/DirectoryScannerParameters.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/testset/DirectoryScannerParameters.java
@@ -19,15 +19,20 @@ package org.apache.maven.surefire.testset;
  * under the License.
  */
 
+import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.RunOrderMapper;
+import org.apache.maven.surefire.util.RunOrders;
+
 import java.io.File;
 import java.util.List;
-import org.apache.maven.surefire.util.RunOrder;
 
 /**
  * @author Kristian Rosenvold
  */
 public class DirectoryScannerParameters
 {
+    private static final RunOrderMapper RUN_ORDER_MAPPER = new RunOrderMapper();
+
     private final File testClassesDirectory;
 
     @Deprecated
@@ -41,25 +46,21 @@ public class DirectoryScannerParameters
 
     private final boolean failIfNoTests;
 
-    private final RunOrder[] runOrder;
+    private final RunOrders runOrders;
 
-    private DirectoryScannerParameters( File testClassesDirectory, List<String> includes, List<String> excludes,
-                                        List<String> specificTests, boolean failIfNoTests, RunOrder[] runOrder )
+    public DirectoryScannerParameters( File testClassesDirectory,
+                                       @Deprecated List<String> includes,
+                                       @Deprecated List<String> excludes,
+                                       @Deprecated List<String> specificTests,
+                                       boolean failIfNoTests,
+                                       RunOrders runOrders )
     {
         this.testClassesDirectory = testClassesDirectory;
         this.includes = includes;
         this.excludes = excludes;
         this.specificTests = specificTests;
         this.failIfNoTests = failIfNoTests;
-        this.runOrder = runOrder;
-    }
-
-    public DirectoryScannerParameters( File testClassesDirectory, @Deprecated List<String> includes,
-                                       @Deprecated List<String> excludes, @Deprecated List<String> specificTests,
-                                       boolean failIfNoTests, String runOrder )
-    {
-        this( testClassesDirectory, includes, excludes, specificTests, failIfNoTests,
-              runOrder == null ? RunOrder.DEFAULT : RunOrder.valueOfMulti( runOrder ) );
+        this.runOrders = runOrders;
     }
 
     @Deprecated
@@ -110,8 +111,15 @@ public class DirectoryScannerParameters
         return failIfNoTests;
     }
 
-    public RunOrder[] getRunOrder()
+    public RunOrders getRunOrders()
     {
-        return runOrder;
+        return runOrders;
+    }
+
+    private static RunOrders readRunOrders( String runOrder )
+    {
+        return runOrder == null
+                ? new RunOrders( RunOrder.DEFAULT )
+                : RUN_ORDER_MAPPER.fromString( runOrder );
     }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/testset/RunOrderParameters.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/testset/RunOrderParameters.java
@@ -19,38 +19,47 @@ package org.apache.maven.surefire.testset;
  * under the License.
  */
 
-import java.io.File;
+import org.apache.maven.surefire.util.Randomizer;
 import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.RunOrders;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
 
 /**
  * @author Kristian Rosenvold
  */
 public class RunOrderParameters
 {
-    private final RunOrder[] runOrder;
+    private final RunOrders runOrders;
 
-    private File runStatisticsFile;
+    private final File runStatisticsFile;
 
-    public RunOrderParameters( RunOrder[] runOrder, File runStatisticsFile )
+    private final Randomizer randomizer;
+
+
+    public RunOrderParameters( @Nonnull RunOrders runOrders,
+                               @Nullable Randomizer randomizer,
+                               @Nullable File runStatisticsFile )
     {
-        this.runOrder = runOrder;
-        this.runStatisticsFile = runStatisticsFile;
-    }
-
-    public RunOrderParameters( String runOrder, File runStatisticsFile )
-    {
-        this.runOrder = runOrder == null ? RunOrder.DEFAULT : RunOrder.valueOfMulti( runOrder );
+        this.runOrders = runOrders;
+        this.randomizer = ensureRandomizer( runOrders, randomizer );
         this.runStatisticsFile = runStatisticsFile;
     }
 
     public static RunOrderParameters alphabetical()
     {
-        return new RunOrderParameters( new RunOrder[]{ RunOrder.ALPHABETICAL }, null );
+        return new RunOrderParameters(
+                new RunOrders( RunOrder.ALPHABETICAL ),
+                null,
+                null
+        );
     }
 
-    public RunOrder[] getRunOrder()
+    public RunOrders getRunOrders()
     {
-        return runOrder;
+        return runOrders;
     }
 
     public File getRunStatisticsFile()
@@ -58,4 +67,30 @@ public class RunOrderParameters
         return runStatisticsFile;
     }
 
+    public Randomizer getRandomizer()
+    {
+        return randomizer;
+    }
+
+    public boolean isRandomized()
+    {
+        return isRandomized( this.runOrders );
+    }
+
+    @Nullable
+    private static Randomizer ensureRandomizer( @Nonnull RunOrders runOrders,
+                                                @Nullable Randomizer randomizer )
+    {
+        Randomizer result = randomizer;
+        if ( isRandomized( runOrders ) && result == null )
+        {
+            result = new Randomizer();
+        }
+        return result;
+    }
+
+    private static boolean isRandomized( @Nonnull RunOrders runOrders )
+    {
+        return runOrders.contains( RunOrder.RANDOM );
+    }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/ClassesShuffler.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/ClassesShuffler.java
@@ -1,4 +1,4 @@
-package testng.suiteXml;
+package org.apache.maven.surefire.util;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,33 +19,13 @@ package testng.suiteXml;
  * under the License.
  */
 
-import org.testng.annotations.Test;
-
-import java.nio.charset.Charset;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.List;
 
 /**
- * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
- * @since 2.19
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2018-06-13
  */
-public class TestNGSuiteTest {
-	private static final AtomicInteger COUNTER = new AtomicInteger();
-
-	@Test
-	public void shouldRunAndPrintItself()
-		throws Exception
-	{
-        String message = String.format(
-                "%s#shouldRunAndPrintItself() %d.",
-                getClass().getSimpleName(),
-                COUNTER.incrementAndGet()
-        );
-
-        synchronized ( System.out )
-        {
-            System.out.println( message );
-            TimeUnit.SECONDS.sleep( 2 );
-        }
-    }
+public interface ClassesShuffler
+{
+    void shuffle( List<Class<?>> classes );
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/ClassesShufflerImpl.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/ClassesShufflerImpl.java
@@ -19,38 +19,36 @@ package org.apache.maven.surefire.util;
  * under the License.
  */
 
-import org.junit.Test;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-public class RunOrderTest
+/**
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2018-06-13
+ */
+final class ClassesShufflerImpl implements ClassesShuffler
 {
+    private final Randomizer randomizer;
 
-    @Test
-    public void testShouldReturnRunOrderForLowerCaseName()
+    ClassesShufflerImpl( Randomizer randomizer )
     {
-        assertEquals( RunOrder.HOURLY, RunOrder.valueOf( "hourly" ) );
+        this.randomizer = randomizer;
     }
 
-    @Test
-    public void testShouldThrowExceptionForInvalidName()
+    @Override
+    public void shuffle( List<Class<?>> classes )
     {
-        try
-        {
-            RunOrder.valueOf( "arbitraryName" );
-            fail( "IllegalArgumentException not thrown." );
-        }
-        catch ( IllegalArgumentException expected )
-        {
-            assertTrue( expected.getMessage().contains( "Please use one of the following RunOrders" ) );
-        }
+        Collections.sort( classes, new ClassNameComparator() );
+        Collections.shuffle( classes, randomizer.getRandom() );
     }
 
-    @Test
-    public void testShouldReturnStringRepr()
+    private static final class ClassNameComparator implements Comparator<Class<?>>
     {
-        assertEquals( "hourly", RunOrder.HOURLY.toString() );
+        @Override
+        public int compare( Class<?> cls1, Class<?> cls2 )
+        {
+            return cls1.getName().compareTo( cls2.getName() );
+        }
     }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/DefaultRunOrderCalculator.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/DefaultRunOrderCalculator.java
@@ -37,9 +37,11 @@ import java.util.List;
 public class DefaultRunOrderCalculator
     implements RunOrderCalculator
 {
+    private static final int INITIAL_CAPACITY = 512;
+
     private final Comparator<Class> sortOrder;
 
-    private final RunOrder[] runOrder;
+    private final RunOrders runOrders;
 
     private final RunOrderParameters runOrderParameters;
 
@@ -49,30 +51,33 @@ public class DefaultRunOrderCalculator
     {
         this.runOrderParameters = runOrderParameters;
         this.threadCount = threadCount;
-        this.runOrder = runOrderParameters.getRunOrder();
-        this.sortOrder = this.runOrder.length > 0 ? getSortOrderComparator( this.runOrder[0] ) : null;
+        this.runOrders = runOrderParameters.getRunOrders();
+        this.sortOrder = this.runOrders.any() ? getSortOrderComparator( this.runOrders ) : null;
     }
 
     @Override
-    @SuppressWarnings( "checkstyle:magicnumber" )
     public TestsToRun orderTestClasses( TestsToRun scannedClasses )
     {
-        List<Class<?>> result = new ArrayList<>( 512 );
+        List<Class<?>> result = new ArrayList<Class<?>>( INITIAL_CAPACITY );
 
         for ( Class<?> scannedClass : scannedClasses )
         {
             result.add( scannedClass );
         }
 
-        orderTestClasses( result, runOrder.length != 0 ? runOrder[0] : null );
-        return new TestsToRun( new LinkedHashSet<>( result ) );
+        orderTestClasses(
+                result,
+                runOrders.any() ? runOrders.firstAsType() : null
+        );
+        return new TestsToRun( new LinkedHashSet<Class<?>>( result ) );
     }
 
     private void orderTestClasses( List<Class<?>> testClasses, RunOrder runOrder )
     {
         if ( RunOrder.RANDOM.equals( runOrder ) )
         {
-            Collections.shuffle( testClasses );
+            ClassesShuffler shuffler = new ClassesShufflerImpl( runOrderParameters.getRandomizer() );
+            shuffler.shuffle( testClasses );
         }
         else if ( RunOrder.FAILEDFIRST.equals( runOrder ) )
         {
@@ -96,8 +101,9 @@ public class DefaultRunOrderCalculator
         }
     }
 
-    private Comparator<Class> getSortOrderComparator( RunOrder runOrder )
+    private Comparator<Class> getSortOrderComparator( RunOrders runOrders )
     {
+        RunOrder runOrder = runOrders.firstAsType();
         if ( RunOrder.ALPHABETICAL.equals( runOrder ) )
         {
             return getAlphabeticalComparator();

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/Randomizer.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/Randomizer.java
@@ -1,0 +1,128 @@
+package org.apache.maven.surefire.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.util.internal.UniqIdGenerator;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Random;
+import java.util.zip.CRC32;
+
+/**
+ * An object that holds an random seed and random order
+ *
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2016-04-02
+ */
+public class Randomizer
+{
+    public static final String DEFAULT_SEED = "";
+    private static final int DECIMAL_RADIX = 10;
+    private static final int UPPER_BOUND = 1000000;
+    private static final int LOWER_BOUND = 100000;
+    private static final UniqIdGenerator UNIQ_ID_GENERATOR = new UniqIdGenerator(
+            LOWER_BOUND, UPPER_BOUND
+    );
+    private final String givenSeed;
+    private final long calculatedSeed;
+
+    /**
+     * Default constructor
+     */
+    public Randomizer()
+    {
+        this( Randomizer.DEFAULT_SEED );
+    }
+
+    /**
+     * Default constructor with a seed as a parameter.
+     *
+     * @param givenSeed a user given seed
+     */
+    public Randomizer( @Nullable String givenSeed )
+    {
+        this.givenSeed = ensureSeed( givenSeed );
+        this.calculatedSeed = makeItInRange( calculateSeed( this.givenSeed ) );
+    }
+
+    /**
+     * Copy constructor
+     *
+     * @param givenSeed      a user given seed
+     * @param calculatedSeed a calculated seed
+     */
+    public Randomizer( @Nonnull String givenSeed, long calculatedSeed )
+    {
+        this.givenSeed = givenSeed;
+        this.calculatedSeed = calculatedSeed;
+    }
+
+    public long getSeed()
+    {
+        return calculatedSeed;
+    }
+
+    @Nonnull
+    public String getGivenSeed()
+    {
+        return givenSeed;
+    }
+
+    @Nonnull
+    public Random getRandom()
+    {
+        return new Random( getSeed() );
+    }
+
+    @Nonnull
+    private static String ensureSeed( @Nullable String givenSeed )
+    {
+        return givenSeed != null ? givenSeed : DEFAULT_SEED;
+    }
+
+    private static long calculateSeed( @Nonnull String givenSeed )
+    {
+        if ( DEFAULT_SEED.equals( givenSeed ) )
+        {
+            return UNIQ_ID_GENERATOR.generateUniqId();
+        }
+        try
+        {
+            return Long.valueOf( givenSeed, DECIMAL_RADIX );
+        }
+        catch ( NumberFormatException nfex )
+        {
+            CRC32 crc32 = new CRC32();
+            crc32.update( givenSeed.getBytes() );
+            return crc32.getValue();
+        }
+    }
+
+    private static long makeItInRange( long seed )
+    {
+        long strippedDown = seed % UPPER_BOUND;
+        if ( strippedDown < LOWER_BOUND )
+        {
+            strippedDown += LOWER_BOUND;
+        }
+        return strippedDown;
+    }
+}

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrder.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrder.java
@@ -19,10 +19,6 @@ package org.apache.maven.surefire.util;
  * under the License.
  */
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.StringTokenizer;
-
 /**
  * A RunOrder specifies the order in which the tests will be run.
  *
@@ -45,26 +41,6 @@ public class RunOrder
     public static final RunOrder FAILEDFIRST = new RunOrder( "failedfirst" );
 
     public static final RunOrder[] DEFAULT = new RunOrder[]{ FILESYSTEM };
-
-    /**
-     * Returns the specified RunOrder
-     *
-     * @param values The runorder string value
-     * @return An array of RunOrder objects, never null
-     */
-    public static RunOrder[] valueOfMulti( String values )
-    {
-        List<RunOrder> result = new ArrayList<>();
-        if ( values != null )
-        {
-            StringTokenizer stringTokenizer = new StringTokenizer( values, "," );
-            while ( stringTokenizer.hasMoreTokens() )
-            {
-                result.add( valueOf( stringTokenizer.nextToken() ) );
-            }
-        }
-        return result.toArray( new RunOrder[result.size()] );
-    }
 
     public static RunOrder valueOf( String name )
     {
@@ -109,21 +85,6 @@ public class RunOrder
     private static RunOrder[] values()
     {
         return new RunOrder[]{ ALPHABETICAL, FILESYSTEM, HOURLY, RANDOM, REVERSE_ALPHABETICAL, BALANCED, FAILEDFIRST };
-    }
-
-    public static String asString( RunOrder[] runOrder )
-    {
-        StringBuilder stringBuffer = new StringBuilder();
-        for ( int i = 0; i < runOrder.length; i++ )
-        {
-            stringBuffer.append( runOrder[i].name );
-            if ( i < ( runOrder.length - 1 ) )
-            {
-                stringBuffer.append( "," );
-            }
-        }
-        return stringBuffer.toString();
-
     }
 
     private final String name;

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrderArguments.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrderArguments.java
@@ -1,4 +1,4 @@
-package testng.suiteXml;
+package org.apache.maven.surefire.util;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,33 +19,27 @@ package testng.suiteXml;
  * under the License.
  */
 
-import org.testng.annotations.Test;
-
-import java.nio.charset.Charset;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
- * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
- * @since 2.19
+ * Represents an arguments for a given {@link RunOrder}.
+ *
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
  */
-public class TestNGSuiteTest {
-	private static final AtomicInteger COUNTER = new AtomicInteger();
+@ParametersAreNonnullByDefault
+public final class RunOrderArguments
+{
+    private final Iterable<String> positional;
 
-	@Test
-	public void shouldRunAndPrintItself()
-		throws Exception
-	{
-        String message = String.format(
-                "%s#shouldRunAndPrintItself() %d.",
-                getClass().getSimpleName(),
-                COUNTER.incrementAndGet()
-        );
+    RunOrderArguments( @Nonnull Iterable<String> positional )
+    {
+        this.positional = positional;
+    }
 
-        synchronized ( System.out )
-        {
-            System.out.println( message );
-            TimeUnit.SECONDS.sleep( 2 );
-        }
+    @Nonnull
+    public Iterable<String> getPositional()
+    {
+        return positional;
     }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrderMapper.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrderMapper.java
@@ -1,0 +1,119 @@
+package org.apache.maven.surefire.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * A mapper for a Run order object to read them from string representation and back.
+ *
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ */
+@ParametersAreNonnullByDefault
+public final class RunOrderMapper
+{
+
+    private static final String RUN_ORDERS_DELIMITER = ",";
+    private static final String ARGUMENTS_DELIMITER = ":";
+
+    /**
+     * Returns the specified RunOrder from provided String representation
+     *
+     * @param values The runorder string value
+     * @return An iterable of RunOrder objects
+     */
+    public RunOrders fromString( @Nullable String values )
+    {
+        List<RunOrderWithArguments> result = new ArrayList<RunOrderWithArguments>();
+        if ( values != null )
+        {
+            StringTokenizer stringTokenizer = new StringTokenizer( values, RUN_ORDERS_DELIMITER );
+            while ( stringTokenizer.hasMoreTokens() )
+            {
+                String token = stringTokenizer.nextToken();
+                RunOrderWithArguments order = readOneFromString( token );
+                result.add( order );
+            }
+        }
+        return new RunOrders( result );
+    }
+
+    /**
+     * Returns the string representation of provided run order(s)
+     *
+     * @param runOrders a provided run order(s)
+     * @return a string representation of run order
+     */
+    public String asString( RunOrders runOrders )
+    {
+        StringBuilder sb = new StringBuilder();
+        for ( RunOrderWithArguments order : runOrders.getIterable() )
+        {
+            sb.append( asString( order ) );
+            sb.append( RUN_ORDERS_DELIMITER );
+        }
+        if ( sb.length() > 0 )
+        {
+            sb.delete( sb.length() - RUN_ORDERS_DELIMITER.length(), sb.length() );
+        }
+        return sb.toString();
+    }
+
+    Iterable<RunOrder> readWithoutArgumentsFromString( String values )
+    {
+        RunOrders runOrders = fromString( values );
+        List<RunOrder> result = new ArrayList<RunOrder>();
+        for ( RunOrderWithArguments order : runOrders.getIterable() )
+        {
+            result.add( order.getRunOrder() );
+        }
+        return result;
+    }
+
+    private String asString( RunOrderWithArguments order )
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append( order.getRunOrder().name() );
+        for ( String arg : order.getRunOrderArguments().getPositional() )
+        {
+            sb.append( ARGUMENTS_DELIMITER );
+            sb.append( arg );
+        }
+        return sb.toString();
+    }
+
+    private RunOrderWithArguments readOneFromString( String token )
+    {
+        String[] splited = token.split( ARGUMENTS_DELIMITER );
+        String name = splited[0];
+        RunOrder runOrder = RunOrder.valueOf( name );
+        List<String> asList = new ArrayList<String>( Arrays.asList( splited ) );
+        asList.remove( 0 );
+        RunOrderArguments arguments = new RunOrderArguments( asList );
+        return new RunOrderWithArguments( runOrder, arguments );
+    }
+
+}

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrderWithArguments.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrderWithArguments.java
@@ -1,4 +1,4 @@
-package testng.suiteXml;
+package org.apache.maven.surefire.util;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,33 +19,33 @@ package testng.suiteXml;
  * under the License.
  */
 
-import org.testng.annotations.Test;
-
-import java.nio.charset.Charset;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
- * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
- * @since 2.19
+ * Represents a Run Order with attached arguments.
+ *
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
  */
-public class TestNGSuiteTest {
-	private static final AtomicInteger COUNTER = new AtomicInteger();
+@ParametersAreNonnullByDefault
+public final class RunOrderWithArguments
+{
+    private final RunOrder runOrder;
+    private final RunOrderArguments runOrderArguments;
 
-	@Test
-	public void shouldRunAndPrintItself()
-		throws Exception
-	{
-        String message = String.format(
-                "%s#shouldRunAndPrintItself() %d.",
-                getClass().getSimpleName(),
-                COUNTER.incrementAndGet()
-        );
+    public RunOrderWithArguments( RunOrder runOrder,
+                                  RunOrderArguments runOrderArguments )
+    {
+        this.runOrder = runOrder;
+        this.runOrderArguments = runOrderArguments;
+    }
 
-        synchronized ( System.out )
-        {
-            System.out.println( message );
-            TimeUnit.SECONDS.sleep( 2 );
-        }
+    public RunOrder getRunOrder()
+    {
+        return runOrder;
+    }
+
+    public RunOrderArguments getRunOrderArguments()
+    {
+        return runOrderArguments;
     }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrders.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/RunOrders.java
@@ -1,0 +1,103 @@
+package org.apache.maven.surefire.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a complete set of run orders with arguments
+ *
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ */
+@ParametersAreNonnullByDefault
+public final class RunOrders
+{
+    private final List<RunOrderWithArguments> withArguments;
+
+    public RunOrders( RunOrder... runOrders )
+    {
+        this( withEmptyArguments( runOrders ) );
+    }
+
+    RunOrders( List<RunOrderWithArguments> runOrders )
+    {
+        this.withArguments = Collections.unmodifiableList( runOrders );
+    }
+
+    public Iterable<RunOrderWithArguments> getIterable()
+    {
+        return withArguments;
+    }
+
+    public boolean any()
+    {
+        return !withArguments.isEmpty();
+    }
+
+    public boolean contains( RunOrder runOrder )
+    {
+        for ( RunOrderWithArguments order : withArguments )
+        {
+            if ( order.getRunOrder().equals( runOrder ) )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public RunOrderArguments getArguments( RunOrder runOrder )
+    {
+        for ( RunOrderWithArguments order : withArguments )
+        {
+            if ( order.getRunOrder().equals( runOrder ) )
+            {
+                return order.getRunOrderArguments();
+            }
+        }
+        throw new IllegalStateException( "Check if contains specific run "
+                + "order before using getArguments" );
+    }
+
+    RunOrder firstAsType()
+    {
+        if ( !any() )
+        {
+            throw new IllegalStateException(
+                    "Use #any() method before invoking #firstAsType() method."
+            );
+        }
+        return withArguments.iterator().next().getRunOrder();
+    }
+
+    private static List<RunOrderWithArguments> withEmptyArguments( RunOrder[] runOrders )
+    {
+        List<RunOrderWithArguments> orderWithArguments = new ArrayList<>();
+        for ( RunOrder runOrder : runOrders )
+        {
+            RunOrderArguments args = new RunOrderArguments( new ArrayList<String>() );
+            orderWithArguments.add( new RunOrderWithArguments( runOrder, args ) );
+        }
+        return orderWithArguments;
+    }
+}

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/internal/RandomizerSerializer.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/internal/RandomizerSerializer.java
@@ -1,0 +1,65 @@
+package org.apache.maven.surefire.util.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.util.Randomizer;
+
+/**
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2016-04-11
+ */
+public final class RandomizerSerializer
+{
+    private static final String SPLITTER = "\u001E\u0003";
+
+    private RandomizerSerializer()
+    {
+        // nothing
+    }
+
+    /**
+     * Deserialize a string into randomizer object
+     * @param serialized a serialized
+     * @return a randomizer object
+     */
+    public static Randomizer deserialize( String serialized )
+    {
+        String[] parts = serialized.split( SPLITTER, 2 );
+        if ( parts.length == 2 )
+        {
+            return new Randomizer( parts[0], Long.parseLong( parts[1], 10 ) );
+        }
+        else
+        {
+            return new Randomizer( parts[0] );
+        }
+    }
+
+    /**
+     * Serialize the randomizer into string format
+     *
+     * @param randomizer a randomizer object
+     * @return a stringed form
+     */
+    public static String serialize( Randomizer randomizer )
+    {
+        return String.format( "%s%s%s", randomizer.getGivenSeed(), SPLITTER, randomizer.getSeed() );
+    }
+}

--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/internal/UniqIdGenerator.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/internal/UniqIdGenerator.java
@@ -1,0 +1,54 @@
+package org.apache.maven.surefire.util.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Random;
+
+/**
+ * Creates a randomized simple long, using fast random
+ *
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2016-04-01
+ */
+public class UniqIdGenerator
+{
+    private final Random random;
+    private final int lowerBound;
+    private final int upperBound;
+
+    public UniqIdGenerator( int lowerBound, int upperBound )
+    {
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+        this.random = getUnsecuredFastRandom();
+    }
+
+    public long generateUniqId()
+    {
+        int next = random.nextInt( upperBound - lowerBound );
+        next += lowerBound;
+        return next;
+    }
+
+    private static Random getUnsecuredFastRandom()
+    {
+        return new Random( System.currentTimeMillis() );
+    }
+}

--- a/surefire-api/src/test/java/org/apache/maven/JUnit4SuiteTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/JUnit4SuiteTest.java
@@ -33,14 +33,19 @@ import org.apache.maven.surefire.suite.RunResultTest;
 import org.apache.maven.surefire.testset.FundamentalFilterTest;
 import org.apache.maven.surefire.testset.ResolvedTestTest;
 import org.apache.maven.surefire.testset.TestListResolverTest;
+import org.apache.maven.surefire.util.ClassesShufflerImplTest;
 import org.apache.maven.surefire.util.DefaultDirectoryScannerTest;
+import org.apache.maven.surefire.util.RandomizerTest;
 import org.apache.maven.surefire.util.ReflectionUtilsTest;
 import org.apache.maven.surefire.util.RunOrderCalculatorTest;
+import org.apache.maven.surefire.util.RunOrderMapperTest;
 import org.apache.maven.surefire.util.RunOrderTest;
 import org.apache.maven.surefire.util.ScanResultTest;
 import org.apache.maven.surefire.util.TestsToRunTest;
 import org.apache.maven.surefire.util.internal.ConcurrencyUtilsTest;
 import org.apache.maven.surefire.util.internal.ImmutableMapTest;
+import org.apache.maven.surefire.util.internal.RandomizerSerializerTest;
+import org.apache.maven.surefire.util.internal.UniqIdGeneratorTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -62,6 +67,11 @@ import org.junit.runners.Suite;
     TestListResolverTest.class,
     ConcurrencyUtilsTest.class,
     DefaultDirectoryScannerTest.class,
+    ClassesShufflerImplTest.class,
+    RandomizerTest.class,
+    RandomizerSerializerTest.class,
+    RunOrderMapperTest.class,
+    UniqIdGeneratorTest.class,
     RunOrderCalculatorTest.class,
     RunOrderTest.class,
     ScanResultTest.class,

--- a/surefire-api/src/test/java/org/apache/maven/surefire/util/ClassesShufflerImplTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/util/ClassesShufflerImplTest.java
@@ -21,36 +21,46 @@ package org.apache.maven.surefire.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import java.util.List;
 
-public class RunOrderTest
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2018-06-13
+ */
+public class ClassesShufflerImplTest
 {
 
     @Test
-    public void testShouldReturnRunOrderForLowerCaseName()
+    public void testShuffle()
     {
-        assertEquals( RunOrder.HOURLY, RunOrder.valueOf( "hourly" ) );
+        // given
+        String seed = "123456";
+        Randomizer randomizer = new Randomizer( seed );
+        ClassesShuffler shuffler = new ClassesShufflerImpl( randomizer );
+        List<Class<?>> list = asList( A.class, B.class, C.class );
+
+        // when
+        shuffler.shuffle( list );
+
+        // then
+        assertEquals( asList( C.class, B.class, A.class ), list );
     }
 
-    @Test
-    public void testShouldThrowExceptionForInvalidName()
+    private static final class A
     {
-        try
-        {
-            RunOrder.valueOf( "arbitraryName" );
-            fail( "IllegalArgumentException not thrown." );
-        }
-        catch ( IllegalArgumentException expected )
-        {
-            assertTrue( expected.getMessage().contains( "Please use one of the following RunOrders" ) );
-        }
+
     }
 
-    @Test
-    public void testShouldReturnStringRepr()
+    private static final class B
     {
-        assertEquals( "hourly", RunOrder.HOURLY.toString() );
+
+    }
+
+    private static final class C
+    {
+
     }
 }

--- a/surefire-api/src/test/java/org/apache/maven/surefire/util/RandomizerTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/util/RandomizerTest.java
@@ -1,0 +1,119 @@
+package org.apache.maven.surefire.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+/**
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2016-04-02
+ */
+public class RandomizerTest
+{
+
+    @Test
+    public void testGetSeed()
+    {
+        // given
+        String seed = "123123";
+        Randomizer randomizer = new Randomizer( seed );
+        // when
+        long seedAsLong = randomizer.getSeed();
+
+        // then
+        assertEquals( 123123, seedAsLong );
+    }
+
+    @Test
+    public void testGetGivenSeed()
+    {
+        // given
+        String seed = "678";
+        Randomizer randomizer = new Randomizer( seed );
+
+        // when
+        String given = randomizer.getGivenSeed();
+
+        // then
+        assertSame( seed, given );
+    }
+
+    @Test
+    public void testGetRandom()
+    {
+        // given
+        String seed = "fdfrty";
+        Randomizer randomizer = new Randomizer( seed );
+
+        // when
+        Random random = randomizer.getRandom();
+        assertNotNull( random );
+        int first = random.nextInt();
+        randomizer = new Randomizer( seed );
+        random = randomizer.getRandom();
+        assertNotNull( random );
+        int second = random.nextInt();
+
+        // then
+        assertEquals( first, second );
+    }
+
+    @Test
+    public void testGetRandomRandomly()
+    {
+        // given
+        Randomizer randomizer = new Randomizer();
+
+        // when
+        Random random = randomizer.getRandom();
+        assertNotNull( random );
+        int first = random.nextInt();
+        randomizer = new Randomizer();
+        Random secrandom = randomizer.getRandom();
+        assertNotNull( secrandom );
+        int second = random.nextInt();
+
+        // then
+        assertNotSame( first, second );
+    }
+
+    @Test
+    public void testCopyConstructor()
+    {
+        // given
+        Randomizer first = new Randomizer();
+        String asString = String.valueOf( first.getSeed() );
+        Randomizer second = new Randomizer( asString );
+
+        // when
+        int firstInt = first.getRandom().nextInt();
+        int secondInt = second.getRandom().nextInt();
+
+        // then
+        assertEquals( firstInt, secondInt );
+    }
+}

--- a/surefire-api/src/test/java/org/apache/maven/surefire/util/RunOrderCalculatorTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/util/RunOrderCalculatorTest.java
@@ -18,22 +18,23 @@ package org.apache.maven.surefire.util;
  * under the License.
  */
 
-import java.util.LinkedHashSet;
-import java.util.Set;
-
+import junit.framework.TestCase;
 import org.apache.maven.surefire.testset.RunOrderParameters;
 
-import junit.framework.TestCase;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author Kristian Rosenvold
  */
 public class RunOrderCalculatorTest
-    extends TestCase
+        extends TestCase
 {
 
     public void testOrderTestClasses()
-        throws Exception
     {
         getClassesToRun();
         TestsToRun testsToRun = new TestsToRun( getClassesToRun() );
@@ -41,6 +42,89 @@ public class RunOrderCalculatorTest
         final TestsToRun testsToRun1 = runOrderCalculator.orderTestClasses( testsToRun );
         assertEquals( A.class, testsToRun1.iterator().next() );
 
+    }
+
+    public void testOrderTestClassesWithRandom()
+    {
+        getClassesToRun();
+        TestsToRun testsToRun = new TestsToRun( getClassesToRun() );
+        RunOrderCalculator runOrderCalculator = new DefaultRunOrderCalculator(
+                randomizedWith( "424242" ), 1
+        );
+        final TestsToRun testsToRun1 = runOrderCalculator.orderTestClasses( testsToRun );
+        Iterator<Class<?>> iter = testsToRun1.iterator();
+        assertEquals( B.class, iter.next() );
+        assertEquals( A.class, iter.next() );
+
+        TestsToRun testsToRun2 = runOrderCalculator.orderTestClasses( testsToRun );
+        iter = testsToRun2.iterator();
+        assertEquals( B.class, iter.next() );
+        assertEquals( A.class, iter.next() );
+    }
+
+    public void testOrderTestClassesWithRandomized()
+    {
+        getClassesToRun();
+        TestsToRun testsToRun = new TestsToRun( getClassesToRun() );
+        RunOrderCalculator runOrderCalculator = new DefaultRunOrderCalculator( randomized(), 1 );
+        final TestsToRun testsToRun1 = runOrderCalculator.orderTestClasses( testsToRun );
+        String names1 = join( asNamesList( testsToRun1 ) );
+
+        TestsToRun testsToRun2 = runOrderCalculator.orderTestClasses( testsToRun );
+        String names2 = join( asNamesList( testsToRun2 ) );
+
+        int times = 100000;
+        while ( names1.equals( names2 ) && times > 0 )
+        {
+            testsToRun2 = runOrderCalculator.orderTestClasses( testsToRun );
+            names2 = join( asNamesList( testsToRun2 ) );
+            times--;
+        }
+        assertEquals( 0, times );
+    }
+
+    private static String join( List<String> names )
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        Iterator<String> iter = names.iterator();
+        if ( iter.hasNext() )
+        {
+            stringBuilder.append( iter.next() );
+        }
+        while ( iter.hasNext() )
+        {
+            stringBuilder.append( "-" ).append( iter.next() );
+        }
+        return stringBuilder.toString();
+    }
+
+    private static List<String> asNamesList( TestsToRun testsToRun )
+    {
+        List<String> names1 = new ArrayList<String>();
+        for ( Class<?> cls : testsToRun )
+        {
+            names1.add( cls.getSimpleName() );
+        }
+        return names1;
+    }
+
+    private RunOrderParameters randomizedWith( String seed )
+    {
+        Randomizer randomizer = new Randomizer( seed );
+        return new RunOrderParameters(
+                new RunOrders( RunOrder.RANDOM ),
+                randomizer,
+                null
+        );
+    }
+
+    private RunOrderParameters randomized()
+    {
+        return new RunOrderParameters(
+                new RunOrders( RunOrder.RANDOM ),
+                new Randomizer(),
+                null
+        );
     }
 
     private Set<Class<?>> getClassesToRun()

--- a/surefire-api/src/test/java/org/apache/maven/surefire/util/RunOrderMapperTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/util/RunOrderMapperTest.java
@@ -1,0 +1,148 @@
+package org.apache.maven.surefire.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+/**
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2018-05-27
+ */
+public class RunOrderMapperTest
+{
+
+    private final RunOrderMapper mapper = new RunOrderMapper();
+
+    @Test
+    public void testShouldReturnRunOrderForLowerCaseName()
+    {
+        assertEquals( RunOrder.HOURLY, mapper.fromString( "hourly" ).firstAsType() );
+    }
+
+    @Test
+    public void testMultiValue()
+    {
+        RunOrders hourlies = mapper.fromString( "failedfirst,balanced" );
+        Iterator<RunOrderWithArguments> iterator = hourlies.getIterable().iterator();
+        RunOrderWithArguments first = iterator.next();
+        RunOrderWithArguments second = iterator.next();
+        assertFalse( iterator.hasNext() );
+        assertEquals( RunOrder.FAILEDFIRST, first.getRunOrder() );
+        assertEquals( RunOrder.BALANCED, second.getRunOrder() );
+    }
+
+    @Test
+    public void testRandom()
+    {
+        RunOrders orders = mapper.fromString( "random" );
+        int elems = 0;
+        for ( RunOrderWithArguments ignored : orders.getIterable() )
+        {
+            elems++;
+        }
+        assertEquals( 1, elems );
+        assertEquals( RunOrder.RANDOM, orders.firstAsType() );
+    }
+
+    @Test
+    public void testAsString()
+    {
+        RunOrders orders = new RunOrders( RunOrder.FAILEDFIRST, RunOrder.ALPHABETICAL );
+        assertEquals( "failedfirst,alphabetical", mapper.asString( orders ) );
+    }
+
+    @Test
+    public void testShouldReturnRunOrderForUpperCaseName()
+    {
+        assertEquals( RunOrder.HOURLY, mapper.fromString( "HOURLY" ).firstAsType() );
+    }
+
+    @Test
+    public void testShouldReturnNullForNullName()
+    {
+        assertFalse( mapper.fromString( null ).any() );
+    }
+
+    @Test
+    public void testShouldThrowExceptionForInvalidName()
+    {
+        try
+        {
+            mapper.fromString( "arbitraryName" );
+            fail( "IllegalArgumentException not thrown." );
+        }
+        catch ( IllegalArgumentException expected )
+        {
+
+        }
+    }
+
+    @Test
+    public void testFromStringWithArguments()
+    {
+        // given
+        String repr = "random:123322,failedfirst";
+
+        // when
+        RunOrders orders = mapper.fromString( repr );
+        List<RunOrderWithArguments> asList = new ArrayList<RunOrderWithArguments>();
+        for ( RunOrderWithArguments order : orders.getIterable() )
+        {
+            asList.add( order );
+        }
+        RunOrderArguments args = orders.getArguments( RunOrder.RANDOM );
+        Iterator<String> positional = args.getPositional().iterator();
+
+        // then
+        assertEquals( 2, asList.size() );
+        assertEquals( RunOrder.RANDOM, orders.firstAsType() );
+        assertEquals( "123322", positional.next() );
+        assertFalse( positional.hasNext() );
+        assertEquals( RunOrder.FAILEDFIRST, asList.get( 1 ).getRunOrder() );
+    }
+
+    @Test
+    public void testReadWithoutArgumentsFromString()
+    {
+        // given
+        String repr = "random:123322,failedfirst";
+
+        // when
+        Iterable<RunOrder> orders = mapper.readWithoutArgumentsFromString( repr );
+        List<RunOrder> runOrders = new ArrayList<RunOrder>();
+        for ( RunOrder order : orders )
+        {
+            runOrders.add( order );
+        }
+
+        // then
+        assertEquals( 2, runOrders.size() );
+        assertEquals( RunOrder.RANDOM, runOrders.get( 0 ) );
+        assertEquals( RunOrder.FAILEDFIRST, runOrders.get( 1 ) );
+    }
+}

--- a/surefire-api/src/test/java/org/apache/maven/surefire/util/internal/RandomizerSerializerTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/util/internal/RandomizerSerializerTest.java
@@ -1,4 +1,4 @@
-package org.apache.maven.surefire.util;
+package org.apache.maven.surefire.util.internal;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,38 +19,43 @@ package org.apache.maven.surefire.util;
  * under the License.
  */
 
+import org.apache.maven.surefire.util.Randomizer;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-public class RunOrderTest
+/**
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2016-04-11
+ */
+public class RandomizerSerializerTest
 {
 
     @Test
-    public void testShouldReturnRunOrderForLowerCaseName()
+    public void testDeserialize()
     {
-        assertEquals( RunOrder.HOURLY, RunOrder.valueOf( "hourly" ) );
+        // given
+        String serialized = "\u001E\u0003123456";
+
+        // when
+        Randomizer randomizer = RandomizerSerializer.deserialize( serialized );
+
+        // then
+        assertTrue( StringUtils.isBlank( randomizer.getGivenSeed() ) );
+        assertEquals( 123456L, randomizer.getSeed() );
     }
 
     @Test
-    public void testShouldThrowExceptionForInvalidName()
+    public void testSerialize()
     {
-        try
-        {
-            RunOrder.valueOf( "arbitraryName" );
-            fail( "IllegalArgumentException not thrown." );
-        }
-        catch ( IllegalArgumentException expected )
-        {
-            assertTrue( expected.getMessage().contains( "Please use one of the following RunOrders" ) );
-        }
-    }
+        // given
+        Randomizer randomizer = new Randomizer( "123456" );
 
-    @Test
-    public void testShouldReturnStringRepr()
-    {
-        assertEquals( "hourly", RunOrder.HOURLY.toString() );
+        // when
+        String result = RandomizerSerializer.serialize( randomizer );
+
+        // then
+        assertEquals( "123456\u001E\u0003123456", result );
     }
 }

--- a/surefire-api/src/test/java/org/apache/maven/surefire/util/internal/UniqIdGeneratorTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/util/internal/UniqIdGeneratorTest.java
@@ -1,4 +1,4 @@
-package testng.suiteXml;
+package org.apache.maven.surefire.util.internal;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,33 +19,32 @@ package testng.suiteXml;
  * under the License.
  */
 
-import org.testng.annotations.Test;
+import org.junit.Test;
 
-import java.nio.charset.Charset;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import static org.junit.Assert.assertTrue;
 
 /**
- * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
- * @since 2.19
+ * @author <a href="mailto:krzysztof.suszynski@wavesoftware.pl">Krzysztof Suszynski</a>
+ * @since 2016-04-02
  */
-public class TestNGSuiteTest {
-	private static final AtomicInteger COUNTER = new AtomicInteger();
+public class UniqIdGeneratorTest
+{
 
-	@Test
-	public void shouldRunAndPrintItself()
-		throws Exception
-	{
-        String message = String.format(
-                "%s#shouldRunAndPrintItself() %d.",
-                getClass().getSimpleName(),
-                COUNTER.incrementAndGet()
-        );
-
-        synchronized ( System.out )
+    @Test
+    public void testGenerateUniqId()
+    {
+        // given
+        int lower = 5;
+        int upper = 10;
+        UniqIdGenerator uniqIdGenerator = new UniqIdGenerator( lower, upper );
+        int times = ( upper - lower ) * 10;
+        for ( int i = 0; i < times; i++ )
         {
-            System.out.println( message );
-            TimeUnit.SECONDS.sleep( 2 );
+            // when
+            long id = uniqIdGenerator.generateUniqId();
+            // then
+            assertTrue( id >= lower );
+            assertTrue( id < upper );
         }
     }
 }

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
@@ -46,6 +46,7 @@ public final class BooterConstants
     public static final String SOURCE_DIRECTORY = "testSuiteDefinitionTestSourceDirectory";
     public static final String TEST_CLASSES_DIRECTORY = "testClassesDirectory";
     public static final String RUN_ORDER = "runOrder";
+    public static final String RANDOM_SEED = "randomSeed";
     public static final String RUN_STATISTICS_FILE = "runStatisticsFile";
     public static final String TEST_SUITE_XML_FILES = "testSuiteXmlFiles";
     public static final String PROVIDER_CONFIGURATION = "providerConfiguration";

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
@@ -19,21 +19,27 @@ package org.apache.maven.surefire.booter;
  * under the License.
  */
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.List;
 import org.apache.maven.surefire.report.ReporterConfiguration;
 import org.apache.maven.surefire.testset.DirectoryScannerParameters;
 import org.apache.maven.surefire.testset.RunOrderParameters;
 import org.apache.maven.surefire.testset.TestArtifactInfo;
 import org.apache.maven.surefire.testset.TestListResolver;
 import org.apache.maven.surefire.testset.TestRequest;
+import org.apache.maven.surefire.util.Randomizer;
+import org.apache.maven.surefire.util.RunOrderMapper;
+import org.apache.maven.surefire.util.RunOrders;
+import org.apache.maven.surefire.util.internal.RandomizerSerializer;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
 
 // CHECKSTYLE_OFF: imports
 import static org.apache.maven.surefire.booter.BooterConstants.*;
-import static org.apache.maven.surefire.cli.CommandLineOption.*;
+import static org.apache.maven.surefire.cli.CommandLineOption.fromStrings;
 
 /**
  * Knows how to serialize and deserialize the booter configuration.
@@ -51,6 +57,8 @@ import static org.apache.maven.surefire.cli.CommandLineOption.*;
 public class BooterDeserializer
 {
     private final PropertiesWrapper properties;
+
+    private final RunOrderMapper runOrderMapper = new RunOrderMapper();
 
     public BooterDeserializer( InputStream inputStream )
         throws IOException
@@ -86,16 +94,27 @@ public class BooterDeserializer
         final List<String> testSuiteXmlFiles = properties.getStringList( TEST_SUITE_XML_FILES );
         final File testClassesDirectory = properties.getFileProperty( TEST_CLASSES_DIRECTORY );
         final String runOrder = properties.getProperty( RUN_ORDER );
-        final String runStatisticsFile = properties.getProperty( RUN_STATISTICS_FILE );
+        final String randomSeed = properties.getProperty( RANDOM_SEED );
+        final RunOrders runOrders = runOrderMapper.fromString( runOrder );
+        final String runStatisticsFileName = properties.getProperty( RUN_STATISTICS_FILE );
 
         final int rerunFailingTestsCount = properties.getIntProperty( RERUN_FAILING_TESTS_COUNT );
 
         DirectoryScannerParameters dirScannerParams =
-            new DirectoryScannerParameters( testClassesDirectory, includes, excludes, specificTests,
-                                            properties.getBooleanProperty( FAILIFNOTESTS ), runOrder );
+            new DirectoryScannerParameters(
+                    testClassesDirectory,
+                    includes,
+                    excludes,
+                    specificTests,
+                    properties.getBooleanProperty( FAILIFNOTESTS ),
+                    runOrders
+            );
 
-        RunOrderParameters runOrderParameters
-                = new RunOrderParameters( runOrder, runStatisticsFile == null ? null : new File( runStatisticsFile ) );
+
+        Randomizer randomizer = getRandomizer( randomSeed );
+        RunOrderParameters runOrderParameters = new RunOrderParameters(
+                runOrders, randomizer, asFile( runStatisticsFileName )
+        );
 
         TestArtifactInfo testNg = new TestArtifactInfo( testNgVersion, testArtifactClassifier );
         TestRequest testSuiteDefinition =
@@ -120,6 +139,20 @@ public class BooterDeserializer
                                           testSuiteDefinition, properties.getProperties(), typeEncodedTestForFork,
                                           preferTestsFromInStream, fromStrings( cli ), failFastCount, shutdown,
                                           systemExitTimeout );
+    }
+
+    @Nullable
+    private File asFile( @Nullable String fileName )
+    {
+        return fileName != null
+                ? new File( fileName )
+                : null;
+    }
+
+    private Randomizer getRandomizer( String randomSeed )
+    {
+
+        return RandomizerSerializer.deserialize( randomSeed );
     }
 
     public StartupConfiguration getProviderConfiguration()

--- a/surefire-grouper/src/test/java/org/apache/maven/surefire/group/parse/GroupMatcherParserTest.java
+++ b/surefire-grouper/src/test/java/org/apache/maven/surefire/group/parse/GroupMatcherParserTest.java
@@ -18,13 +18,12 @@ package org.apache.maven.surefire.group.parse;
  * under the License.
  */
 
+import junit.framework.TestCase;
 import org.apache.maven.surefire.group.match.AndGroupMatcher;
 import org.apache.maven.surefire.group.match.GroupMatcher;
 import org.apache.maven.surefire.group.match.InverseGroupMatcher;
 import org.apache.maven.surefire.group.match.OrGroupMatcher;
 import org.apache.maven.surefire.group.match.SingleGroupMatcher;
-
-import junit.framework.TestCase;
 
 public class GroupMatcherParserTest
     extends TestCase

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
@@ -19,13 +19,17 @@ package org.apache.maven.surefire.its;
  * under the License.
  */
 
-import java.io.IOException;
-import java.util.Calendar;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.apache.maven.surefire.its.fixture.SurefireLauncher;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Calendar;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Verifies the runOrder setting and its effect
@@ -38,6 +42,10 @@ public class RunOrderIT
     private static final String[] TESTS_IN_ALPHABETICAL_ORDER = { "TA", "TB", "TC" };
 
     private static final String[] TESTS_IN_REVERSE_ALPHABETICAL_ORDER = { "TC", "TB", "TA" };
+
+    private static final String[] TESTS_IN_RANDOM_ORDER_WITH_SEED_123456 = { "TC", "TB", "TA" };
+
+    private static final String[] TESTS_IN_RANDOM_ORDER_WITH_SEED_654321 = { "TA", "TB", "TC" };
 
     // testing random is left as an exercise to the reader. Patches welcome
 
@@ -75,21 +83,78 @@ public class RunOrderIT
     }
 
     @Test
-    public void testNonExistingRunOrder()
-        throws Exception
+    public void testRandomWithSeed123456() throws VerificationException
     {
-        unpack().forkMode( getForkMode() ).runOrder( "nonExistingRunOrder" ).maven().withFailure().executeTest().verifyTextInLog(
-            "There's no RunOrder with the name nonExistingRunOrder." );
+        OutputValidator validator = executeWithRunOrder( "random:123456" );
+        assertTestnamesAppearInSpecificOrder( validator, TESTS_IN_RANDOM_ORDER_WITH_SEED_123456 );
+        validator.assertThatLogLine(
+                containsString( "Tests are randomly ordered. Re-run the same "
+                        + "execution order with -Dsurefire.runOrder=random:123456" ),
+                equalTo( 2 )
+        );
+    }
+
+    @Test
+    public void testRandomWithSeed654321() throws VerificationException
+    {
+        OutputValidator validator = executeWithRunOrder( "random:654321" );
+        assertTestnamesAppearInSpecificOrder( validator, TESTS_IN_RANDOM_ORDER_WITH_SEED_654321 );
+        validator.assertThatLogLine(
+                containsString( "Tests are randomly ordered. Re-run the same "
+                        + "execution order with -Dsurefire.runOrder=random:654321" ),
+                equalTo( 2 )
+        );
+    }
+
+    @Test
+    public void testRandomWithSetInPomAndSeed123456() throws VerificationException
+    {
+        OutputValidator validator = forkingMode( unpack( "runOrder-random" ) )
+                .executeTest()
+                .verifyErrorFree( 3 );
+
+        validator.assertThatLogLine(
+                containsString( "Tests are randomly ordered. Re-run the same "
+                        + "execution order with -Dsurefire.runOrder=random:" ),
+                equalTo( 2 )
+        );
+
+        validator = forkingMode( unpack( "runOrder-random" ) )
+                .runOrder( "random:123456" )
+                .executeTest()
+                .verifyErrorFree( 3 );
+        assertTestnamesAppearInSpecificOrder( validator, TESTS_IN_RANDOM_ORDER_WITH_SEED_123456 );
+        validator.assertThatLogLine(
+                containsString( "Tests are randomly ordered. Re-run the same "
+                        + "execution order with -Dsurefire.runOrder=random:123456" ),
+                equalTo( 2 )
+        );
+    }
+
+    @Test
+    public void testNonExistingRunOrder()
+    {
+        forkingMode( unpack() )
+                .runOrder( "nonExistingRunOrder" )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog(
+                    "There's no RunOrder with the name nonExistingRunOrder."
+                );
     }
 
     private OutputValidator executeWithRunOrder( String runOrder )
     {
-        return unpack().forkMode( getForkMode() ).runOrder( runOrder ).executeTest().verifyErrorFree( 3 );
+        return forkingMode( unpack() )
+                .runOrder( runOrder )
+                .executeTest()
+                .verifyErrorFree( 3 );
     }
 
-    protected String getForkMode()
+    protected SurefireLauncher forkingMode(SurefireLauncher launcher )
     {
-        return "once";
+        return launcher.forkMode( "once" );
     }
 
     private SurefireLauncher unpack()
@@ -102,7 +167,10 @@ public class RunOrderIT
     {
         if ( !validator.stringsAppearInSpecificOrderInLog( testnames ) )
         {
-            throw new VerificationException( "Response does not contain expected item" );
+            throw new VerificationException(
+                    "Does not contain tests in sequence: "
+                            + Arrays.toString( testnames )
+            );
         }
     }
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderParallelForksIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderParallelForksIT.java
@@ -19,13 +19,17 @@ package org.apache.maven.surefire.its;
  * under the License.
  */
 
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+
 public class RunOrderParallelForksIT
     extends RunOrderIT
 {
 
     @Override
-    protected String getForkMode()
+    protected SurefireLauncher forkingMode( SurefireLauncher launcher )
     {
-        return "perthread";
+        return launcher
+                .forkMode( "perthread" )
+                .threadCount( 1 );
     }
 }

--- a/surefire-its/src/test/resources/runOrder-random/pom.xml
+++ b/surefire-its/src/test/resources/runOrder-random/pom.xml
@@ -24,14 +24,15 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.plugins.surefire</groupId>
-  <artifactId>runOrder</artifactId>
+  <artifactId>runOrder-random</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <name>Test for runOrder</name>
+  <name>Test for runOrder in random</name>
 
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
     <forkMode>once</forkMode>
+    <surefire.runOrder>random</surefire.runOrder>
   </properties>
 
   <dependencies>
@@ -56,9 +57,8 @@
           given through parameter.
            -->
           <forkMode>${forkMode}</forkMode>
+          <runOrder>${surefire.runOrder}</runOrder>
         </configuration>
-        <dependencies>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/surefire-its/src/test/resources/runOrder-random/src/test/java/junit/runOrder/TestA.java
+++ b/surefire-its/src/test/resources/runOrder-random/src/test/java/junit/runOrder/TestA.java
@@ -1,4 +1,4 @@
-package testng.suiteXml;
+package junit.runOrder;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,33 +19,13 @@ package testng.suiteXml;
  * under the License.
  */
 
-import org.testng.annotations.Test;
+import junit.framework.TestCase;
 
-import java.nio.charset.Charset;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-/**
- * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
- * @since 2.19
- */
-public class TestNGSuiteTest {
-	private static final AtomicInteger COUNTER = new AtomicInteger();
-
-	@Test
-	public void shouldRunAndPrintItself()
-		throws Exception
-	{
-        String message = String.format(
-                "%s#shouldRunAndPrintItself() %d.",
-                getClass().getSimpleName(),
-                COUNTER.incrementAndGet()
-        );
-
-        synchronized ( System.out )
-        {
-            System.out.println( message );
-            TimeUnit.SECONDS.sleep( 2 );
-        }
+public class TestA
+    extends TestCase
+{
+    public void testA()
+    {
+        System.out.println( "TA" );
     }
 }

--- a/surefire-its/src/test/resources/runOrder-random/src/test/java/junit/runOrder/TestB.java
+++ b/surefire-its/src/test/resources/runOrder-random/src/test/java/junit/runOrder/TestB.java
@@ -1,4 +1,4 @@
-package testng.suiteXml;
+package junit.runOrder;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,33 +19,13 @@ package testng.suiteXml;
  * under the License.
  */
 
-import org.testng.annotations.Test;
+import junit.framework.TestCase;
 
-import java.nio.charset.Charset;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-/**
- * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
- * @since 2.19
- */
-public class TestNGSuiteTest {
-	private static final AtomicInteger COUNTER = new AtomicInteger();
-
-	@Test
-	public void shouldRunAndPrintItself()
-		throws Exception
-	{
-        String message = String.format(
-                "%s#shouldRunAndPrintItself() %d.",
-                getClass().getSimpleName(),
-                COUNTER.incrementAndGet()
-        );
-
-        synchronized ( System.out )
-        {
-            System.out.println( message );
-            TimeUnit.SECONDS.sleep( 2 );
-        }
+public class TestB
+    extends TestCase
+{
+    public void testB()
+    {
+        System.out.println( "TB" );
     }
 }

--- a/surefire-its/src/test/resources/runOrder-random/src/test/java/junit/runOrder/TestC.java
+++ b/surefire-its/src/test/resources/runOrder-random/src/test/java/junit/runOrder/TestC.java
@@ -1,4 +1,4 @@
-package testng.suiteXml;
+package junit.runOrder;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,33 +19,13 @@ package testng.suiteXml;
  * under the License.
  */
 
-import org.testng.annotations.Test;
+import junit.framework.TestCase;
 
-import java.nio.charset.Charset;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-/**
- * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
- * @since 2.19
- */
-public class TestNGSuiteTest {
-	private static final AtomicInteger COUNTER = new AtomicInteger();
-
-	@Test
-	public void shouldRunAndPrintItself()
-		throws Exception
-	{
-        String message = String.format(
-                "%s#shouldRunAndPrintItself() %d.",
-                getClass().getSimpleName(),
-                COUNTER.incrementAndGet()
-        );
-
-        synchronized ( System.out )
-        {
-            System.out.println( message );
-            TimeUnit.SECONDS.sleep( 2 );
-        }
+public class TestC
+    extends TestCase
+{
+    public void testC()
+    {
+        System.out.println( "TC" );
     }
 }

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
@@ -29,7 +29,10 @@ import org.apache.maven.surefire.report.ConsoleOutputReceiver;
 import org.apache.maven.surefire.report.DefaultDirectConsoleReporter;
 import org.apache.maven.surefire.report.ReporterFactory;
 import org.apache.maven.surefire.report.RunListener;
+import org.apache.maven.surefire.testset.RunOrderParameters;
 import org.apache.maven.surefire.testset.TestSetFailedException;
+import org.apache.maven.surefire.util.RunOrder;
+import org.apache.maven.surefire.util.RunOrders;
 import org.junit.runner.Computer;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
@@ -107,8 +110,18 @@ public class JUnitCoreTester
     {
         File target = new File( "./target" );
         File statisticsFile = new File( target, "TESTHASHxXML" );
-        return new StartupReportConfiguration( true, true, "PLAIN", false, target, false, null, statisticsFile,
-                false, 0, null, null, false, new SurefireStatelessReporter(), new SurefireConsoleOutputReporter(),
-                new SurefireStatelessTestsetInfoReporter() );
+        RunOrders runOrders = new RunOrders( RunOrder.DEFAULT );
+        RunOrderParameters runOrderParameters = new RunOrderParameters(
+                runOrders, null, null
+        );
+        return new StartupReportConfiguration(
+                true, true, "PLAIN", false,
+                target, false, null, statisticsFile,
+                false, 0, null,
+                null, false, new SurefireStatelessReporter(),
+                new SurefireConsoleOutputReporter(),
+                new SurefireStatelessTestsetInfoReporter(),
+                StartupReportConfiguration.DEFAULT_PLUGIN_NAME , runOrderParameters
+        );
     }
 }


### PR DESCRIPTION
It's good practice to execute tests in random order. That ensures tests are atomic and not depend on each other or some stateful entity. But, if such error occurs, right now, there is no way to reproduce this exact, erroneous execution.

This PR adds the ability to reproduce those errors by adding support for externally passed random seed. If random seed is not passed, it will be generated automatically. Also, random seed will be printed on console. That's enable it to be achieved by CI server for later.

This operation is strongly influenced by Ruby's rspec order command line option: https://www.relishapp.com/rspec/rspec-core/v/2-13/docs/command-line/order-new-in-rspec-core-2-8

Showcase of execution:

[![asciicast](https://asciinema.org/a/42342.png)](https://asciinema.org/a/42342)
