### PR TITLE
[SUREFIRE-1293] Simplify org.apache.maven.plugin.surefire.report.TestSetRunListener by using the null object pattern

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullConsoleOutputReceiver.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullConsoleOutputReceiver.java
@@ -1,0 +1,55 @@
+package org.apache.maven.plugin.surefire.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.report.ReportEntry;
+
+/**
+ * ConsoleReporter doing nothing rather than using null.
+ *
+ * @author <a href="mailto:britter@apache.org">Benedikt Ritter</a>
+ * @since 2.19.2
+ */
+class NullConsoleOutputReceiver
+    implements TestcycleConsoleOutputReceiver
+{
+
+    static final NullConsoleOutputReceiver INSTANCE = new NullConsoleOutputReceiver();
+
+    private NullConsoleOutputReceiver()
+    {
+    }
+
+    public void testSetStarting( ReportEntry reportEntry )
+    {
+    }
+
+    public void testSetCompleted( ReportEntry report )
+    {
+    }
+
+    public void close()
+    {
+    }
+
+    public void writeTestOutput( byte[] buf, int off, int len, boolean stdout )
+    {
+    }
+}

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullConsoleReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullConsoleReporter.java
@@ -1,0 +1,58 @@
+package org.apache.maven.plugin.surefire.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.surefire.report.ReportEntry;
+
+/**
+ * ConsoleReporter doing nothing rather than using null.
+ *
+ * @author <a href="mailto:britter@apache.org">Benedikt Ritter</a>
+ * @since 2.19.2
+ */
+class NullConsoleReporter
+    extends ConsoleReporter
+{
+
+    static final NullConsoleReporter INSTANCE = new NullConsoleReporter();
+
+    private NullConsoleReporter()
+    {
+        super( new NullConsoleLogger() );
+    }
+
+    @Override
+    public void testSetStarting( ReportEntry report )
+    {
+    }
+
+    @Override
+    public void testSetCompleted( WrappedReportEntry report, TestSetStats testSetStats, List<String> testResults )
+    {
+    }
+
+    @Override
+    public void reset()
+    {
+    }
+}

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullFileReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullFileReporter.java
@@ -1,0 +1,45 @@
+package org.apache.maven.plugin.surefire.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+/**
+ * FileReporter doing nothing rather than using null.
+ *
+ * @author <a href="mailto:britter@apache.org">Benedikt Ritter</a>
+ * @since 2.19.2
+ */
+class NullFileReporter
+    extends FileReporter
+{
+
+    static final NullFileReporter INSTANCE = new NullFileReporter();
+
+    private NullFileReporter()
+    {
+        super( null, null );
+    }
+
+    @Override
+    public void testSetCompleted( WrappedReportEntry report, TestSetStats testSetStats, List<String> testResults )
+    {
+    }
+}

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
@@ -1,0 +1,48 @@
+package org.apache.maven.plugin.surefire.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * FileReporter doing nothing rather than using null.
+ *
+ * @author <a href="mailto:britter@apache.org">Benedikt Ritter</a>
+ * @since 2.19.2
+ */
+class NullStatelessXmlReporter
+    extends StatelessXmlReporter
+{
+
+    static final NullStatelessXmlReporter INSTANCE = new NullStatelessXmlReporter();
+
+    private NullStatelessXmlReporter()
+    {
+        super( null, null, false, 0, null, null );
+    }
+
+    @Override
+    public void testSetCompleted( WrappedReportEntry testSetReportEntry, TestSetStats testSetStats )
+    {
+    }
+
+    @Override
+    public void cleanTestHistoryMap()
+    {
+    }
+}

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatisticsReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatisticsReporter.java
@@ -1,0 +1,66 @@
+package org.apache.maven.plugin.surefire.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.surefire.runorder.StatisticsReporter;
+import org.apache.maven.surefire.report.ReportEntry;
+
+/**
+ * StatisticsReporter doing nothing rather than using null.
+ *
+ * @author <a href="mailto:britter@apache.org">Benedikt Ritter</a>
+ * @since 2.19.2
+ */
+class NullStatisticsReporter
+    extends StatisticsReporter
+{
+
+    static final NullStatisticsReporter INSTANCE = new NullStatisticsReporter();
+
+    private NullStatisticsReporter()
+    {
+        super( null, null, null );
+    }
+
+    @Override
+    public synchronized void testSetCompleted()
+    {
+    }
+
+    @Override
+    public void testSucceeded( ReportEntry report )
+    {
+    }
+
+    @Override
+    public void testSkipped( ReportEntry report )
+    {
+    }
+
+    @Override
+    public void testError( ReportEntry report )
+    {
+    }
+
+    @Override
+    public void testFailed( ReportEntry report )
+    {
+    }
+}

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.maven.plugin.surefire.runorder.StatisticsReporter;
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.plugin.surefire.runorder.StatisticsReporter;
 import org.apache.maven.surefire.report.ConsoleOutputReceiver;
 import org.apache.maven.surefire.report.ReportEntry;
 import org.apache.maven.surefire.report.RunListener;
