### PR TITLE
SUREFIRE-1307: Provide a convenient way to run tests against multiple JUnit versions

### DIFF
--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4VersionsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4VersionsIT.java
@@ -83,6 +83,15 @@ public class JUnit4VersionsIT
     }
 
     @Test
+    public void test412M2()
+            throws Exception
+    {
+        assumeJavaVersion( JAVA_1_8 );
+
+        runJUnitTest( "4.12.0-M2" );
+    }
+
+    @Test
     public void test500M2()
         throws Exception
     {
@@ -99,10 +108,14 @@ public class JUnit4VersionsIT
 
     private String getProfile( String version )
     {
-        if ( version.startsWith( "4" ) )
+        if ( version.startsWith( "4.12" ) )
         {
-            return "junit4";
+            return "junit5-vintage";
         }
-        return "junit5";
+        else if ( version.startsWith( "5" ) )
+        {
+            return "junit5-jupiter";
+        }
+        return "junit4";
     }
 }

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4VersionsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4VersionsIT.java
@@ -88,11 +88,6 @@ public class JUnit4VersionsIT
     @Parameter
     public JUnitVersion version;
 
-    private SurefireLauncher unpack()
-    {
-        return unpack( "/junit4", version.toString() );
-    }
-
     @Test
     public void testJunit()
         throws Exception
@@ -104,6 +99,11 @@ public class JUnit4VersionsIT
         throws Exception
     {
         version.configure( unpack() ).executeTest().verifyErrorFree( 1 );
+    }
+
+    private SurefireLauncher unpack()
+    {
+        return unpack( "/junit4", version.toString() );
     }
 
 }

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4VersionsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4VersionsIT.java
@@ -31,6 +31,9 @@ import org.junit.runners.Parameterized.Parameter;
 
 import static org.junit.runners.Parameterized.*;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_1_8;
