### PR TITLE
[SUREFIRE-1495] Encoding of TXT report file should be configured by ${project.reporting.outputEncoding} and MOJO parameter encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,12 @@
 # Auto detect text files and perform LF normalization
-*        text=auto
+* text eol=lf
 
+*.xml    text diff=xml
 *.java   text diff=java
 *.html   text diff=html
+*.vm     text
+*.fml    text
+*.md     text
 *.css    text
 *.js     text
 *.sql    text

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,8 +27,8 @@ properties(
 )
 
 final def oses = ['linux', 'windows']
-final def mavens = ['3.2.x', '3.3.x', '3.5.x']//env.BRANCH_NAME == 'master' ? ['3.2.x', '3.3.x', '3.5.x'] : ['3.5.x']
-final def jdks = [7, 8, 9, 10]//env.BRANCH_NAME == 'master' ? [7, 8, 9, 10] : [9, 10]
+final def mavens = ['3.2.x', '3.3.x', '3.5.x'] // env.BRANCH_NAME == 'master' ? ['3.2.x', '3.3.x', '3.5.x'] : ['3.2.x', '3.5.x']
+final def jdks = [7, 8, 9, 10] // env.BRANCH_NAME == 'master' ? [7, 8, 9, 10] : [7, 10]
 
 final def options = ['-e', '-V', '-B', '-nsu', '-P', 'run-its']
 final def goals = ['clean', 'install', 'jacoco:report']

--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -256,10 +256,11 @@ public class IntegrationTestMojo
     private boolean useManifestOnlyJar;
 
     /**
-     * The character encoding scheme to be applied.
-     * Deprecated since 2.20.1 and used encoding UTF-8 in <tt>failsafe-summary.xml</tt>.
+     * The character encoding scheme to be applied while generating test report
+     * files (see target/surefire-reports/yourTestName.txt).
+     * The report output files (*-out.txt) are still encoded with JVM's encoding used in standard out/err pipes.
      *
-     * @deprecated since of 2.20.1
+     * @since 3.0.0-M1
      */
     @Parameter( property = "encoding", defaultValue = "${project.reporting.outputEncoding}" )
     private String encoding;
@@ -701,6 +702,18 @@ public class IntegrationTestMojo
     public void setUseManifestOnlyJar( boolean useManifestOnlyJar )
     {
         this.useManifestOnlyJar = useManifestOnlyJar;
+    }
+
+    @Override
+    public String getEncoding()
+    {
+        return encoding;
+    }
+
+    @Override
+    public void setEncoding( String encoding )
+    {
+        this.encoding = encoding;
     }
 
     // the following will be refactored out once the common code is all in one place

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1807,7 +1807,7 @@ public abstract class AbstractSurefireMojo
                                                isRedirectTestOutputToFile(), isDisableXmlReport(),
                                                getReportsDirectory(), isTrimStackTrace(), getReportNameSuffix(),
                                                getStatisticsFile( configChecksum ), requiresRunHistory(),
-                                               getRerunFailingTestsCount(), getReportSchemaLocation() );
+                                               getRerunFailingTestsCount(), getReportSchemaLocation(), getEncoding() );
     }
 
     private boolean isSpecificTestSpecified()
@@ -2337,6 +2337,7 @@ public abstract class AbstractSurefireMojo
         checksum.add( isDisableXmlReport() );
         checksum.add( isUseSystemClassLoader() );
         checksum.add( isUseManifestOnlyJar() );
+        checksum.add( getEncoding() );
         checksum.add( isEnableAssertions() );
         checksum.add( getObjectFactory() );
         checksum.add( getFailIfNoTests() );

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/CommonReflector.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/CommonReflector.java
@@ -72,14 +72,15 @@ public class CommonReflector
         Constructor<?> constructor = getConstructor( startupReportConfiguration, boolean.class, boolean.class,
                                                            String.class, boolean.class, boolean.class, File.class,
                                                            boolean.class, String.class, File.class, boolean.class,
-                                                           int.class, String.class );
+                                                           int.class, String.class, String.class );
         //noinspection BooleanConstructorCall
         Object[] params = { reporterConfiguration.isUseFile(), reporterConfiguration.isPrintSummary(),
             reporterConfiguration.getReportFormat(), reporterConfiguration.isRedirectTestOutputToFile(),
             reporterConfiguration.isDisableXmlReport(), reporterConfiguration.getReportsDirectory(),
             reporterConfiguration.isTrimStackTrace(), reporterConfiguration.getReportNameSuffix(),
             reporterConfiguration.getStatisticsFile(), reporterConfiguration.isRequiresRunHistory(),
-            reporterConfiguration.getRerunFailingTestsCount(), reporterConfiguration.getXsdSchemaLocation() };
+            reporterConfiguration.getRerunFailingTestsCount(), reporterConfiguration.getXsdSchemaLocation(),
+            reporterConfiguration.getEncoding().name() };
         return newInstance( constructor, params );
     }
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireExecutionParameters.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/SurefireExecutionParameters.java
@@ -118,6 +118,10 @@ public interface SurefireExecutionParameters
 
     void setUseManifestOnlyJar( boolean useManifestOnlyJar );
 
