### PR TITLE
Reporters use buffers to reduce number of I/O operations

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ConsoleOutputFileReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ConsoleOutputFileReporter.java
@@ -19,9 +19,11 @@ package org.apache.maven.plugin.surefire.report;
  * under the License.
  */
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 
 import org.apache.maven.surefire.report.ReportEntry;
 
@@ -44,7 +46,7 @@ public class ConsoleOutputFileReporter
 
     private String reportEntryName;
 
-    private FileOutputStream fileOutputStream;
+    private OutputStream fileOutputStream;
 
     public ConsoleOutputFileReporter( File reportsDirectory, String reportNameSuffix )
     {
@@ -70,10 +72,18 @@ public class ConsoleOutputFileReporter
             try
             {
                 fileOutputStream.flush();
-                fileOutputStream.close();
             }
             catch ( IOException e )
             {
+            }
+            finally
+            {
+                try
+                {
+                    fileOutputStream.close();
+                } catch (IOException e)
+                {
+                }
             }
             fileOutputStream = null;
         }
@@ -91,7 +101,7 @@ public class ConsoleOutputFileReporter
                     reportsDirectory.mkdirs();
                 }
                 File file = getReportFile( reportsDirectory, reportEntryName, reportNameSuffix, "-output.txt" );
-                fileOutputStream = new FileOutputStream( file );
+                fileOutputStream = new BufferedOutputStream( new FileOutputStream( file ), 16 * 1024 );
             }
             fileOutputStream.write( buf, off, len );
         }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/FileReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/FileReporter.java
@@ -22,6 +22,7 @@ package org.apache.maven.plugin.surefire.report;
 import org.apache.maven.surefire.report.ReportEntry;
 import org.apache.maven.surefire.report.ReporterException;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -60,7 +61,7 @@ public class FileReporter
 
         try
         {
-            PrintWriter writer = new PrintWriter( new FileWriter( reportFile ) );
+            PrintWriter writer = new PrintWriter( new BufferedWriter( new FileWriter( reportFile ), 16 * 1024 ) );
 
             writer.println( "-------------------------------------------------------------------------------" );
 
@@ -86,9 +87,10 @@ public class FileReporter
 
     public void testSetCompleted( WrappedReportEntry report, TestSetStats testSetStats, List<String> testResults )
     {
-        PrintWriter writer = testSetStarting( report );
+        PrintWriter writer = null;
         try
         {
+            writer = testSetStarting( report );
             writer.println( testSetStats.getTestSetSummary( report ) );
             for ( String testResult : testResults )
             {
@@ -98,7 +100,10 @@ public class FileReporter
         }
         finally
         {
-            writer.close();
+            if (writer != null)
+            {
+                writer.close();
+            }
         }
     }
 }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -26,6 +26,7 @@ import org.apache.maven.surefire.report.ReportEntry;
 import org.apache.maven.surefire.report.ReporterException;
 import org.apache.maven.surefire.report.SafeThrowable;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FilterOutputStream;
@@ -124,7 +125,7 @@ public class StatelessXmlReporter
             getAddMethodEntryList( methodRunHistoryMap, methodEntry );
         }
 
-        FileOutputStream outputStream = getOutputStream( testSetReportEntry );
+        OutputStream outputStream = getOutputStream( testSetReportEntry );
         OutputStreamWriter fw = getWriter( outputStream );
         try
         {
@@ -281,7 +282,7 @@ public class StatelessXmlReporter
         return methodRunHistoryMap;
     }
 
-    private FileOutputStream getOutputStream( WrappedReportEntry testSetReportEntry )
+    private OutputStream getOutputStream( WrappedReportEntry testSetReportEntry )
     {
         File reportFile = getReportFile( testSetReportEntry, reportsDirectory, reportNameSuffix );
 
@@ -292,7 +293,7 @@ public class StatelessXmlReporter
 
         try
         {
-            return new FileOutputStream( reportFile );
+            return new BufferedOutputStream( new FileOutputStream( reportFile ), 16 * 1024 );
         }
         catch ( Exception e )
         {
@@ -300,7 +301,7 @@ public class StatelessXmlReporter
         }
     }
 
-    private static OutputStreamWriter getWriter( FileOutputStream fos )
+    private static OutputStreamWriter getWriter( OutputStream fos )
     {
         return new OutputStreamWriter( fos, ENCODING_CS );
     }
@@ -374,7 +375,7 @@ public class StatelessXmlReporter
     }
 
     private static void getTestProblems( OutputStreamWriter outputStreamWriter, XMLWriter ppw,
-                                         WrappedReportEntry report, boolean trimStackTrace, FileOutputStream fw,
+                                         WrappedReportEntry report, boolean trimStackTrace, OutputStream fw,
                                          String testErrorType, boolean createOutErrElementsInside )
     {
         ppw.startElement( testErrorType );
@@ -420,7 +421,7 @@ public class StatelessXmlReporter
 
     // Create system-out and system-err elements
     private static void createOutErrElements( OutputStreamWriter outputStreamWriter, XMLWriter ppw,
-                                              WrappedReportEntry report, FileOutputStream fw )
+                                              WrappedReportEntry report, OutputStream fw )
     {
         EncodingOutputStream eos = new EncodingOutputStream( fw );
         addOutputStreamElement( outputStreamWriter, eos, ppw, report.getStdout(), "system-out" );


### PR DESCRIPTION
Fixes [SUREFIRE-1362](https://issues.apache.org/jira/browse/SUREFIRE-1362) and [SUREFIRE-1361](https://issues.apache.org/jira/browse/SUREFIRE-1361)
Also adds buffering to FileReporter.