### PR TITLE
[SUREFIRE-1593] Correcting relativization logic to produce valid URIs on Windows

### DIFF
--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfigurationTest.java
@@ -1,0 +1,119 @@
+package org.apache.maven.plugin.surefire.booterclient;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import org.apache.maven.plugin.surefire.booterclient.output.InPluginProcessDumpSingleton;
+import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.*;
+import static org.powermock.api.mockito.PowerMockito.*;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * Unit tests for {@link JarManifestForkConfiguration}.
+ */
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( { JarManifestForkConfiguration.class, InPluginProcessDumpSingleton.class } )
+public class JarManifestForkConfigurationTest
+{
+
+    @Test
+    public void relativeClasspathUnixSimple()
+        throws Exception
+    {
+        mockStatic( JarManifestForkConfiguration.class );
+        String parent = "/home/me/prj/target/surefire";
+        String classPathElement = "/home/me/.m2/repository/grp/art/1.0/art-1.0.jar";
+        when( JarManifestForkConfiguration.relativize( parent, classPathElement ) ).
+                thenReturn( "../../../.m2/repository/grp/art/1.0/art-1.0.jar" );
+        when( JarManifestForkConfiguration.toClasspathElementUri( anyString(), anyString(), any( File.class ) ) ).
+                thenCallRealMethod();
+        assertThat( JarManifestForkConfiguration.toClasspathElementUri( parent, classPathElement, new File(".") ) ).
+                isEqualTo( "../../../.m2/repository/grp/art/1.0/art-1.0.jar" );
+    }
+
+    @Test
+    public void relativeClasspathUnixTricky()
+        throws Exception
+    {
+        mockStatic( JarManifestForkConfiguration.class );
+        String parent = "/home/me/prj/target/surefire";
+        String classPathElement = "/the Maven repo/grp/art/1.0/art-1.0.jar";
+        when( JarManifestForkConfiguration.relativize( parent, classPathElement ) ).
+                thenReturn( "../../../../../the Maven repo/grp/art/1.0/art-1.0.jar" );
+        when( JarManifestForkConfiguration.toClasspathElementUri( anyString(), anyString(), any( File.class ) ) ).
+                thenCallRealMethod();
+        assertThat( JarManifestForkConfiguration.toClasspathElementUri( parent, classPathElement, new File(".") ) ).
+                isEqualTo( "../../../../../the%20Maven%20repo/grp/art/1.0/art-1.0.jar" );
+    }
+
+    @Test
+    public void relativeClasspathWindowsSimple()
+        throws Exception
+    {
+        mockStatic( JarManifestForkConfiguration.class );
+        String parent = "C:\\Windows\\Temp\\surefire";
+        String classPathElement = "C:\\Users\\me\\.m2\\repository\\grp\\art\\1.0\\art-1.0.jar";
+        when( JarManifestForkConfiguration.relativize( parent, classPathElement ) ).
+                thenReturn( "..\\..\\..\\Users\\me\\.m2\\repository\\grp\\art\\1.0\\art-1.0.jar" );
+        when( JarManifestForkConfiguration.toClasspathElementUri( anyString(), anyString(), any( File.class ) ) ).
+                thenCallRealMethod();
+        assertThat( JarManifestForkConfiguration.toClasspathElementUri( parent, classPathElement, new File(".") ) ).
+                isEqualTo( "../../../Users/me/.m2/repository/grp/art/1.0/art-1.0.jar" );
+    }
+
+    @Test
+    public void relativeClasspathWindowsTricky()
+        throws Exception
+    {
+        mockStatic( JarManifestForkConfiguration.class );
+        String parent = "C:\\Windows\\Temp\\surefire";
+        String classPathElement = "C:\\Test User\\me\\.m2\\repository\\grp\\art\\1.0\\art-1.0.jar";
+        when( JarManifestForkConfiguration.relativize( parent, classPathElement ) ).
+                thenReturn( "..\\..\\..\\Test User\\me\\.m2\\repository\\grp\\art\\1.0\\art-1.0.jar" );
+        when( JarManifestForkConfiguration.toClasspathElementUri( anyString(), anyString(), any( File.class ) ) ).
+                thenCallRealMethod();
+        assertThat( JarManifestForkConfiguration.toClasspathElementUri( parent, classPathElement, new File(".") ) ).
+                isEqualTo( "../../../Test%20User/me/.m2/repository/grp/art/1.0/art-1.0.jar" );
+    }
+
+    @Test
+    public void crossDriveWindows()
+        throws Exception
+    {
+        mockStatic( JarManifestForkConfiguration.class );
+        mockStatic( InPluginProcessDumpSingleton.class );
+        when( InPluginProcessDumpSingleton.getSingleton() ).thenReturn(mock( InPluginProcessDumpSingleton.class ));
+        String parent = "C:\\Windows\\Temp\\surefire";
+        String classPathElement = "X:\\Users\\me\\.m2\\repository\\grp\\art\\1.0\\art-1.0.jar";
+        when( JarManifestForkConfiguration.relativize( parent, classPathElement ) ).
+                thenThrow( new IllegalArgumentException() );
+        when( JarManifestForkConfiguration.absoluteUri( classPathElement ) ).
+                thenReturn( "file:///X:/Users/me/.m2/repository/grp/art/1.0/art-1.0.jar" );
+        when( JarManifestForkConfiguration.toClasspathElementUri( anyString(), anyString(), any( File.class ) ) ).
+                thenCallRealMethod();
+        assertThat( JarManifestForkConfiguration.toClasspathElementUri( parent, classPathElement, new File(".") ) ).
+                isEqualTo( "file:///X:/Users/me/.m2/repository/grp/art/1.0/art-1.0.jar" );
+    }
+
+}

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/JUnit4SuiteTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/JUnit4SuiteTest.java
@@ -34,6 +34,7 @@ import org.apache.maven.plugin.surefire.booterclient.BooterDeserializerStartupCo
 import org.apache.maven.plugin.surefire.booterclient.DefaultForkConfigurationTest;
 import org.apache.maven.plugin.surefire.booterclient.ForkConfigurationTest;
 import org.apache.maven.plugin.surefire.booterclient.ForkingRunListenerTest;