+    String getEncoding();
+
+    void setEncoding( String encoding );
+
     Boolean getFailIfNoSpecifiedTests();
 
     void setFailIfNoSpecifiedTests( boolean failIfNoSpecifiedTests );

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
@@ -22,7 +22,6 @@ package org.apache.maven.plugin.surefire.report;
 import org.apache.maven.plugin.surefire.StartupReportConfiguration;
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.plugin.surefire.log.api.Level;
-import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
 import org.apache.maven.plugin.surefire.runorder.StatisticsReporter;
 import org.apache.maven.shared.utils.logging.MessageBuilder;
 import org.apache.maven.surefire.report.ReporterFactory;
@@ -205,16 +204,6 @@ public class DefaultReporterFactory
     {
         mergeTestHistoryResult();
         return globalStats;
-    }
-
-    /**
-     * For testing purposes only.
-     *
-     * @return DefaultReporterFactory for testing purposes
-     */
-    public static DefaultReporterFactory defaultNoXml()
-    {
-        return new DefaultReporterFactory( StartupReportConfiguration.defaultNoXml(), new NullConsoleLogger() );
     }
 
     /**

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/FileReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/FileReporter.java
@@ -24,9 +24,12 @@ import org.apache.maven.surefire.report.ReporterException;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.List;
 
 import static org.apache.maven.plugin.surefire.report.FileReporterUtils.stripIllegalFilenameChars;
@@ -41,13 +44,14 @@ import static org.apache.maven.surefire.util.internal.StringUtils.isNotBlank;
 public class FileReporter
 {
     private final File reportsDirectory;
-
     private final String reportNameSuffix;
+    private final Charset encoding;
 
-    public FileReporter( File reportsDirectory, String reportNameSuffix )
+    public FileReporter( File reportsDirectory, String reportNameSuffix, Charset encoding )
     {
         this.reportsDirectory = reportsDirectory;
         this.reportNameSuffix = reportNameSuffix;
+        this.encoding = encoding;
     }
 
     private PrintWriter testSetStarting( ReportEntry report )
@@ -61,7 +65,9 @@ public class FileReporter
 
         try
         {
-            PrintWriter writer = new PrintWriter( new BufferedWriter( new FileWriter( reportFile ), 16 * 1024 ) );
+            Writer encodedStream = new OutputStreamWriter( new FileOutputStream( reportFile ), encoding );
+
+            PrintWriter writer = new PrintWriter( new BufferedWriter( encodedStream, 16 * 1024 ) );
 
             writer.println( "-------------------------------------------------------------------------------" );
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullFileReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullFileReporter.java
@@ -35,7 +35,7 @@ class NullFileReporter
 
     private NullFileReporter()
     {
-        super( null, null );
+        super( null, null, null );
     }
 
     @Override

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
@@ -473,6 +473,18 @@ public class AbstractSurefireMojoJava7PlusTest
         }
 
         @Override
+        public String getEncoding()
+        {
+            return null;
+        }
+
+        @Override
+        public void setEncoding( String encoding )
+        {
+
+        }
+
+        @Override
         public Boolean getFailIfNoSpecifiedTests()
         {
             return null;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -494,6 +494,18 @@ public class AbstractSurefireMojoTest
         }
 
         @Override
+        public String getEncoding()
+        {
+            return null;
+        }
+
+        @Override
+        public void setEncoding( String encoding )
+        {
+
+        }
+
+        @Override
         public Boolean getFailIfNoSpecifiedTests()
         {
             return null;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
@@ -19,11 +19,12 @@ package org.apache.maven.plugin.surefire.booterclient;
  * under the License.
  */
 
+import org.apache.maven.plugin.surefire.StartupReportConfiguration;
 import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
 import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
 import org.apache.maven.surefire.report.RunListener;
 
