### PR TITLE
[SUREFIRE-1453] Allow to specify non existant classes as groups

### DIFF
--- a/surefire-grouper/src/main/java/org/apache/maven/surefire/group/match/SingleGroupMatcher.java
+++ b/surefire-grouper/src/main/java/org/apache/maven/surefire/group/match/SingleGroupMatcher.java
@@ -139,7 +139,8 @@ public class SingleGroupMatcher
         }
         catch ( ClassNotFoundException e )
         {
-            throw new RuntimeException( "Unable to load category: " + enabled, e );
+            // class is not available at runtime, for instance this would happen in reactor projects
+            // in which not all modules have the required class on the classpath/module path
         }
     }
 }

--- a/surefire-grouper/src/test/java/org/apache/maven/surefire/group/match/SingleGroupMatcherTest.java
+++ b/surefire-grouper/src/test/java/org/apache/maven/surefire/group/match/SingleGroupMatcherTest.java
@@ -37,6 +37,13 @@ public class SingleGroupMatcherTest
         assertTrue( matcher.enabled( SingleGroupMatcher.class ) );
     }
 
+    public void testMatchUnknownClass()
+    {
+        SingleGroupMatcher matcher = new SingleGroupMatcher( "BadClass" );
+        matcher.loadGroupClasses( Thread.currentThread().getContextClassLoader() );
+        assertTrue( matcher.enabled( "BadClass" ) );
+    }
+
     public void testMatchClassNameWithoutPackage()
     {
         SingleGroupMatcher matcher = new SingleGroupMatcher( SingleGroupMatcher.class.getSimpleName() );

--- a/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit48TestCategoriesIT.java
+++ b/surefire-integration-tests/src/test/java/org/apache/maven/surefire/its/JUnit48TestCategoriesIT.java
@@ -47,14 +47,49 @@ public class JUnit48TestCategoriesIT
     public void testCategoriesABForkAlways()
         throws Exception
     {
-        runAB( unpacked() );
+        runAB( unpacked().forkAlways() );
     }
 
     @Test
-    public void testCategoriesAC()
+    public void testCategoriesACFullyQualifiedClassName()
         throws Exception
     {
-        runAC( unpacked() );
+        runACFullyQualifiedClassName( unpacked() );
+    }
+
+    @Test
+    public void testCategoriesACFullyQualifiedClassNameForkAlways()
+        throws Exception
+    {
+        runACFullyQualifiedClassName( unpacked().forkAlways() );
+    }
+
+    @Test
+    public void testCategoriesACClassNameSuffix()
+        throws Exception
+    {
+        runACClassNameSuffix( unpacked() );
+    }
+
+    @Test
+    public void testCategoriesACClassNameSuffixForkAlways()
+        throws Exception
+    {
+        runACClassNameSuffix( unpacked().forkAlways() );
+    }
+
+    @Test
+    public void testCategoriesBadCategory()
+        throws Exception
+    {
+        runBadCategory( unpacked() );
+    }
+
+    @Test
+    public void testBadCategoryForkAlways()
+        throws Exception
+    {
+        runBadCategory( unpacked().forkAlways() );
     }
 
     private void runAB( SurefireLauncher unpacked )
@@ -64,24 +99,34 @@ public class JUnit48TestCategoriesIT
                 "catA: 1" ).verifyTextInLog( "catB: 1" ).verifyTextInLog( "catC: 0" ).verifyTextInLog( "catNone: 0" );
     }
 
-    @Test
-    public void testCategoriesACForkAlways()
+    private void runACClassNameSuffix( SurefireLauncher unpacked )
         throws Exception
     {
-        runAC( unpacked().forkAlways() );
+        unpacked.groups(
+            "CategoryA,CategoryC" ).executeTest().verifyErrorFreeLog().assertTestSuiteResults( 6, 0, 0, 0 ).verifyTextInLog(
+            "catA: 1" ).verifyTextInLog( "catB: 0" ).verifyTextInLog( "catC: 1" ).verifyTextInLog(
+            "catNone: 0" ).verifyTextInLog( "mA: 1" ).verifyTextInLog(
+            "mB: 1" ) // This seems questionable !? The class is annotated with category C and method with B
+            .verifyTextInLog( "mC: 1" ).verifyTextInLog( "CatNone: 1" );
     }
 
-
-    private void runAC( SurefireLauncher surefireLauncher )
+    private void runACFullyQualifiedClassName( SurefireLauncher unpacked )
         throws Exception
     {
-        surefireLauncher.groups(
+        unpacked.groups(
             "junit4.CategoryA,junit4.CategoryC" ).executeTest().verifyErrorFreeLog().assertTestSuiteResults( 6, 0, 0,
                                                                                                              0 ).verifyTextInLog(
             "catA: 1" ).verifyTextInLog( "catB: 0" ).verifyTextInLog( "catC: 1" ).verifyTextInLog(
             "catNone: 0" ).verifyTextInLog( "mA: 1" ).verifyTextInLog(
             "mB: 1" ) // This seems questionable !? The class is annotated with category C and method with B
             .verifyTextInLog( "mC: 1" ).verifyTextInLog( "CatNone: 1" );
+    }
+
+    private void runBadCategory( SurefireLauncher unpacked )
+        throws Exception
+    {
+        unpacked.failIfNoTests(false).groups(
+            "BadCategory" ).executeTest().verifyErrorFreeLog();
     }
 
     private SurefireLauncher unpacked()


### PR DESCRIPTION
Allow to specify class names which does not resolve to a class in the scope of the project classpath.
This will be useful for instance in reactor projects in which non all modules contain the requested marker interface in the classpath.
See SUREFIRE-1453 for a complete description