### PR TITLE
Fix SUREFIRE-1239

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -166,6 +166,8 @@ public class TestSetRunListener
 
         addTestMethodStats();
         detailsForThis.reset();
+
+        clearCapture();
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
Project to reproduce - https://github.com/jsdima/SUREFIRE-1239-reproduce

More info:
Problem appears when there are a lot of console output after last test(which leads to save this output to file) in TestSet, and in the next TestSet some test fails. It happens because stream (`Utf8RecodingDeferredFileOutputStream testStdOut`)  which collects data after test execution but before TestSet finished  then also used in next TestSet.

Sometimes it leads to 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.19.1:test (default-test) on project SUREFIRE-1239-reproduce: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.19.1:test failed: java.lang.RuntimeException: org.apache.maven.surefire.report.ReporterException: When writing xml report stdout/stderr: /tmp/stdout8948920314382993444deferred (No such file or directory) -> [Help 1]
```

sometimes build just hangs