-import static org.apache.maven.plugin.surefire.StartupReportConfiguration.defaultValue;
+import java.io.File;
 
 /**
  * Internal tests use only.
@@ -42,5 +43,19 @@ public class TestSetMockReporterFactory
     public RunListener createReporter()
     {
         return new MockReporter();
+    }
+
+
+    /**
+     * For testing purposes only.
+     *
+     * @return StartupReportConfiguration fo testing purposes
+     */
+    private static StartupReportConfiguration defaultValue()
+    {
+        File target = new File( "./target" );
+        File statisticsFile = new File( target, "TESTHASH" );
+        return new StartupReportConfiguration( true, true, "PLAIN", false, false, target, false, null, statisticsFile,
+                false, 0, null, null );
     }
 }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
@@ -66,7 +66,7 @@ public class DefaultReporterFactoryTest
         File reportsDirectory = new File("target");
         StartupReportConfiguration reportConfig =
                 new StartupReportConfiguration( true, true, "PLAIN", false, false, reportsDirectory, false, null,
-                                                      new File( reportsDirectory, "TESTHASH" ), false, 1, null );
+                                                      new File( reportsDirectory, "TESTHASH" ), false, 1, null, null );
 
         DummyTestReporter reporter = new DummyTestReporter();
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/report/ConsoleOutputFileReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/report/ConsoleOutputFileReporterTest.java
@@ -20,9 +20,15 @@ package org.apache.maven.surefire.report;
  */
 
 import java.io.File;
+import java.io.IOException;
+
 import org.apache.maven.plugin.surefire.report.ConsoleOutputFileReporter;
 
 import junit.framework.TestCase;
+import org.apache.maven.shared.utils.io.FileUtils;
+
+import static org.apache.maven.surefire.util.internal.StringUtils.US_ASCII;
+import static org.fest.assertions.Assertions.assertThat;
 
 public class ConsoleOutputFileReporterTest
     extends TestCase
@@ -32,42 +38,52 @@ public class ConsoleOutputFileReporterTest
 
     private ReportEntry reportEntry;
 
-    private static final String testName = "org.apache.maven.surefire.report.ConsoleOutputFileReporterTest";
+    private static final String testName = ConsoleOutputFileReporterTest.class.getName();
 
     /*
      * Test method for 'org.codehaus.surefire.report.ConsoleOutputFileReporter.testSetCompleted(ReportEntry report)'
      */
-    public void testFileNameWithoutSuffix()
+    public void testFileNameWithoutSuffix() throws IOException
     {
-        File reportDir = new File( System.getProperty( "java.io.tmpdir" ) );
-        reportEntry = new SimpleReportEntry( this.getClass().getName(), testName );
+        File reportDir = new File( new File( System.getProperty( "user.dir" ), "target" ), "tmp" );
+        //noinspection ResultOfMethodCallIgnored
+        reportDir.mkdirs();
+        reportEntry = new SimpleReportEntry( getClass().getName(), testName );
         reporter = new ConsoleOutputFileReporter( reportDir, null );
         reporter.testSetStarting( reportEntry );
-        reporter.writeTestOutput( "some text".getBytes(), 0, 5, true );
+        reporter.writeTestOutput( "some text".getBytes( US_ASCII ), 0, 5, true );
         reporter.testSetCompleted( reportEntry );
+        reporter.close();
 
         File expectedReportFile = new File( reportDir, testName + "-output.txt" );
         assertTrue( "Report file (" + expectedReportFile.getAbsolutePath() + ") doesn't exist",
                     expectedReportFile.exists() );
+        assertThat( FileUtils.fileRead( expectedReportFile, US_ASCII.name() ) ).contains( "some " );
+        //noinspection ResultOfMethodCallIgnored
         expectedReportFile.delete();
     }
 
     /*
      * Test method for 'org.codehaus.surefire.report.ConsoleOutputFileReporter.testSetCompleted(ReportEntry report)'
      */
