### PR TITLE
SUREFIRE-1588 Patch (Java7)

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/DefaultForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/DefaultForkConfiguration.java
@@ -332,4 +332,10 @@ public abstract class DefaultForkConfiguration
     {
         return config.isShadefire() ? relocate( DEFAULT_PROVIDER_CLASS ) : DEFAULT_PROVIDER_CLASS;
     }
+
+    @Nonnull
+    protected ConsoleLogger getConsoleLogger()
+    {
+        return log;
+    }
 }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/DefaultForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/DefaultForkConfiguration.java
@@ -332,10 +332,4 @@ public abstract class DefaultForkConfiguration
     {
         return config.isShadefire() ? relocate( DEFAULT_PROVIDER_CLASS ) : DEFAULT_PROVIDER_CLASS;
     }
-
-    @Nonnull
-    protected ConsoleLogger getConsoleLogger()
-    {
-        return log;
-    }
 }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
@@ -114,7 +115,7 @@ public final class JarManifestForkConfiguration
             {
                 File file1 = new File( it.next() );
 
-                String uri = parent.relativize( file1.toPath() ).toString();
+                String uri = URI.create( parent.relativize( file1.toPath() ).toString() ).toASCIIString();
                 cp.append( uri );
                 if ( file1.isDirectory() && !uri.endsWith( "/" ) )
                 {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
@@ -123,7 +123,6 @@ public final class JarManifestForkConfiguration
                 catch ( IllegalArgumentException e )
                 {
                     uri = file1.toURI().toASCIIString();
-                    getConsoleLogger().warning( "Boot Manifest-JAR contains absolute paths in classpath" );
                 }
                 catch ( URISyntaxException e )
                 {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
@@ -114,8 +114,17 @@ public final class JarManifestForkConfiguration
             for ( Iterator<String> it = classPath.iterator(); it.hasNext(); )
             {
                 File file1 = new File( it.next() );
+                String uri;
+                try
+                {
+                    uri = URI.create( parent.relativize( file1.toPath() ).toString() ).toASCIIString();
+                }
+                catch ( IllegalArgumentException e )
+                {
+                    uri = file1.toURI().toASCIIString();
+                    getConsoleLogger().warning( "Boot Manifest-JAR contains absolute paths in classpath" );
+                }
 
-                String uri = URI.create( parent.relativize( file1.toPath() ).toString() ).toASCIIString();
                 cp.append( uri );
                 if ( file1.isDirectory() && !uri.endsWith( "/" ) )
                 {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -95,6 +96,7 @@ public final class JarManifestForkConfiguration
         {
             file.deleteOnExit();
         }
+        Path parent = file.getParentFile().toPath();
         FileOutputStream fos = new FileOutputStream( file );
         JarOutputStream jos = new JarOutputStream( fos );
         try
@@ -111,7 +113,8 @@ public final class JarManifestForkConfiguration
             for ( Iterator<String> it = classPath.iterator(); it.hasNext(); )
             {
                 File file1 = new File( it.next() );
-                String uri = file1.toURI().toASCIIString();
+
+                String uri = parent.relativize( file1.toPath() ).toString();
                 cp.append( uri );
                 if ( file1.isDirectory() && !uri.endsWith( "/" ) )
                 {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
@@ -117,12 +118,17 @@ public final class JarManifestForkConfiguration
                 String uri;
                 try
                 {
-                    uri = URI.create( parent.relativize( file1.toPath() ).toString() ).toASCIIString();
+                    uri = new URI( null, parent.relativize( file1.toPath() ).toString(), null ).toASCIIString();
                 }
                 catch ( IllegalArgumentException e )
                 {
                     uri = file1.toURI().toASCIIString();
                     getConsoleLogger().warning( "Boot Manifest-JAR contains absolute paths in classpath" );
+                }
+                catch ( URISyntaxException e )
+                {
+                    // This is really unexpected, so fail
+                    throw new IOException( "Could not relativize path " + file1 + " against " + parent, e );
                 }
 
                 cp.append( uri );

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
   </distributionManagement>
 
   <properties>
+    <javaVersion>7</javaVersion>
     <mavenVersion>2.2.1</mavenVersion>
     <!-- <shadedVersion>2.12.4</shadedVersion> commented out due to https://issues.apache.org/jira/browse/MRELEASE-799 -->
     <commonsLang3Version>3.5</commonsLang3Version>
@@ -434,8 +435,8 @@
               <configuration>
                 <signature>
                   <groupId>org.codehaus.mojo.signature</groupId>
-                  <artifactId>java16</artifactId>
-                  <version>1.1</version>
+                  <artifactId>java17</artifactId>
+                  <version>1.0</version>
                 </signature>
                 <excludeDependencies>
                   <param>org.codehaus.plexus:plexus-java</param>


### PR DESCRIPTION
The `JarManifestForkConfiguration.java` changes that makes Surefire 2.22.1 work for me ;)

Still, this is not a "real" solution, as surefire (for me unnkown reasons) is set to Java6. So, 2nd commit is laxing this, and am happy to use this "patched" surefire on my machine as my shop is Java8+.

Code is done against `surefire-2.22.1` tag, but the PR is targeting master as there is no branch for 2.22.x?