+import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaVersion;
+
 /**
  * Basic suite test using all known versions of JUnit 4.x
  *
@@ -79,9 +82,27 @@ public class JUnit4VersionsIT
         runJUnitTest( version );
     }
 
+    @Test
+    public void test500M2()
+        throws Exception
+    {
+        assumeJavaVersion( JAVA_1_8 );
+
+        runJUnitTest( "5.0.0-M2" );
+    }
+
     public void runJUnitTest( String version )
         throws Exception
     {
-        unpack().setJUnitVersion( version ).executeTest().verifyErrorFree( 1 );
+        unpack().setJUnitVersion( version ).activateProfile( getProfile( version ) ).executeTest().verifyErrorFree( 1 );
+    }
+
+    private String getProfile( String version )
+    {
+        if ( version.startsWith( "4" ) )
+        {
+            return "junit4";
+        }
+        return "junit5";
     }
 }

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4VersionsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit4VersionsIT.java
@@ -29,10 +29,26 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_10;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_11;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_12;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_8;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_8_1;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_8_2;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_9;
 import static org.junit.runners.Parameterized.*;
 
-import static org.apache.commons.lang3.JavaVersion.JAVA_1_8;
-import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaVersion;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_0;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_1;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_2;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_3;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_3_1;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_4;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_5;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_6;
+import static org.apache.maven.surefire.its.JUnitVersion.JUNIT_4_7;
+import static org.apache.maven.surefire.its.JUnitVersion.JUPITER_5_0_0_M2;
+import static org.apache.maven.surefire.its.JUnitVersion.VINTAGE_4_12_0_M2;
 
 /**
  * Basic suite test using all known versions of JUnit 4.x
@@ -48,31 +64,33 @@ public class JUnit4VersionsIT
     public static Collection<Object[]> junitVersions()
     {
         return Arrays.asList( new Object[][] {
-                { "4.0" },
-                { "4.1" },
-                { "4.2" },
-                { "4.3" },
-                { "4.3.1" },
-                { "4.4" },
-                { "4.5" },
-                { "4.6" },
-                { "4.7" },
-                { "4.8" },
-                { "4.8.1" },
-                { "4.8.2" },
-                { "4.9" },
-                { "4.10" },
-                { "4.11" },
-                { "4.12" }
+                { JUNIT_4_0 },
+                { JUNIT_4_1 },
+                { JUNIT_4_2 },
+                { JUNIT_4_3 },
+                { JUNIT_4_3_1 },
+                { JUNIT_4_4 },
+                { JUNIT_4_5 },
+                { JUNIT_4_6 },
+                { JUNIT_4_7 },
+                { JUNIT_4_8 },
+                { JUNIT_4_8_1 },
+                { JUNIT_4_8_2 },
+                { JUNIT_4_9 },
+                { JUNIT_4_10 },
+                { JUNIT_4_11 },
+                { JUNIT_4_12 },
+                { VINTAGE_4_12_0_M2 },
+                { JUPITER_5_0_0_M2 }
         } );
     }
 
     @Parameter
-    public String version;
+    public JUnitVersion version;
 
     private SurefireLauncher unpack()
     {
-        return unpack( "/junit4", version );
+        return unpack( "/junit4", version.toString() );
     }
 
     @Test
@@ -82,40 +100,10 @@ public class JUnit4VersionsIT
         runJUnitTest( version );
     }
 
-    @Test
-    public void test412M2()
-            throws Exception
-    {
-        assumeJavaVersion( JAVA_1_8 );
-
-        runJUnitTest( "4.12.0-M2" );
-    }
-
-    @Test
-    public void test500M2()
+    private void runJUnitTest( JUnitVersion version )
         throws Exception
     {
-        assumeJavaVersion( JAVA_1_8 );
-
-        runJUnitTest( "5.0.0-M2" );
+        version.configure( unpack() ).executeTest().verifyErrorFree( 1 );
     }
 
-    public void runJUnitTest( String version )
-        throws Exception
-    {
-        unpack().setJUnitVersion( version ).activateProfile( getProfile( version ) ).executeTest().verifyErrorFree( 1 );
-    }
-
-    private String getProfile( String version )
-    {
-        if ( version.startsWith( "4.12" ) )
-        {
-            return "junit5-vintage";
-        }
-        else if ( version.startsWith( "5" ) )
-        {
-            return "junit5-jupiter";
-        }
-        return "junit4";
-    }
 }

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnitVersion.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnitVersion.java
@@ -1,0 +1,78 @@
+package org.apache.maven.surefire.its;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+
+/**
+ * Enum listing all the JUnit version.
+ */
+public enum JUnitVersion {
+
+    JUNIT_4_0( "4.0" ),
+    JUNIT_4_1( "4.1" ),
+    JUNIT_4_2( "4.2" ),
+    JUNIT_4_3( "4.3" ),
+    JUNIT_4_3_1( "4.3.1" ),
+    JUNIT_4_4( "4.4" ),
+    JUNIT_4_5( "4.5" ),
+    JUNIT_4_6( "4.6" ),
+    JUNIT_4_7( "4.7" ),
+    JUNIT_4_8( "4.8" ),
+    JUNIT_4_8_1( "4.8.1" ),
+    JUNIT_4_8_2( "4.8.2" ),
+    JUNIT_4_9( "4.9" ),
+    JUNIT_4_10( "4.10" ),
+    JUNIT_4_11( "4.11" ),
+    JUNIT_4_12( "4.12" ),
+    VINTAGE_4_12_0_M2( "4.12.0-M2" )
+    {
+        @Override
+        public SurefireLauncher configure( SurefireLauncher launcher )
+        {
+            return super.configure( launcher ).activateProfile( "junit5-vintage" );
+        }
+    },
+    JUPITER_5_0_0_M2( "5.0.0-M2" )
+    {
+        @Override
+        public SurefireLauncher configure( SurefireLauncher launcher )
+        {
+            return super.configure( launcher ).activateProfile( "junit5-jupiter" );
+        }
+    };
+
+    private final String version;
+
+    JUnitVersion( String version )
+    {
+        this.version = version;
+    }
+
+    public SurefireLauncher configure( SurefireLauncher launcher )
+    {
+        return launcher.setJUnitVersion( version );
+    }
+
+    public String toString()
+    {
+        return version;
+    }
+}

--- a/surefire-integration-tests/src/test/resources/junit4/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit4/pom.xml
@@ -60,7 +60,7 @@
     </profile>
 
     <profile>