+import org.apache.maven.plugin.surefire.booterclient.JarManifestForkConfigurationTest;
 import org.apache.maven.plugin.surefire.booterclient.ModularClasspathForkConfigurationTest;
 import org.apache.maven.plugin.surefire.booterclient.lazytestprovider.TestLessInputStreamBuilderTest;
 import org.apache.maven.plugin.surefire.booterclient.lazytestprovider.TestProvidingInputStreamTest;
@@ -88,6 +89,7 @@ public class JUnit4SuiteTest extends TestCase
         suite.addTest( new JUnit4TestAdapter( SurefireHelperTest.class ) );
         suite.addTest( new JUnit4TestAdapter( AbstractSurefireMojoTest.class ) );
         suite.addTest( new JUnit4TestAdapter( DefaultForkConfigurationTest.class ) );
+        suite.addTest( new JUnit4TestAdapter( JarManifestForkConfigurationTest.class ) );
         suite.addTest( new JUnit4TestAdapter( ModularClasspathForkConfigurationTest.class ) );
         if ( JAVA_RECENT.atLeast( JAVA_1_7 ) )
         {


### PR DESCRIPTION
[SUREFIRE-1593](https://issues.apache.org/jira/browse/SUREFIRE-1593)

Amends #197 or the commits it turned in to. The root issue is that `Path.relativize` uses a native path separator while `URI.path` expects `/`.

Observed errors running Jenkins functional tests on a Windows CI machine in which the system temporary directory (used for the booter as of [SUREFIRE-1400](https://issues.apache.org/jira/browse/SUREFIRE-1400)) used the same drive as the local repository, and Surefire thus attempted relativization.

(When the drives were different, it falls back to the original behavior of using absolute paths, which still works at least on the Windows JDK 8u191. This made it harder for me to reproduce at first. Passing `-Djava.io.tmpdir=…` to `mvn` allows it to be reproduced locally, and to confirm that the test passes when using a snapshot version of Surefire.)

The problem was that `Class-Path` entries included nonsense URIs with components like `..%5C` rather than `../`. The Java class loader is apparently able to load classes from the result, but then the `Class.protectionDomain.codeSource.location` is weird.

@Tibor17 @cstamas