### PR TITLE
[SUREFIRE-1398] threadCount is set for JUnit only when it is positive

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1300,7 +1300,11 @@ public abstract class AbstractSurefireMojo
         }
 
         getProperties().setProperty( ProviderParameterNames.PARALLEL_PROP, usedParallel );
-        getProperties().setProperty( ProviderParameterNames.THREADCOUNT_PROP, Integer.toString( getThreadCount() ) );
+        if ( this.getThreadCount() > 0 )
+        {
+            getProperties().setProperty( ProviderParameterNames.THREADCOUNT_PROP,
+                                         Integer.toString( getThreadCount() ) );
+        }
         getProperties().setProperty( "perCoreThreadCount", Boolean.toString( getPerCoreThreadCount() ) );
         getProperties().setProperty( "useUnlimitedThreads", Boolean.toString( getUseUnlimitedThreads() ) );
         getProperties().setProperty( ProviderParameterNames.THREADCOUNTSUITES_PROP,


### PR DESCRIPTION
Otherwise, the TestNG fails with 
`Cannot use a threadCount parameter less than 1; 1 > 0` 
in some cases when the parallel parameter was not set. To identify the cases, take a look at related Jira issue: https://issues.apache.org/jira/browse/SUREFIRE-1398
I removed the check for positiveness of the `threadCount` value as it's a responsibility of the user to provide correct value.
The question is if the default value of `threadCount` parameter shouldn't be 1, to avoid such a problems...? If yes, then I'll update my PR