-      <id>junit5</id>
+      <id>junit5-jupiter</id>
 
       <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -81,6 +81,48 @@
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
           <version>${junit.vintage.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>${java.version}</source>
+              <target>${java.version}</target>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-surefire-provider</artifactId>
+                <version>${junit.platform.version}</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>junit5-vintage</id>
+
+      <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <junit.platform.version>1.0.0-M2</junit.platform.version>
+      </properties>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <version>${junit.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/surefire-integration-tests/src/test/resources/junit4/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit4/pom.xml
@@ -28,11 +28,6 @@
   <version>1.0-SNAPSHOT</version>
   <name>Test for JUnit 4</name>
 
-
-  <properties>
-    <junitVersion>4.4</junitVersion>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/surefire-integration-tests/src/test/resources/junit4/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit4/pom.xml
@@ -28,9 +28,27 @@
   <version>1.0-SNAPSHOT</version>
   <name>Test for JUnit 4</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>junit4</id>
+
+      <properties>
+        <java.version>1.5</java.version>
+      </properties>
+
       <dependencies>
         <dependency>
           <groupId>junit</groupId>
@@ -42,14 +60,6 @@
 
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <source>1.5</source>
-              <target>1.5</target>
-            </configuration>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
@@ -77,23 +87,10 @@
           <version>${junit.jupiter.version}</version>
           <scope>test</scope>
         </dependency>
-        <dependency>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-          <version>${junit.vintage.version}</version>
-          <scope>test</scope>
-        </dependency>
       </dependencies>
 
       <build>
         <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <source>${java.version}</source>
-              <target>${java.version}</target>
-            </configuration>
-          </plugin>
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${surefire.version}</version>
@@ -129,13 +126,6 @@
 
       <build>
         <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <source>${java.version}</source>
-              <target>${java.version}</target>
-            </configuration>
-          </plugin>
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${surefire.version}</version>

--- a/surefire-integration-tests/src/test/resources/junit4/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit4/pom.xml
@@ -28,31 +28,87 @@
   <version>1.0-SNAPSHOT</version>
   <name>Test for JUnit 4</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-  
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <profile>
+      <id>junit4</id>
+      <dependencies>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>1.5</source>
+              <target>1.5</target>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>junit5</id>
+
+      <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <junit.jupiter.version>5.0.0-M2</junit.jupiter.version>
+        <junit.vintage.version>4.12.0-M2</junit.vintage.version>
+        <junit.platform.version>1.0.0-M2</junit.platform.version>
+      </properties>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+          <version>${junit.jupiter.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <version>${junit.vintage.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>${java.version}</source>
+              <target>${java.version}</target>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-surefire-provider</artifactId>
+                <version>${junit.platform.version}</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 
 </project>

--- a/surefire-integration-tests/src/test/resources/junit4/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit4/pom.xml
@@ -28,14 +28,28 @@
   <version>1.0-SNAPSHOT</version>
   <name>Test for JUnit 4</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.0.0-M2</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>
@@ -44,10 +58,6 @@
   <profiles>
     <profile>
       <id>junit4</id>
-
-      <properties>
-        <java.version>1.5</java.version>
-      </properties>
 
       <dependencies>
         <dependency>
@@ -74,7 +84,6 @@
 
       <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
         <junit.jupiter.version>5.0.0-M2</junit.jupiter.version>
         <junit.vintage.version>4.12.0-M2</junit.vintage.version>
         <junit.platform.version>1.0.0-M2</junit.platform.version>
@@ -111,7 +120,6 @@
 
       <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
         <junit.platform.version>1.0.0-M2</junit.platform.version>
       </properties>
 

--- a/surefire-integration-tests/src/test/resources/junit4/pom.xml
+++ b/surefire-integration-tests/src/test/resources/junit4/pom.xml
@@ -89,15 +89,6 @@
         <junit.platform.version>1.0.0-M2</junit.platform.version>
       </properties>
 
-      <dependencies>
-        <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-engine</artifactId>
-          <version>${junit.jupiter.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-
       <build>
         <plugins>
           <plugin>
@@ -108,6 +99,11 @@
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-surefire-provider</artifactId>
                 <version>${junit.platform.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.jupiter.version}</version>
               </dependency>
             </dependencies>
           </plugin>
@@ -123,15 +119,6 @@
         <junit.platform.version>1.0.0-M2</junit.platform.version>
       </properties>
 
-      <dependencies>
-        <dependency>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-          <version>${junit.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-
       <build>
         <plugins>
           <plugin>
@@ -143,12 +130,16 @@
                 <artifactId>junit-platform-surefire-provider</artifactId>
                 <version>${junit.platform.version}</version>
               </dependency>
+              <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit.version}</version>
+              </dependency>
             </dependencies>
           </plugin>
         </plugins>
       </build>
     </profile>
   </profiles>
-
 
 </project>

--- a/surefire-integration-tests/src/test/resources/junit4/src/test/java/junit5/JUnit5Test.java
+++ b/surefire-integration-tests/src/test/resources/junit4/src/test/java/junit5/JUnit5Test.java
@@ -1,0 +1,65 @@
+package junit5;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * A test using the JUnit 5 API, which should be executed by JUnit jupiter enigne
+ */
+public class JUnit5Test
+{
+
+    private boolean setUpCalled;
+
+    private static boolean tearDownCalled;
+
+    @BeforeEach
+    public void setUp()
+    {
+        setUpCalled = true;
+        System.out.println( "Called setUp" );
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        tearDownCalled = true;
+        System.out.println( "Called tearDown" );
+    }
+
+    @Test
+    public void testSetUp()
+    {
+        Assertions.assertTrue( setUpCalled, "setUp was not called" );
+    }
+
+    @AfterAll
+    public static void oneTimeTearDown()
+    {
+        Assertions.assertTrue( tearDownCalled, "tearDown was not called" );
+    }
+
+}


### PR DESCRIPTION
First proposal to run tests against multiple JUnit versions.

I implemented an Enum representing the available JUnit versions. The Enum values know how to configure the maven launcher in order to execute tests with that JUnit version. For all 4.x versions this is simply done by setting the junit.version system property. For JUnit 5 and the JUnit 5 vintage support, a profile needs to be activated.

If this i going into the right direction, we can create a parent pom file with the profiles and adopt this to more of the existing tests.