### PR TITLE
[SUREFIRE-1635] Set properties readonly where it doesn't make sense to change values

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
@@ -109,7 +109,7 @@ public class VerifyMojo
      * The directory containing generated test classes of the project being tested.
      * This will be included at the beginning the test classpath.
      */
-    @Parameter( defaultValue = "${project.build.testOutputDirectory}" )
+    @Parameter( defaultValue = "${project.build.testOutputDirectory}", readonly = true )
     private File testClassesDirectory;
 
     /**

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -197,7 +197,7 @@ public abstract class AbstractSurefireMojo
      * The base directory of the project being tested. This can be obtained in your integration test via
      * System.getProperty("basedir").
      */
-    @Parameter( defaultValue = "${basedir}" )
+    @Parameter( defaultValue = "${basedir}", readonly = true )
     protected File basedir;
 
     /**
@@ -242,11 +242,12 @@ public abstract class AbstractSurefireMojo
     private String[] additionalClasspathElements;
 
     /**
-     * The test source directory containing test class sources.
+     * The test source directory containing test class sources. Only used by the TestNG provider to process JavaDoc
+     * tags.
      *
      * @since 2.2
      */
-    @Parameter( defaultValue = "${project.build.testSourceDirectory}", required = true )
+    @Parameter( defaultValue = "${project.build.testSourceDirectory}", readonly = true )
     private File testSourceDirectory;
 
     /**
@@ -660,7 +661,7 @@ public abstract class AbstractSurefireMojo
      *
      * @since 2.2
      */
-    @Parameter( defaultValue = "${project.pluginArtifactRepositories}" )
+    @Parameter( defaultValue = "${project.pluginArtifactRepositories}", readonly = true )
     private List<ArtifactRepository> remoteRepositories;
 
     /**

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -197,14 +197,14 @@ public abstract class AbstractSurefireMojo
      * The base directory of the project being tested. This can be obtained in your integration test via
      * System.getProperty("basedir").
      */
-    @Parameter( defaultValue = "${basedir}", readonly = true )
+    @Parameter( defaultValue = "${basedir}" )
     protected File basedir;
 
     /**
      * The directory containing generated test classes of the project being tested. This will be included at the
      * beginning of the test classpath. *
      */
-    @Parameter( defaultValue = "${project.build.testOutputDirectory}" )
+    @Parameter( defaultValue = "${project.build.testOutputDirectory}", required = true )
     protected File testClassesDirectory;
 
     /**

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -49,7 +49,7 @@ public class SurefirePlugin
      * The directory containing generated classes of the project being tested. This will be included after the test
      * classes in the test classpath.
      */
-    @Parameter( defaultValue = "${project.build.outputDirectory}" )
+    @Parameter( defaultValue = "${project.build.outputDirectory}", readonly = true )
     private File classesDirectory;
 
     /**


### PR DESCRIPTION
It doesn't make sense for a user to change the values of `remoteRepository`, `basedir` and `testSourceDirectory`. These values are all configured on the project level. Furthermore I've removed the `required` from `testSourcesDirectory` since it has a default value and is now readonly.