### PR TITLE
Speedup Standard Output if Tests

### DIFF
--- a/surefire-api/src/main/java/org/apache/maven/surefire/booter/ForkingRunListener.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/booter/ForkingRunListener.java
@@ -200,14 +200,8 @@ public class ForkingRunListener
     @Override
     public void writeTestOutput( byte[] buf, int off, int len, boolean stdout )
     {
-        byte[] header = stdout ? stdOutHeader : stdErrHeader;
-        byte[] content =
-            new byte[buf.length * 3 + 1]; // Hex-escaping can be up to 3 times length of a regular byte.
-        int i = escapeBytesToPrintable( content, 0, buf, off, len );
-        content[i++] = (byte) '\n';
-        byte[] encodeBytes = new byte[header.length + i];
-        System.arraycopy( header, 0, encodeBytes, 0, header.length );
-        System.arraycopy( content, 0, encodeBytes, header.length, i );
+        final byte[] header = stdout ? stdOutHeader : stdErrHeader;
+        final byte[] encodeBytes = escapeBytesToPrintable( header, buf, off, len );
 
         synchronized ( target ) // See notes about synchronization/thread safety in class javadoc
         {

--- a/surefire-api/src/test/java/org/apache/maven/surefire/util/internal/StringUtilsTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/util/internal/StringUtilsTest.java
@@ -66,6 +66,35 @@ public class StringUtilsTest
         return sb;
     }
 
+    public void testUnescapeBytesList()
+    {
+        byte[] input = new byte[256];
+
+        for ( int i = 0; i <= 0xFF; i++ )
+        {
+            byte b = (byte) ( 0xFF & i );
+            input[i] = b;
+        }
+
+        byte[] escaped = StringUtils.escapeBytesToPrintable( new byte[0], input, 0, input.length );
+
+        String escapedString = new String( escaped, 0, escaped.length );
+
+        assertEquals( escaped.length, escapedString.length() );
+
+        java.nio.ByteBuffer unescaped = StringUtils.unescapeBytes( escapedString, Charset.defaultCharset().name() );
+
+        // +1, since escapeBytesToPrintable in this version adds a line break,
+        // since this is expected for surefire test output
+        assertEquals( input.length + 1, unescaped.remaining() - unescaped.position() );
+
+        for ( int i = 0; i < input.length; i++ )
+        {
+            byte actual = unescaped.get();
+            assertEquals( "At position " + i, input[i], actual );
+        }
+    }
+
     public void testUnescapeBytes()
     {
         byte[] input = new byte[256];


### PR DESCRIPTION
Currently, surefire creates a new byte array with size of the input *3 for saving the unescaped input. This made surefire way slower than running a test directly in eclipse or with gradle, if it used standardout or error heavily.
By using a list for saving the elements and converting them to an array afterwards, this problem is solved, and stdout-heavy surefire tests get faster.