@@ -88,50 +88,32 @@ public class TestSetRunListener
 
     public void debug( String message )
     {
-        if ( consoleReporter != null )
-        {
-            consoleReporter.getConsoleLogger().debug( trimTrailingNewLine( message ) );
-        }
+        consoleReporter.getConsoleLogger().debug( trimTrailingNewLine( message ) );
     }
 
     public void info( String message )
     {
-        if ( consoleReporter != null )
-        {
-            consoleReporter.getConsoleLogger().info( trimTrailingNewLine( message ) );
-        }
+        consoleReporter.getConsoleLogger().info( trimTrailingNewLine( message ) );
     }
 
     public void warning( String message )
     {
-        if ( consoleReporter != null )
-        {
-            consoleReporter.getConsoleLogger().warning( trimTrailingNewLine( message ) );
-        }
+        consoleReporter.getConsoleLogger().warning( trimTrailingNewLine( message ) );
     }
 
     public void error( String message )
     {
-        if ( consoleReporter != null )
-        {
-            consoleReporter.getConsoleLogger().error( trimTrailingNewLine( message ) );
-        }
+        consoleReporter.getConsoleLogger().error( trimTrailingNewLine( message ) );
     }
 
     public void error( String message, Throwable t )
     {
-        if ( consoleReporter != null )
-        {
-            consoleReporter.getConsoleLogger().error( message, t );
-        }
+        consoleReporter.getConsoleLogger().error( message, t );
     }
 
     public void error( Throwable t )
     {
-        if ( consoleReporter != null )
-        {
-            consoleReporter.getConsoleLogger().error( t );
-        }
+        consoleReporter.getConsoleLogger().error( t );
     }
 
     public void writeTestOutput( byte[] buf, int off, int len, boolean stdout )
@@ -157,10 +139,7 @@ public class TestSetRunListener
     public void testSetStarting( ReportEntry report )
     {
         detailsForThis.testSetStart();
-        if ( consoleReporter != null )
-        {
-            consoleReporter.testSetStarting( report );
-        }
+        consoleReporter.testSetStarting( report );
         consoleOutputReceiver.testSetStarting( report );
     }
 
@@ -175,27 +154,12 @@ public class TestSetRunListener
         final WrappedReportEntry wrap = wrapTestSet( report );
         final List<String> testResults =
                 briefOrPlainFormat ? detailsForThis.getTestResults() : Collections.<String>emptyList();