-    public void testFileNameWithSuffix()
+    public void testFileNameWithSuffix() throws IOException
     {
-        File reportDir = new File( System.getProperty( "java.io.tmpdir" ) );
+        File reportDir = new File( new File( System.getProperty( "user.dir" ), "target" ), "tmp" );
+        //noinspection ResultOfMethodCallIgnored
+        reportDir.mkdirs();
         String suffixText = "sampleSuffixText";
-        reportEntry = new SimpleReportEntry( this.getClass().getName(), testName );
+        reportEntry = new SimpleReportEntry( getClass().getName(), testName );
         reporter = new ConsoleOutputFileReporter( reportDir, suffixText );
         reporter.testSetStarting( reportEntry );
-        reporter.writeTestOutput( "some text".getBytes(), 0, 5, true );
+        reporter.writeTestOutput( "some text".getBytes( US_ASCII ), 0, 5, true );
         reporter.testSetCompleted( reportEntry );
+        reporter.close();
 
         File expectedReportFile = new File( reportDir, testName + "-" + suffixText + "-output.txt" );
         assertTrue( "Report file (" + expectedReportFile.getAbsolutePath() + ") doesn't exist",
                     expectedReportFile.exists() );
+        assertThat( FileUtils.fileRead( expectedReportFile, US_ASCII.name() ) ).contains( "some " );
+        //noinspection ResultOfMethodCallIgnored
         expectedReportFile.delete();
     }
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/report/FileReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/report/FileReporterTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.surefire.report;
  */
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import org.apache.maven.plugin.surefire.report.FileReporter;
 import org.apache.maven.plugin.surefire.report.ReportEntryType;
@@ -44,12 +45,13 @@ public class FileReporterTest
         reportEntry = new SimpleReportEntry( this.getClass().getName(), testName );
         WrappedReportEntry wrappedReportEntry =
             new WrappedReportEntry( reportEntry, ReportEntryType.SUCCESS, 12, null, null );
-        reporter = new FileReporter( reportDir, null );
+        reporter = new FileReporter( reportDir, null, Charset.defaultCharset() );
         reporter.testSetCompleted( wrappedReportEntry, createTestSetStats(), new ArrayList<String>() );
 
         File expectedReportFile = new File( reportDir, testName + ".txt" );
         assertTrue( "Report file (" + expectedReportFile.getAbsolutePath() + ") doesn't exist",
                     expectedReportFile.exists() );
+        //noinspection ResultOfMethodCallIgnored
         expectedReportFile.delete();
     }
 
@@ -65,13 +67,13 @@ public class FileReporterTest
         reportEntry = new SimpleReportEntry( this.getClass().getName(), testName );
         WrappedReportEntry wrappedReportEntry =
             new WrappedReportEntry( reportEntry, ReportEntryType.SUCCESS, 12, null, null );
-        reporter = new FileReporter( reportDir, suffixText );
+        reporter = new FileReporter( reportDir, suffixText, Charset.defaultCharset() );
         reporter.testSetCompleted( wrappedReportEntry, createTestSetStats(), new ArrayList<String>() );
 
         File expectedReportFile = new File( reportDir, testName + "-" + suffixText + ".txt" );
         assertTrue( "Report file (" + expectedReportFile.getAbsolutePath() + ") doesn't exist",
                     expectedReportFile.exists() );
+        //noinspection ResultOfMethodCallIgnored
         expectedReportFile.delete();
     }
