### PR TITLE
[SUREFIRE-1602] Surefire fails loading class ForkedBooter when using a sub-directory pom file and a local maven repo

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/JarManifestForkConfiguration.java
@@ -103,7 +103,7 @@ public final class JarManifestForkConfiguration
         {
             file.deleteOnExit();
         }
-        Path parent = file.getParentFile().toPath();
+        Path parent = file.getParentFile().toPath().normalize();
         FileOutputStream fos = new FileOutputStream( file );
         try ( JarOutputStream jos = new JarOutputStream( fos ) )
         {


### PR DESCRIPTION
Compute Class-Path entries as relative to normalized temporary directory

Signed-off-by: Enrico Olivelli <eolivelli@apache.org>