### PR TITLE
Parallel runner should not drop away runners that have zero children.

### DIFF
--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilder.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilder.java
@@ -428,10 +428,7 @@ public final class ParallelComputerBuilder
                 {
                     int children = countChildren( runner );
                     childrenCounter += children;
-                    if ( children != 0 )
-                    {
-                        runs.add( runner );
-                    }
+                    runs.add( runner );
                 }
             }
             return runs.isEmpty() ? new WrappedRunners() : new WrappedRunners( createSuite( runs ), childrenCounter );


### PR DESCRIPTION
JUnit does not force runners to include all child tests in Description. Therefore Parallel Runner should not throw such tests away.
For example Spock does not report parametrized tests.
