### PR TITLE
[SUREFIRE-1498] Surefire prints own logs "Couldn't load group class" to native stream.

### DIFF
--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreProvider.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreProvider.java
@@ -122,11 +122,11 @@ public class JUnitCoreProvider
 
         final ConsoleStream consoleStream = providerParameters.getConsoleLogger();
 
-        Filter filter = jUnit48Reflector.isJUnit48Available() ? createJUnit48Filter() : null;
-
         Notifier notifier =
             new Notifier( createRunListener( reporterFactory, consoleStream ), getSkipAfterFailureCount() );
         // startCapture() called in createRunListener() in prior to setTestsToRun()
+
+        Filter filter = jUnit48Reflector.isJUnit48Available() ? createJUnit48Filter() : null;
 
         if ( testsToRun == null )
         {


### PR DESCRIPTION
Related to JIRA [SUREFIRE-1498](https://issues.apache.org/jira/browse/SUREFIRE-1498).