### PR TITLE
[SUREFIRE-1538] Let Git handle PNG files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 *.css    text
 *.js     text
 *.sql    text
+*.PNG    -text


### PR DESCRIPTION
Otherweise Git tries to add a linefeed at the end of the file.

JIRA issue: [Git considers PNG files as changed although there is no change](https://issues.apache.org/jira/browse/SUREFIRE-1538)