### PR TITLE
Add a doctype to the StatelessXmlReporter output

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -128,6 +128,7 @@ public class StatelessXmlReporter
         {
             XMLWriter ppw = new PrettyPrintXMLWriter( fw );
             ppw.setEncoding( StringUtils.UTF_8.name() );
+            ppw.setsetDocType( "testsuite" );
 
             createTestSuiteElement( ppw, testSetReportEntry, testSetStats, testSetReportEntry.elapsedTimeAsString() );
 


### PR DESCRIPTION
I like eclipse not to have any complaints about a missing doctype/dtd.