### PR TITLE
SUREFIRE-1382: fixing OutOfMemoryError

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/MultipleFailureException.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/MultipleFailureException.java
@@ -42,7 +42,7 @@ final class MultipleFailureException
     public String getLocalizedMessage()
     {
         StringBuilder messages = new StringBuilder();
-        for ( Throwable exception = exceptions.peek(); exception != null; exception = exceptions.peek() )
+        for ( Throwable exception : exceptions )
         {
             if ( messages.length() != 0 )
             {
@@ -58,7 +58,7 @@ final class MultipleFailureException
     public String getMessage()
     {
         StringBuilder messages = new StringBuilder();
-        for ( Throwable exception = exceptions.peek(); exception != null; exception = exceptions.peek() )
+        for ( Throwable exception : exceptions )
         {
             if ( messages.length() != 0 )
             {


### PR DESCRIPTION
We experienced out of memory errors also on Apache Camel with JUnit 4. The reason is probably this infinite loop whenever the `exceptions` Queue contains at least one element.