-
 }

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -237,6 +237,16 @@ public class SurefirePlugin
     private boolean useManifestOnlyJar;
 
     /**
+     * The character encoding scheme to be applied while generating test report
+     * files (see target/surefire-reports/yourTestName.txt).
+     * The report output files (*-out.txt) are still encoded with JVM's encoding used in standard out/err pipes.
+     *
+     * @since 3.0.0-M1
+     */
+    @Parameter( property = "surefire.encoding", defaultValue = "${project.reporting.outputEncoding}" )
+    private String encoding;
+
+    /**
      * (JUnit 4+ providers)
      * The number of times each failing test will be rerun. If set larger than 0, rerun failing tests immediately after
      * they fail. If a failing test passes in any of those reruns, it will be marked as pass and reported as a "flake".
@@ -511,6 +521,18 @@ public class SurefirePlugin
     public void setUseManifestOnlyJar( boolean useManifestOnlyJar )
     {
         this.useManifestOnlyJar = useManifestOnlyJar;
+    }
+
+    @Override
+    public String getEncoding()
+    {
+        return encoding;
+    }
+
+    @Override
+    public void setEncoding( String encoding )
+    {
+        this.encoding = encoding;
     }
 
     @Override

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/UnicodeTestNamesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/UnicodeTestNamesIT.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static org.apache.commons.io.Charsets.UTF_8;
+import static org.apache.maven.surefire.its.fixture.HelperAssertions.convertUnicodeToUTF8;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
@@ -37,6 +39,7 @@ import static org.junit.Assume.assumeFalse;
 public class UnicodeTestNamesIT
         extends SurefireJUnit4IntegrationTestCase
 {
+    private static final String REPORT_FILE_CONTENT = "junit.twoTestCases.\u800C\u7D22\u5176\u60C5Test";
     private static final String TXT_REPORT = "junit.twoTestCases.\u800C\u7D22\u5176\u60C5Test.txt";
     private static final String XML_REPORT = "TEST-junit.twoTestCases.\u800C\u7D22\u5176\u60C5Test.xml";
 
@@ -62,14 +65,17 @@ public class UnicodeTestNamesIT
                 unpacked.executeTest()
                         .assertTestSuiteResults( 2, 0, 0, 0 );
 
-        TestFile surefireReportFile = outputValidator.getSurefireReportsFile( TXT_REPORT );
+        TestFile surefireReportFile = outputValidator.getSurefireReportsFile( TXT_REPORT, UTF_8 );
         assertTrue( surefireReportFile.exists() );
-        surefireReportFile.assertContainsText( "junit.twoTestCases.????Test" );
+
+        // See src/test/resources/unicode-testnames/pom.xml and property project.build.sourceEncoding set to UTF-8.
+        surefireReportFile.assertContainsText( convertUnicodeToUTF8( REPORT_FILE_CONTENT ) );
 
         TestFile surefireXmlReportFile = outputValidator.getSurefireReportsXmlFile( XML_REPORT );
         assertTrue( surefireXmlReportFile.exists() );
         assertFalse( surefireXmlReportFile.readFileToString().isEmpty() );
-        surefireXmlReportFile.assertContainsText( "junit.twoTestCases.\u800C\u7D22\u5176\u60C5Test" );
-    }
 
+        // See src/test/resources/unicode-testnames/pom.xml and property project.build.sourceEncoding set to UTF-8.
+        surefireXmlReportFile.assertContainsText( convertUnicodeToUTF8( REPORT_FILE_CONTENT ) );
+    }
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/HelperAssertions.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/HelperAssertions.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.apache.commons.io.Charsets.UTF_8;
 import static org.junit.Assume.assumeTrue;
 
 @SuppressWarnings( { "JavaDoc" } )
@@ -170,5 +171,10 @@ public class HelperAssertions
         String thisVersion = System.getProperty( "java.specification.version" );
         assumeTrue( "java.specification.version: " + thisVersion,
                 Double.valueOf( thisVersion ) >= expectedVersion );
+    }
+
+    public static String convertUnicodeToUTF8( String unicode )
+    {
+        return new String( unicode.getBytes( UTF_8 ), UTF_8 );
     }
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/OutputValidator.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/OutputValidator.java
@@ -182,10 +182,15 @@ public class OutputValidator
         return new TestFile( new File( targetDir, fileName ), this );
     }
 
-    public TestFile getSurefireReportsFile( String fileName )
+    public TestFile getSurefireReportsFile( String fileName, Charset charset )
     {
         File targetDir = getSurefireReportsDirectory();
-        return new TestFile( new File( targetDir, fileName ), this );
+        return new TestFile( new File( targetDir, fileName ), charset, this );
+    }
+
+    public TestFile getSurefireReportsFile( String fileName )
+    {
+        return getSurefireReportsFile( fileName, null );
     }
 
     public TestFile getSurefireReportsXmlFile( String fileName )

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/TestFile.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/TestFile.java
@@ -53,7 +53,7 @@ public class TestFile
     public TestFile( File file, Charset charset, OutputValidator surefireVerifier )
     {
         this.file = file;
-        this.encoding = charset;
+        this.encoding = charset == null ? Charset.defaultCharset() : charset;
         this.surefireVerifier = surefireVerifier;
     }
 

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire141PluggableProvidersIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire141PluggableProvidersIT.java
@@ -155,25 +155,11 @@ public class Surefire141PluggableProvidersIT
         try
         {
             validator.verifyTextInLog( errorText );
-            return  true;
+            return true;
         }
         catch ( SurefireVerifierException e )
         {
             return false;
         }
     }
-
-    private static boolean verifiedErrorInDump( OutputValidator validator, String errorText )
-    {
-        try
-        {
-            assertErrorMessage( validator, errorText );
-            return true;
-        }
-        catch ( AssertionError e )
-        {
-            return false;
-        }
-    }
-
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire975DefaultVMEncodingIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire975DefaultVMEncodingIT.java
@@ -23,6 +23,8 @@ import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.junit.Test;
 
+import static org.apache.maven.surefire.its.fixture.HelperAssertions.convertUnicodeToUTF8;
+
 public class Surefire975DefaultVMEncodingIT
     extends SurefireJUnit4IntegrationTestCase
 {
@@ -34,7 +36,8 @@ public class Surefire975DefaultVMEncodingIT
         OutputValidator outputValidator =
             unpack( "surefire-975-wrong-encoding" ).setMavenOpts( "-Dfile.encoding=windows-1251" ).executeTest();
         outputValidator.getSurefireReportsXmlFile( "TEST-EncodingInReportTest.xml" ).assertContainsText(
-            "\u043A\u0438\u0440\u0438\u043B\u043B\u0438\u0446\u0435" );
+                // see project.build.sourceEncoding=UTF-8 in src/test/resources/surefire-975-wrong-encoding/pom.xml
+                convertUnicodeToUTF8( "\u043A\u0438\u0440\u0438\u043B\u043B\u0438\u0446\u0435" ) );
     }
 
 }

--- a/surefire-its/src/test/resources/unicode-testnames/pom.xml
+++ b/surefire-its/src/test/resources/unicode-testnames/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
   </properties>

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/ConcurrentRunListenerTest.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/ConcurrentRunListenerTest.java
@@ -382,7 +382,7 @@ public class ConcurrentRunListenerTest
 
     private DefaultReporterFactory createReporterFactory()
     {
-        return DefaultReporterFactory.defaultNoXml();
+        return JUnitCoreTester.defaultNoXml();
     }
 
 

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
@@ -19,6 +19,8 @@ package org.apache.maven.surefire.junitcore;
  * under the License.
  */
 
