### PR TITLE
[SUREFIRE-1295] Attribute JVM crashes to tests

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClient.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClient.java
@@ -35,7 +35,11 @@ import java.io.StringReader;
 import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 import java.util.Properties;
+import java.util.Queue;
+import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.lang.Integer.decode;

--- a/maven-surefire-plugin/src/site/apt/examples/shutdown.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/shutdown.apt.vm
@@ -85,4 +85,10 @@ Shutdown of Forked JVM
   amount of time and the whole plugin fails with the error message:
 
   <<<There was a timeout or other error in the fork>>>
-  
+
+
+* Crashed forked JVM caused listing the crashed test(s)
+
+  After the JVM exited abruptly, the console lists the message <<<Crashed tests:>>> if the entire
+  test-set has not been yet completed. This happens if a test exited, killed JVM or segmentation fault crashed JVM.
+

--- a/maven-surefire-plugin/src/site/fml/faq.fml
+++ b/maven-surefire-plugin/src/site/fml/faq.fml
@@ -67,6 +67,16 @@ under the License.
         </p>
       </answer>
     </faq>
+    <faq id="crashed-forks">
+      <question>Crashed Surefire or Failsafe plugin must indicate crashed tests</question>
+      <answer>
+        <p>
+        After a forked JVM has crashed the console of forked JVM prints <em>Crashed tests:</em> and lists the last test
+        which has crashed. In the console log you can find the message
+        <em>The forked VM terminated without properly saying goodbye</em>.
+        </p>
+      </answer>
+    </faq>
     <faq id="GWT">
       <question>How can I run GWT tests?</question>
       <answer>

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1295AttributeJvmCrashesToTestsIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1295AttributeJvmCrashesToTestsIT.java
@@ -1,0 +1,117 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+
+/**
+ * https://issues.apache.org/jira/browse/SUREFIRE-1295
+ * https://github.com/apache/maven-surefire/pull/136
+ *
+ * @author michaeltandy
+ * @since 2.19.2
+ */
+public class Surefire1295AttributeJvmCrashesToTestsIT
+        extends SurefireJUnit4IntegrationTestCase
+{
+    @Before
+    public void skipWindows()
+    {
+        assumeFalse( System.getProperty( "os.name" ).startsWith( "Windows" ) );
+    }
+
+    @Test
+    public void crashInFork() throws VerificationException
+    {
+        SurefireLauncher launcher = unpack( "crash-during-test" );
+
+        checkCrashTypes( launcher );
+    }
+
+    @Test
+    public void crashInSingleUseFork() throws VerificationException
+    {
+        SurefireLauncher launcher = unpack( "crash-during-test" )
+                                            .forkCount( 1 )
+                                            .reuseForks( false );
+
+        checkCrashTypes( launcher );
+    }
+
+    @Test
+    public void crashInReusableFork() throws VerificationException
+    {
+        SurefireLauncher launcher = unpack( "crash-during-test" )
+                                            .forkOncePerThread()
+                                            .threadCount( 1 );
+
+        checkCrashTypes( launcher );
+    }
+
+    private static void checkCrashTypes( SurefireLauncher launcher )
+            throws VerificationException
+    {
+        checkCrash( launcher.addGoal( "-DcrashType=exit" ) );
+        checkCrash( launcher.addGoal( "-DcrashType=abort" ) );
+        checkCrash( launcher.addGoal( "-DcrashType=segfault" ) );
+    }
+
+    private static void checkCrash( SurefireLauncher launcher ) throws VerificationException
+    {
+        OutputValidator validator = launcher.maven()
+                                            .withFailure()
+                                            .executeTest()
+                                            .verifyTextInLog( "The forked VM terminated without properly saying "
+                                                                      + "goodbye. VM crash or System.exit called?"
+                                            )
+                                            .verifyTextInLog( "Crashed tests:" );
+
+        for ( Iterator<String> it = validator.loadLogLines().iterator(); it.hasNext(); )
+        {
+            String line = it.next();
+            if ( line.contains( "Crashed tests:" ) )
+            {
+                line = it.next();
+                if ( it.hasNext() )
+                {
+                    assertThat( line ).contains( "junit44.environment.BasicTest" );
+                }
+                else
+                {
+                    fail( "Could not find any line after 'Crashed tests:'." );
+                }
+            }
+        }
+
+    }
+
+
+}

--- a/surefire-integration-tests/src/test/resources/crash-during-test/pom.xml
+++ b/surefire-integration-tests/src/test/resources/crash-during-test/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>crash-during-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Tests vm crash while a test is in progress</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.me.mjt</groupId>
+      <artifactId>crashjvm</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <forkMode>once</forkMode>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-integration-tests/src/test/resources/crash-during-test/src/test/java/junit44/environment/BasicTest.java
+++ b/surefire-integration-tests/src/test/resources/crash-during-test/src/test/java/junit44/environment/BasicTest.java
@@ -1,0 +1,52 @@
+package junit44.environment;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import uk.me.mjt.CrashJvm;
+
+public class BasicTest
+{
+    @Test
+    public void testCrashJvm()
+    {
+        assertTrue(CrashJvm.loadedOk());
+        
+        String crashType = System.getProperty("crashType");
+        assertNotNull(crashType);
+        if ( crashType.equals( "exit" ) )
+        {
+            CrashJvm.exit();
+        }
+        else if ( crashType.equals( "abort" ) )
+        {
+            CrashJvm.abort();
+        }
+        else if (crashType.equals( "segfault" ))
+        {
+            CrashJvm.segfault();
+        }
+        else
+        {
+            fail("Don't recognise crashType " + crashType);
+        }
+    }
+}

--- a/surefire-integration-tests/src/test/resources/crash-during-test/src/test/java/junit44/environment/SomeOtherTest.java
+++ b/surefire-integration-tests/src/test/resources/crash-during-test/src/test/java/junit44/environment/SomeOtherTest.java
@@ -1,0 +1,28 @@
+
+package junit44.environment;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+public class SomeOtherTest {
+    @Test
+    public void nonCrashingTest() {}
+}


### PR DESCRIPTION
I have 4 tests ATest.java .. DTest.java, and CTest fails like this:

```
@Test
    public void x() {
        Runtime.getRuntime().halt( 0 );
    }
```
Here is the result, see "Crashed tests".
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.19.2-SNAPSHOT:test (default-test) on project b: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.19.2-SNAPSHOT:test failed: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was cmd.exe /X /C ""D:\Program Files\Java\jdk1.8.0_112\jre\bin\java" -jar D:\vcs\zmaz6\target\surefire\surefirebooter8109843199172464014.jar D:\vcs\zmaz6\target\surefire\surefire4550764212193522341tmp D:\vcs\zmaz6\target\surefire\surefire_07316673656092271862tmp"
[ERROR] Process Exit Code: 0
[ERROR] Crashed tests:
[ERROR] pkg.CTest
[ERROR] -> [Help 1]
```