### PR TITLE
SUREFIRE-1391: Eliminate redundant call in calculation of effective properties

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireProperties.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireProperties.java
@@ -148,7 +148,6 @@ public class SurefireProperties
         result.copyPropertiesFrom( props );
 
         copyProperties( result, systemPropertyVariables );
-        copyProperties( result, systemPropertyVariables );
 
         // We used to take all of our system properties and dump them in with the
         // user specified properties for SUREFIRE-121, causing SUREFIRE-491.


### PR DESCRIPTION
Eliminate redundant call to copy systemPropertyVariables in the calculation of effective properties