### PR TITLE
[SUREFIRE-1416] maven-surefire-parser: add new method isError in ReportTestCase 

### DIFF
--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
@@ -600,7 +600,12 @@ public final class SurefireReportGenerator
 
                 sink.tableCell();
                 SinkEventAttributeSet atts = new SinkEventAttributeSet();
-                atts.addAttribute( SinkEventAttributes.ID, tCase.getName() + "error" );
+                if (tCase.isError()) {
+                    atts.addAttribute( SinkEventAttributes.ID, tCase.getName() + "error" );
+                } else {
+                    atts.addAttribute( SinkEventAttributes.ID, tCase.getName() + "failure" );
+                }
+
                 sink.unknown( "div", TAG_TYPE_START, atts );
 
                 String fullClassName = tCase.getFullClassName();

--- a/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/ReportTestCase.java
+++ b/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/ReportTestCase.java
@@ -158,11 +158,13 @@ public final class ReportTestCase
         return hasFailure;
     }
 
-    public boolean isError() {
+    public boolean isError()
+    {
         return isError;
     }
 
-    public ReportTestCase setError(boolean error) {
+    public ReportTestCase setError( boolean error )
+    {
         this.isError = error;
         return this;
     }

--- a/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/ReportTestCase.java
+++ b/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/ReportTestCase.java
@@ -46,6 +46,8 @@ public final class ReportTestCase
 
     private boolean hasFailure;
 
+    private boolean isError;
+
     public String getName()
     {
         return name;
@@ -154,6 +156,15 @@ public final class ReportTestCase
     public boolean hasFailure()
     {
         return hasFailure;
+    }
+
+    public boolean isError() {
+        return isError;
+    }
+
+    public ReportTestCase setError(boolean error) {
+        this.isError = error;
+        return this;
     }
 
     /**

--- a/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/TestSuiteXmlParser.java
+++ b/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/TestSuiteXmlParser.java
@@ -196,7 +196,8 @@ public final class TestSuiteXmlParser
                 }
                 else if ( "error".equals( qName ) )
                 {
-                    testCase.setFailure( attributes.getValue( "message" ), attributes.getValue( "type" ) );
+                    testCase.setFailure( attributes.getValue( "message" ), attributes.getValue( "type" ) )
+                            .setError( true );
                     currentSuite.incrementNumberOfErrors();
                 }
                 else if ( "skipped".equals( qName ) )

--- a/surefire-report-parser/src/test/java/org/apache/maven/plugins/surefire/report/TestSuiteXmlParserTest.java
+++ b/surefire-report-parser/src/test/java/org/apache/maven/plugins/surefire/report/TestSuiteXmlParserTest.java
@@ -158,6 +158,7 @@ public class TestSuiteXmlParserTest
         assertThat( tests.get( 0 ).getFailureMessage(), is( "<" ) );
         assertThat( tests.get( 0 ).getFullName(), is( "wellFormedXmlFailures.TestSurefire3.testLower" ) );
         assertThat( tests.get( 0 ).getFailureType(), is( "junit.framework.AssertionFailedError" ) );
+        assertThat( tests.get( 0 ).isError(), is( false ) );
 
         assertThat( tests.get( 1 ).getFullClassName(), is( "wellFormedXmlFailures.TestSurefire3" ) );
         assertThat( tests.get( 1 ).getName(), is( "testU0000" ) );
@@ -171,6 +172,7 @@ public class TestSuiteXmlParserTest
         assertThat( tests.get( 1 ).getFailureMessage(), is( "&0#;" ) );
         assertThat( tests.get( 1 ).getFullName(), is( "wellFormedXmlFailures.TestSurefire3.testU0000" ) );
         assertThat( tests.get( 1 ).getFailureType(), is( "junit.framework.AssertionFailedError" ) );
+        assertThat( tests.get( 1 ).isError(), is( false ) );
 
         assertThat( tests.get( 2 ).getFullClassName(), is( "wellFormedXmlFailures.TestSurefire3" ) );
         assertThat( tests.get( 2 ).getName(), is( "testGreater" ) );
@@ -184,6 +186,7 @@ public class TestSuiteXmlParserTest
         assertThat( tests.get( 2 ).getFailureMessage(), is( ">" ) );
         assertThat( tests.get( 2 ).getFullName(), is( "wellFormedXmlFailures.TestSurefire3.testGreater" ) );
         assertThat( tests.get( 2 ).getFailureType(), is( "junit.framework.AssertionFailedError" ) );
+        assertThat( tests.get( 2 ).isError(), is( false ) );
 
         assertThat( tests.get( 3 ).getFullClassName(), is( "wellFormedXmlFailures.TestSurefire3" ) );
         assertThat( tests.get( 3 ).getName(), is( "testQuote" ) );
@@ -197,6 +200,7 @@ public class TestSuiteXmlParserTest
         assertThat( tests.get( 3 ).getFailureMessage(), is( "\"" ) );
         assertThat( tests.get( 3 ).getFullName(), is( "wellFormedXmlFailures.TestSurefire3.testQuote" ) );
         assertThat( tests.get( 3 ).getFailureType(), is( "junit.framework.AssertionFailedError" ) );
+        assertThat( tests.get( 3 ).isError(), is( false ) );
     }
 
     @Test
@@ -390,6 +394,7 @@ public class TestSuiteXmlParserTest
         + "\tat surefire.MyTest$Nested.run(MyTest.java:38)\n"
         + "\tat surefire.MyTest.delegate(MyTest.java:29)\n"
         + "\tat surefire.MyTest.rethrownDelegate(MyTest.java:22)" ) );
+        assertThat( tests.get( 0 ).getTestCases().get( 0 ).isError(), is( true ) );
     }
 
     @Test
@@ -466,6 +471,7 @@ public class TestSuiteXmlParserTest
         + "\tat surefire.MyTest$Nested.run(MyTest.java:38)\n"
         + "\tat surefire.MyTest.delegate(MyTest.java:29)\n"
         + "\tat surefire.MyTest.rethrownDelegate(MyTest.java:22)\n" ) );
+        assertThat( tests.get( 0 ).getTestCases().get( 0 ).isError(), is( true ) );
     }
 
     @Test
@@ -508,6 +514,7 @@ public class TestSuiteXmlParserTest
                             + "\tat surefire.MyTest.newRethrownDelegate(MyTest.java:17)\n"
                             + "\tat surefire.MyTest.access$200(MyTest.java:9)\n"
                             + "\tat surefire.MyTest$A.t(MyTest.java:45)\n" ) );
+        assertThat( tests.get( 0 ).getTestCases().get( 0 ).isError(), is( true ) );
     }
 
     @Test
@@ -575,6 +582,7 @@ public class TestSuiteXmlParserTest
         + "\tat surefire.MyTest$Nested.run(MyTest.java:38)\n"
         + "\tat surefire.MyTest.delegate(MyTest.java:29)\n"
         + "\tat surefire.MyTest.rethrownDelegate(MyTest.java:22)" ) );
+        assertThat( tests.get( 0 ).getTestCases().get( 0 ).isError(), is( true ) );
     }
 
     @Test
@@ -618,6 +626,7 @@ public class TestSuiteXmlParserTest
                             + "\tat surefire.MyTest$Nested.run(MyTest.java:38)\n"
                             + "\tat surefire.MyTest.delegate(MyTest.java:29)\n"
                             + "\tat surefire.MyTest.rethrownDelegate(MyTest.java:22)" ) );
+        assertThat( tests.get( 0 ).getTestCases().get( 0 ).isError(), is( true ) );
     }
 
     @Test


### PR DESCRIPTION
There is currently no way after parsing test suite to know if a test case is a failure or an error. I added a boolean `isError` in ReportTestCase and associated getter and setter and I set it up in the TestSuiteXmlParser. 

I need this feature for an automation repair project: if there is another way with existing tooling, just tell me about it!
