### PR TITLE
MIME type for javascript is now officially application/javascript

### DIFF
--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
@@ -78,9 +78,9 @@ public final class SurefireReportGenerator
         sink.body();
 
         SinkEventAttributeSet atts = new SinkEventAttributeSet();
-        atts.addAttribute( TYPE, "text/javascript" );
+        atts.addAttribute( TYPE, "application/javascript" );
         sink.unknown( "script", new Object[]{ HtmlMarkup.TAG_TYPE_START }, atts );
-        sink.unknown( "cdata", new Object[]{ HtmlMarkup.CDATA_TYPE, javascriptToggleDisplayCode() }, null );
+        sink.unknown( "pcdata", new Object[]{ HtmlMarkup.PCDATA_TYPE, javascriptToggleDisplayCode() }, null );
         sink.unknown( "script", new Object[]{ HtmlMarkup.TAG_TYPE_END }, null );
 
         sink.section1();
@@ -745,8 +745,8 @@ public final class SurefireReportGenerator
     private static String javascriptToggleDisplayCode()
     {
 
-        // the javascript code is emitted within a commented CDATA section
-        // so we have to start with a newline and comment the CDATA closing in the end
+        // the javascript code is emitted within a commented PCDATA section
+        // so we have to start with a newline and comment the PCDATA closing in the end
 
         return "\n" + "function toggleDisplay(elementId) {\n"
                 + " var elm = document.getElementById(elementId + '-error');\n"


### PR DESCRIPTION
 mime js from text/javascript to application/javascript

https://stackoverflow.com/questions/189850/what-is-the-javascript-mime-type-for-the-type-attribute-of-a-script-tag

"This is a common mistake. The MIME type for javascript wasn't standardized for years. It's now officially: "application/javascript"."
http://www.rfc-editor.org/rfc/rfc4329.txt
https://github.com/apache/maven-surefire/pull/188

ain/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
@@ -78,7 +78,7 @@ public void doGenerateReport( LocalizedProperties bundle, Sink sink )
        atts.addAttribute( TYPE, "text/javascript" );
        atts.addAttribute( TYPE, "application/javascript" );

 Please run the build locally. You will see this error
 testWithIdenticalNames(org.apache.maven.surefire.its.jiras.Surefire260TestWithIdenticalNamesIT):
 ReferenceError: "toggleDisplay" is not defined. (javascript url#184)
 I am not sure if this is the only one.
 Feel free to run the build like this mvn install -P run-its. See the README. There are instructions to use JDK8+.
 Do not worry if it takes one hour to complete.
 One hint, do not overload the PC with other tasks. The build has performance tests and if the delays are paused by overloaded CPU, other tests fail.
 Squash all changes in one commit.

>>>>>
 https://www.w3schools.com/tags/tag_script.asp
 Differences Between HTML and XHTML

 In XHTML, the content inside scripts is declared as #PCDATA (instead of CDATA), which means that entities will be parsed.

 This means that in XHTML, all special characters should be encoded, or all content should be wrapped inside a CDATA section

https://maven.apache.org/surefire/maven-surefire-report-plugin/surefire-report.html