### PR TITLE
Close reportSets tag

### DIFF
--- a/maven-surefire-plugin/src/site/apt/usage.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/usage.apt.vm
@@ -281,7 +281,8 @@ mvn verify
             <reports>
               <report>failsafe-report-only</report>
             </reports>
-        </reportSet>
+          </reportSet>
+        </reportSets>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
Close the `<reportSets>` tag in the usage documentation for "Reporting integration test results".