### PR TITLE
[SUREFIRE-1564] ensure provider dependencies can be overriden

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -2856,7 +2856,7 @@ public abstract class AbstractSurefireMojo
         {
             Artifact surefireArtifact = getPluginArtifactMap().get( "org.apache.maven.surefire:surefire-booter" );
             return dependencyResolver.getProviderClasspath( "surefire-testng", surefireArtifact.getBaseVersion(),
-                                                            testNgArtifact );
+                                                            testNgArtifact, project );
         }
     }
 
@@ -2888,7 +2888,7 @@ public abstract class AbstractSurefireMojo
             // add the JUnit provider as default - it doesn't require JUnit to be present,
             // since it supports POJO tests.
             return dependencyResolver.getProviderClasspath( "surefire-junit3", surefireBooterArtifact.getBaseVersion(),
-                                                            null );
+                                                            null, project );
 
         }
     }
@@ -2929,7 +2929,7 @@ public abstract class AbstractSurefireMojo
             throws ArtifactResolutionException, ArtifactNotFoundException
         {
             return dependencyResolver.getProviderClasspath( "surefire-junit4", surefireBooterArtifact.getBaseVersion(),
-                                                            null );
+                                                            null, project );
         }
 
     }
@@ -2964,7 +2964,7 @@ public abstract class AbstractSurefireMojo
         {
             return dependencyResolver.getProviderClasspath( "surefire-junit-platform",
                                                             surefireBooterArtifact.getBaseVersion(),
-                                                            null );
+                                                            null, project );
         }
     }
 
@@ -3013,7 +3013,7 @@ public abstract class AbstractSurefireMojo
             throws ArtifactResolutionException, ArtifactNotFoundException
         {
             return dependencyResolver.getProviderClasspath( "surefire-junit47", surefireBooterArtifact.getBaseVersion(),
-                                                            null );
+                                                            null, project );
         }
     }
 


### PR DESCRIPTION
 either by the plugin definition or through project dependencies (in this order to let the plugin force a transitive dependency of the test stack), fixes the fact JUnit 5 integration is broken with 5.3.0 release