### PR TITLE
[SUREFIRE-1532]  MIME type for javascript is now officially application/javascript

### DIFF
--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
@@ -78,7 +78,7 @@ public final class SurefireReportGenerator
         sink.body();
 
         SinkEventAttributeSet atts = new SinkEventAttributeSet();
-        atts.addAttribute( TYPE, "text/javascript" );
+        atts.addAttribute( TYPE, "application/javascript" );
         sink.unknown( "script", new Object[]{ HtmlMarkup.TAG_TYPE_START }, atts );
         sink.unknown( "cdata", new Object[]{ HtmlMarkup.CDATA_TYPE, javascriptToggleDisplayCode() }, null );
         sink.unknown( "script", new Object[]{ HtmlMarkup.TAG_TYPE_END }, null );


### PR DESCRIPTION
https://stackoverflow.com/questions/189850/what-is-the-javascript-mime-type-for-the-type-attribute-of-a-script-tag

"This is a common mistake. The MIME type for javascript wasn't standardized for years. It's now officially: "application/javascript"."
http://www.rfc-editor.org/rfc/rfc4329.txt