### PR TITLE
[SUREFIRE-1522] fix escapeBytesToPrintable bounds check

### DIFF
--- a/surefire-api/src/main/java/org/apache/maven/surefire/util/internal/StringUtils.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/util/internal/StringUtils.java
@@ -233,7 +233,7 @@ public final class StringUtils
      * @return number of bytes written to {@code out}
      * @throws NullPointerException if the specified parameter {@code header} or {@code input} is null
      * @throws IndexOutOfBoundsException if {@code off} or {@code len} is out of range
-     *         ({@code off < 0 || len < 0 || off >= input.length || len > input.length || off > len})
+     *         ({@code off < 0 || len < 0 || off >= input.length || len > input.length || off + len > input.length})
      */
     @SuppressWarnings( "checkstyle:magicnumber" )
     public static EncodedArray escapeBytesToPrintable( final byte[] header, final byte[] input, final int off,
@@ -243,10 +243,10 @@ public final class StringUtils
         {
             return EncodedArray.EMPTY;
         }
-        if ( off < 0 || len < 0 || off >= input.length || len > input.length || off > len )
+        if ( off < 0 || len < 0 || off >= input.length || len > input.length || off + len > input.length )
         {
             throw new IndexOutOfBoundsException(
-                    "off < 0 || len < 0 || off >= input.length || len > input.length || off > len" );
+                    "off < 0 || len < 0 || off >= input.length || len > input.length || off + len > input.length" );
         }
         // Hex-escaping can be up to 3 times length of a regular byte. Last character is '\n', see (+1).
         final byte[] encodeBytes = new byte[header.length + 3 * len + 1];

--- a/surefire-api/src/test/java/org/apache/maven/surefire/util/internal/StringUtilsTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/util/internal/StringUtilsTest.java
@@ -119,4 +119,24 @@ public class StringUtilsTest
         assertEquals( 0, encodedArray.getSize() );
         assertEquals( 0, encodedArray.getArray().length );
     }
+
+    public void testSubstringSmall()
+    {
+        byte[] header = { (byte) 'a' };
+        byte[] input = "PleaseLookAfterThisBear".getBytes();
+        EncodedArray encodedArray = StringUtils.escapeBytesToPrintable( header, input,
+                "Please".length(), "Look".length() );
+        assertEquals( "Look",
+                new String( encodedArray.getArray(), 1, encodedArray.getArray().length-1).trim() );
+    }
+
+    public void testSubstringLarge()
+    {
+        byte[] header = { (byte) 'a' };
+        byte[] input = "TheQuickBrownFoxJumpsOverTheLazyDog".getBytes();
+        EncodedArray encodedArray = StringUtils.escapeBytesToPrintable( header, input,
+                "The".length(), "QuickBrownFoxJumpsOverTheLazy".length() );
+        assertEquals( "QuickBrownFoxJumpsOverTheLazy",
+                new String( encodedArray.getArray(), 1, encodedArray.getArray().length-1).trim() );
+    }
 }


### PR DESCRIPTION
Proposed new regression test and accompanying fix for SUREFIRE-1522: https://issues.apache.org/jira/browse/SUREFIRE-1522

The array bounds check now compares off+len to the source length, rather than off to len.