### PR TITLE
SUREFIRE-1250: add exceptions to describe usage rules of %regex

### DIFF
--- a/surefire-api/src/main/java/org/apache/maven/surefire/testset/ResolvedTest.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/testset/ResolvedTest.java
@@ -81,11 +81,13 @@ public final class ResolvedTest
         if ( isRegex && classPattern != null )
         {
             classPattern = wrapRegex( classPattern );
+            regexSanityCheck( classPattern );
         }
 
         if ( isRegex && methodPattern != null )
         {
             methodPattern = wrapRegex( methodPattern );
+            regexSanityCheck( methodPattern );
         }
 
         this.classPattern = reformatClassPattern( classPattern, isRegex );
@@ -105,6 +107,7 @@ public final class ResolvedTest
         if ( isRegex && pattern != null )
         {
             pattern = wrapRegex( pattern );
+            regexSanityCheck( pattern );
         }
         classPattern = isClass ? reformatClassPattern( pattern, isRegex ) : null;
         methodPattern = !isClass ? pattern : null;
@@ -391,4 +394,24 @@ public final class ResolvedTest
             return cls;
         }
     }
+    
+    private static void regexSanityCheck( String methodNameExpr )
+    {
+        try
+        {
+            // this will emit regex exceptions
+            from( methodNameExpr );
+            if ( methodNameExpr.indexOf( "#" ) != -1 )
+            {
+                throw new IllegalArgumentException( "Extra # in regex: " + methodNameExpr );
+            }
+        }
+        catch ( IllegalArgumentException pse )
+        {
+            throw new IllegalArgumentException( "%regex[] usage rule violation, valid regex rules:\n"
+                + " * <classNameRegex>#<methodNameRegex> - where both regex can be individually evaluated as a regex\n"
+                + " * you may use at most 1 '#' to in one regex filter.", pse );
+        }
+    }
+    
 }

--- a/surefire-api/src/test/java/org/apache/maven/surefire/testset/TestListResolverTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/testset/TestListResolverTest.java
@@ -411,4 +411,81 @@ public class TestListResolverTest
         }
         return resolved;
     }
+    
+    public void testRegexRuleViolationQuotedHashMark()
+    {
+        try
+        {
+            new TestListResolver( "%regex[.\\Q#\\E.]" );
+            fail( "IllegalArgumentException is expected" );
+        }
+        catch ( IllegalArgumentException iea )
+        {
+            // expected
+        }
+    }
+
+    public void testRegexRuleViolationEnclosedMethodSeparator()
+    {
+        try
+        {
+            new TestListResolver( "%regex[(.|.#.)]" );
+            fail( "IllegalArgumentException is expected" );
+        }
+        catch ( IllegalArgumentException iea )
+        {
+            // expected
+        }
+    }
+
+    public void testRegexRuleViolationMultipleHashmarkWithClassConstraint()
+    {
+        try
+        {
+            new TestListResolver( "%regex[.*#.|#.]" );
+            fail( "IllegalArgumentException is expected" );
+        }
+        catch ( IllegalArgumentException iea )
+        {
+            // expected
+        }
+    }
+
+    public void testRegexRuleViolationMultipleHashmarkForMethods()
+    {
+        try
+        {
+            new TestListResolver( "%regex[#.|#.]" );
+            fail( "IllegalArgumentException is expected" );
+        }
+        catch ( IllegalArgumentException iea )
+        {
+            // expected
+        }
+    }
+    public void testRegexRuleViolationInvalidClassPattern()
+    {
+        try
+        {
+            new TestListResolver( "%regex[.(.]" );
+            fail( "IllegalArgumentException is expected" );
+        }
+        catch ( IllegalArgumentException iea )
+        {
+            // expected
+        }
+    }
+    public void testRegexRuleViolationInvalidMethodPattern()
+    {
+        try
+        {
+            new TestListResolver( "%regex[#.(.]" );
+            fail( "IllegalArgumentException is expected" );
+        }
+        catch ( IllegalArgumentException iea )
+        {
+            // expected
+        }
+    }
+
 }


### PR DESCRIPTION
@Tibor17 i've cleaned it up a bit; and added exception for multiple hashmarks too. tests have passed on my machine.