### PR TITLE
Specify surefire temp directory for run in multiple processes

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -330,6 +330,14 @@ public abstract class AbstractSurefireMojo
     private String forkMode;
 
     /**
+     * Directory for temporary test files. Be removed after tests execute. Value is relative path from reportsDirectory parent
+     *
+     * @since 2.19
+     */
+    @Parameter( property = "tempDir", defaultValue = "surefire" )
+    private String tempDir;
+
+    /**
      * Option to specify the jvm (or path to the java executable) to use with the forking options. For the default, the
      * jvm will be a new instance of the same VM as the one used to run Maven. JVM settings are not inherited from
      * MAVEN_OPTS.
@@ -2032,7 +2040,7 @@ public abstract class AbstractSurefireMojo
      */
     private File getSurefireTempDir()
     {
-        return new File( getProjectBuildDirectory(), "surefire" );
+        return new File( getReportsDirectory().getParentFile(), getTempDir() );
     }
 
     /**
@@ -3300,5 +3308,13 @@ public abstract class AbstractSurefireMojo
     protected void logDebugOrCliShowErrors( String s )
     {
         SurefireHelper.logDebugOrCliShowErrors( s, getConsoleLogger(), cli );
+    }
+
+    public String getTempDir() {
+        return tempDir;
+    }
+
+    public void setTempDir(String tempDir) {
+        this.tempDir = tempDir;
     }
 }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -330,9 +330,9 @@ public abstract class AbstractSurefireMojo
     private String forkMode;
 
     /**
-     * Directory for temporary test files. Be removed after tests execute. Value is relative path from reportsDirectory parent
+     * Relative path to <i>project.build.directory</i> containing internal Surefire temporary files. It is removed after the test set has completed.
      *
-     * @since 2.19
+     * @since 2.19.2
      */
     @Parameter( property = "tempDir", defaultValue = "surefire" )
     private String tempDir;


### PR DESCRIPTION
Tests runed in multiple process use one temporary directory. Each process removed temporary directory after execute. For example configuration https://jenkins.io/blog/2016/06/16/parallel-test-executor-plugin/

For solution this problem I add temDir parameter for specify temporary directory name in runner process. For example I execute in parallel process commands:
`mvn surefire:test -Dsurefire.includesFile=target/parallel-test-includes-0.txt`
`mvn surefire:test -Dsurefire.includesFile=target/parallel-test-includes-1.txt`
`...`

After changes be:
`mvn surefire:test -Dsurefire.includesFile=target/parallel-test-includes-0.txt -DtempDir=surefire0`
`mvn surefire:test -Dsurefire.includesFile=target/parallel-test-includes-1.txt -DtempDir=surefire1`
`...`
