### PR TITLE
SUREFIRE-1396: Provider class path is incorrect for custom provider in Failsafe

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -19,6 +19,7 @@ package org.apache.maven.plugin.failsafe;
  * under the License.
  */
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.surefire.AbstractSurefireMojo;
@@ -36,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.apache.maven.plugin.failsafe.util.FailsafeSummaryXmlUtils.writeSummary;
 
@@ -440,6 +442,13 @@ public class IntegrationTestMojo
     protected String getReportSchemaLocation()
     {
         return "https://maven.apache.org/surefire/maven-failsafe-plugin/xsd/failsafe-test-report.xsd";
+    }
+
+    @Override
+    protected Artifact getMojoArtifact()
+    {
+        final Map<String, Artifact> pluginArtifactMap = getPluginArtifactMap();
+        return pluginArtifactMap.get( "org.apache.maven.plugins:maven-failsafe-plugin" );
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -790,6 +790,8 @@ public abstract class AbstractSurefireMojo
 
     protected abstract String getReportSchemaLocation();
 
+    protected abstract Artifact getMojoArtifact();
+
     private String getDefaultExcludes()
     {
         return "**/*$*";
@@ -2815,9 +2817,7 @@ public abstract class AbstractSurefireMojo
         public Classpath getProviderClasspath()
             throws ArtifactResolutionException, ArtifactNotFoundException
         {
-            final Map<String, Artifact> pluginArtifactMap = getPluginArtifactMap();
-            Artifact plugin = pluginArtifactMap.get( "org.apache.maven.plugins:maven-surefire-plugin" );
-            return dependencyResolver.addProviderToClasspath( pluginArtifactMap, plugin );
+            return dependencyResolver.addProviderToClasspath( pluginArtifactMap, getMojoArtifact() );
         }
     }
 

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -376,6 +378,13 @@ public class SurefirePlugin
         return "https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd";
     }
 
+    @Override
+    protected Artifact getMojoArtifact()
+    {
+        final Map<String, Artifact> pluginArtifactMap = getPluginArtifactMap();
+        return pluginArtifactMap.get( "org.apache.maven.plugins:maven-surefire-plugin" );
+    }
+    
     // now for the implementation of the field accessors
 
     @Override

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1396CustomProviderClassPathIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1396CustomProviderClassPathIT.java
@@ -1,0 +1,52 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Jonathan Bell
+ */
+public class Surefire1396CustomProviderClassPathIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+    @BeforeClass
+    public static void installProvider()
+        throws VerificationException
+    {
+        unpack( Surefire1396CustomProviderClassPathIT.class, "surefire-1396-pluggableproviders-classpath-provider", "prov" ).executeInstall();
+    }
+    
+    @Test
+    public void pluggableProviderClasspathCorrect()
+        throws Exception
+    {
+        unpack( "surefire-1396-pluggableproviders-classpath" )
+            .setForkJvm()
+            .maven()
+            .showExceptionMessages()
+            .debugLogging()
+            .executeVerify()
+            .verifyErrorFreeLog();
+    }
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath-provider/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath-provider/pom.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>surefire-test-classpath-provider</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test provider</name>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.surefire</groupId>
+      <artifactId>surefire-api</artifactId>
+      <version>${surefire.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources/META-INF</directory>
+        <targetPath>META-INF</targetPath>
+      </resource>
+    </resources>
+  </build>
+
+
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath-provider/src/main/java/org/apache/maven/surefire/testprovider/ClassPathTestProvider.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath-provider/src/main/java/org/apache/maven/surefire/testprovider/ClassPathTestProvider.java
@@ -1,0 +1,63 @@
+package org.apache.maven.surefire.testprovider;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.LinkedList;
+import java.util.Map.Entry;
+
+import org.apache.maven.surefire.providerapi.AbstractProvider;
+import org.apache.maven.surefire.providerapi.ProviderParameters;
+import org.apache.maven.surefire.report.ReporterException;
+import org.apache.maven.surefire.suite.RunResult;
+import org.apache.maven.surefire.testset.TestSetFailedException;
+
+/**
+ * @author Jonathan Bell
+ */
+public class ClassPathTestProvider
+    extends AbstractProvider
+{
+    boolean hasSLF4J; // SLF4J is not being included in our deps, so if it's in the classpath, that's a problem...
+
+    public ClassPathTestProvider( ProviderParameters params )
+    {
+        for ( Entry<String, String> propEntry : params.getProviderProperties().entrySet() )
+        {
+            if ( propEntry.getKey().startsWith( "surefireClassPathUrl" ) && propEntry.getValue().contains( "slf4j" ) )
+                hasSLF4J = true;
+        }
+    }
+
+    public Iterable<Class<?>> getSuites()
+    {
+        LinkedList<Class<?>> ret = new LinkedList<Class<?>>();
+        return ret;
+    }
+
+    public RunResult invoke( Object arg0 )
+        throws TestSetFailedException, ReporterException, InvocationTargetException
+    {
+        if ( hasSLF4J )
+            throw new TestSetFailedException( "SLF4J was found on the boot classpath" );
+        return new RunResult( 1, 0, 0, 0 );
+    }
+
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath-provider/src/main/resources/META-INF/services/org.apache.maven.surefire.providerapi.SurefireProvider
+++ b/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath-provider/src/main/resources/META-INF/services/org.apache.maven.surefire.providerapi.SurefireProvider
@@ -1,0 +1,1 @@
+org.apache.maven.surefire.testprovider.ClassPathTestProvider

--- a/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath/pom.xml
+++ b/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>pluggableproviders-classpath</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>pluggableproviders-classpath-test</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.plugins.surefire</groupId>
+            <artifactId>surefire-test-classpath-provider</artifactId>
+            <version>1.0-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire.version}</version>
+	    <executions>
+            <execution>
+                <goals>
+                    <goal>integration-test</goal>
+                    <goal>verify</goal>
+                </goals>
+            </execution>
+        </executions>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven.plugins.surefire</groupId>
+                <artifactId>surefire-test-classpath-provider</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath/src/test/java/pluggableproviders/EmptyIT.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath/src/test/java/pluggableproviders/EmptyIT.java
@@ -1,0 +1,26 @@
+package pluggableproviders;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+public class EmptyIT
+{
+
+}

--- a/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath/src/test/java/pluggableproviders/EmptyTest.java
+++ b/surefire-integration-tests/src/test/resources/surefire-1396-pluggableproviders-classpath/src/test/java/pluggableproviders/EmptyTest.java
@@ -1,0 +1,26 @@
+package pluggableproviders;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+public class EmptyTest
+{
+
+}


### PR DESCRIPTION
Hi,
When using a custom Surefire provider with Surefire (not Failsafe), the "provider classpath" contains only the provider and surefire-api. However, when using a custom provider with Failsafe, the provider class path ends up including a lot more... it seems like perhaps all plugins that are loaded? This has caused some mayhem for me when using a custom provider in projects that use a specific version of SLF4J... because then failsafe forces 1.5.6 to be loaded (from this process of incorrectly finding the custom provider), causing a crash.

This PR contains an integration test case showing the bug and a patch to solve it.