-        if ( fileReporter != null )
-        {
-            fileReporter.testSetCompleted( wrap, detailsForThis, testResults );
-        }
-        if ( simpleXMLReporter != null )
-        {
-            simpleXMLReporter.testSetCompleted( wrap, detailsForThis );
-        }
-        if ( statisticsReporter != null )
-        {
-            statisticsReporter.testSetCompleted();
-        }
-        if ( consoleReporter != null )
-        {
-            consoleReporter.testSetCompleted( wrap, detailsForThis, testResults );
-        }
+        fileReporter.testSetCompleted( wrap, detailsForThis, testResults );
+        simpleXMLReporter.testSetCompleted( wrap, detailsForThis );
+        statisticsReporter.testSetCompleted();
+        consoleReporter.testSetCompleted( wrap, detailsForThis, testResults );
         consoleOutputReceiver.testSetCompleted( wrap );
-        if ( consoleReporter != null )
-        {
-            consoleReporter.reset();
-        }
+        consoleReporter.reset();
 
         wrap.getStdout().free();
         wrap.getStdErr().free();
@@ -218,10 +182,7 @@ public class TestSetRunListener
     {
         WrappedReportEntry wrapped = wrap( reportEntry, SUCCESS );
         detailsForThis.testSucceeded( wrapped );
-        if ( statisticsReporter != null )
-        {
-            statisticsReporter.testSucceeded( reportEntry );
-        }
+        statisticsReporter.testSucceeded( reportEntry );
         clearCapture();
     }
 
@@ -229,10 +190,7 @@ public class TestSetRunListener
     {
         WrappedReportEntry wrapped = wrap( reportEntry, ERROR );
         detailsForThis.testError( wrapped );
-        if ( statisticsReporter != null )
-        {
-            statisticsReporter.testError( reportEntry );
-        }
+        statisticsReporter.testError( reportEntry );
         clearCapture();
     }
 
@@ -240,10 +198,7 @@ public class TestSetRunListener
     {
         WrappedReportEntry wrapped = wrap( reportEntry, FAILURE );
         detailsForThis.testFailure( wrapped );
-        if ( statisticsReporter != null )
-        {
-            statisticsReporter.testFailed( reportEntry );
-        }
+        statisticsReporter.testFailed( reportEntry );
         clearCapture();
     }
 
@@ -256,10 +211,7 @@ public class TestSetRunListener
         WrappedReportEntry wrapped = wrap( reportEntry, SKIPPED );
 
         detailsForThis.testSkipped( wrapped );
-        if ( statisticsReporter != null )
-        {
-            statisticsReporter.testSkipped( reportEntry );
-        }
+        statisticsReporter.testSkipped( reportEntry );
         clearCapture();
     }
 
@@ -303,10 +255,7 @@ public class TestSetRunListener
 
     public void close()
     {
-        if ( consoleOutputReceiver != null )
-        {
-            consoleOutputReceiver.close();
-        }
+        consoleOutputReceiver.close();
     }
 
     public void  addTestMethodStats()

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/runorder/StatisticsReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/runorder/StatisticsReporter.java
@@ -28,7 +28,7 @@ import static org.apache.maven.plugin.surefire.runorder.RunEntryStatisticsMap.fr
 /**
  * @author Kristian Rosenvold
  */
-public final class StatisticsReporter
+public class StatisticsReporter
 {
     private final RunEntryStatisticsMap existing;
 
@@ -38,9 +38,14 @@ public final class StatisticsReporter
 
     public StatisticsReporter( File dataFile )
     {
+        this( dataFile, fromFile( dataFile ), new RunEntryStatisticsMap() );
+    }
+
+    protected StatisticsReporter( File dataFile, RunEntryStatisticsMap existing, RunEntryStatisticsMap newRestuls )
+    {
         this.dataFile = dataFile;
-        existing = fromFile( dataFile );
-        newResults = new RunEntryStatisticsMap();
+        this.existing = existing;
+        this.newResults = newRestuls;
     }
 
     public synchronized void testSetCompleted()


### PR DESCRIPTION
Added null object implementations for fields used by TestSetRunListener in order to simplify TestSetRunListener code.