### PR TITLE
Fixing build on Windows cmd.exe.

### DIFF
--- a/maven-failsafe-plugin/pom.xml
+++ b/maven-failsafe-plugin/pom.xml
@@ -105,6 +105,10 @@
                   <xsd>../maven-surefire-plugin/src/site/resources/xsd/failsafe-summary.xsd</xsd>
                   <bindingFile>../maven-surefire-plugin/src/site/resources/xsd/failsafe-summary.xjb</bindingFile>
                   <packagename>org.apache.maven.plugin.failsafe.xmlsummary</packagename>
+                  <extensionArgs>
+                    <arg>-encoding</arg>
+                    <arg>${project.build.sourceEncoding}</arg>
+                  </extensionArgs>
                 </xsdOption>
               </xsdOptions>
             </configuration>


### PR DESCRIPTION
Files generated with the XJC tool were using the platform encoding, that can be different from the project source encoding. In this case, the project source encoding is UTF-8, but cmd.exe can use another (e.g. code page 850). In turn, this created an error while compiling the generated sources because they contain unmappable characters for UTF-8 as expected by the compiler. The encoding that should be used by XJC is specified through the -encoding option.