+import org.apache.maven.plugin.surefire.StartupReportConfiguration;
+import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
 import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
 import org.apache.maven.surefire.report.ConsoleOutputReceiver;
 import org.apache.maven.surefire.report.DefaultDirectConsoleReporter;
@@ -29,6 +31,7 @@ import org.junit.runner.Computer;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
 
@@ -40,7 +43,6 @@ import static org.apache.maven.surefire.report.ConsoleOutputCapture.startCapture
  */
 public class JUnitCoreTester
 {
-
     private final Computer computer;
 
     public JUnitCoreTester()
@@ -56,7 +58,7 @@ public class JUnitCoreTester
     public Result run( boolean parallelClasses, Class<?>... classes )
         throws TestSetFailedException, ExecutionException
     {
-        ReporterFactory reporterManagerFactory = DefaultReporterFactory.defaultNoXml();
+        ReporterFactory reporterManagerFactory = defaultNoXml();
 
         try
         {
@@ -83,5 +85,26 @@ public class JUnitCoreTester
         }
     }
 
+    /**
+     * For testing purposes only.
+     *
+     * @return DefaultReporterFactory for testing purposes
+     */
+    public static DefaultReporterFactory defaultNoXml()
+    {
+        return new DefaultReporterFactory( defaultStartupReportConfiguration(), new NullConsoleLogger() );
+    }
 
+    /**
+     * For testing purposes only.
+     *
+     * @return StartupReportConfiguration fo testing purposes
+     */
+    private static StartupReportConfiguration defaultStartupReportConfiguration()
+    {
+        File target = new File( "./target" );
+        File statisticsFile = new File( target, "TESTHASHxXML" );
+        return new StartupReportConfiguration( true, true, "PLAIN", false, true, target, false, null, statisticsFile,
+                false, 0, null, null );
+    }
 }

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/Surefire746Test.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/Surefire746Test.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
 import org.apache.maven.surefire.booter.BaseProviderFactory;
 import org.apache.maven.surefire.booter.ProviderParameterNames;
 import org.apache.maven.surefire.common.junit4.JUnit4RunListener;
@@ -87,7 +86,7 @@ public class Surefire746Test
     public void surefireIsConfused_ByMultipleIgnore_OnClassLevel()
         throws Exception
     {
-        ReporterFactory reporterFactory = DefaultReporterFactory.defaultNoXml();
+        ReporterFactory reporterFactory = JUnitCoreTester.defaultNoXml();
         BaseProviderFactory providerParameters = new BaseProviderFactory( reporterFactory, true );
 
         providerParameters.setReporterConfiguration( new ReporterConfiguration( new File( "" ), false ) );


### PR DESCRIPTION
Related to JIRA [SUREFIRE-1495](https://issues.apache.org/jira/browse/SUREFIRE-1495).