### PR TITLE
[SUREFIRE-1004] Support full gavtc format for dependenciesToScan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build
 .classpath
 .project
 .settings
+.checkstyle
 .idea
 .surefire-*
 .DS_Store

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -714,12 +714,28 @@ public abstract class AbstractSurefireMojo
     /**
      * List of dependencies to scan for test classes to include in the test run.
      * The child elements of this element must be &lt;dependency&gt; elements, and the
-     * contents of each of these elements must be a string which follows the format:
-     * <br>
-     * <i>groupId:artifactId</i>. For example: <i>org.acme:project-a</i>.
-     * <br>
-     * Since version 2.22.0 you can scan for test classes from a project
-     * dependency of your multi-module project.
+     * contents of each of these elements must be a string which follows the general form:
+     *
+     * <p>{@code groupId[:artifactId[:type[:classifier][:version]]]}</p>
+     *
+     * <p>The wildcard character <code>*</code> can be used within the sub parts of those composite identifiers to
+     * do glob-like pattern matching. The classifier may be omitted when matching dependencies without a classifier.</p>
+     *
+     * <p>Examples:</p>
+     *
+     * <ul>
+     *     <li>{@code group} or, equivalently, {@code group:*}</li>
+     *     <li>{@code g*p:*rtifac*}</li>
+     *     <li>{@code group:*:jar}</li>
+     *     <li>{@code group:artifact:*:1.0.0} (no classifier)</li>
+     *     <li>{@code group:*:test-jar:tests}</li>
+     *     <li>{@code *:artifact:*:*:1.0.0}</li>
+     * </ul>
+     *
+     * <p>Since version 2.22.0 you can scan for test classes from a project
+     * dependency of your multi-module project.</p>
+     *
+     * <p>In versions before 3.0.0-M4, only <code>groupId:artifactId</code> is supported.</p>
      *
      * @since 2.15
      */

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/util/DependenciesScannerTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/util/DependenciesScannerTest.java
@@ -19,12 +19,17 @@ package org.apache.maven.plugin.surefire.util;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.surefire.testset.TestListResolver;
 import org.apache.maven.surefire.util.ScanResult;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -36,12 +41,16 @@ import java.util.zip.ZipOutputStream;
  * @author Aslak Knutsen
  */
 public class DependenciesScannerTest
-    extends TestCase
 {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
     public void testLocateTestClasses()
         throws Exception
     {
-        File testFile = writeTestFile();
+        File testFile = writeTestFile( "DependenciesScannerTest-tests.jar", "org/test/TestA.class", "org/test/TestB.class" );
 
         // use target as people can configure ide to compile in an other place than maven
         Artifact artifact =
@@ -56,11 +65,7 @@ public class DependenciesScannerTest
         include.add( "**/*A.java" );
         List<String> exclude = new ArrayList<>();
 
-        List<File> dependenciesToScan = new ArrayList<>();
-        for ( Artifact a : DependencyScanner.filter( Collections.singletonList( artifact ), scanDependencies ) )
-        {
-            dependenciesToScan.add( a.getFile() );
-        }
+        List<File> dependenciesToScan = filterArtifactsAsFiles(scanDependencies, Collections.singletonList(artifact));
 
         DependencyScanner scanner =
             new DependencyScanner( dependenciesToScan, new TestListResolver( include, exclude ) );
@@ -74,18 +79,150 @@ public class DependenciesScannerTest
         assertEquals( 1, props.size() );
     }
 
-    private File writeTestFile()
+    /**
+     * Test for artifact with classifier
+     */
+    @Test
+    public void testLocateTestClassesFromArtifactWithClassifier()
         throws Exception
     {
-        File output = new File( "target/DependenciesScannerTest-tests.jar" );
-        output.delete();
+        File testJarFile = writeTestFile( "DependenciesScannerTest2-1.0-tests-jdk15.jar", "org/test/TestA.class",
+                                          "org/test/other/TestAA.class", "org/test/TestB.class" );
+        Artifact testArtifact =
+            new DefaultArtifact( "org.surefire.dependency", "dependent-artifact2",
+                                 VersionRange.createFromVersion( "1.0" ), "test", "jar", "tests-jdk15", null );
+        testArtifact.setFile( testJarFile );
+
+        List<String> scanDependencies = new ArrayList<String>();
+        scanDependencies.add( "org.surefire.dependency:dependent-artifact2:*:*:tests-jdk15" );
+
+        List<String> include = new ArrayList<String>();
+        include.add( "**/*A.java" );
+        List<String> exclude = new ArrayList<String>();
+
+
+        List<File> filesToScan = filterArtifactsAsFiles(scanDependencies, Collections.singletonList(testArtifact));
+
+        DependencyScanner scanner =
+            new DependencyScanner( filesToScan, new TestListResolver( include, exclude ) );
+
+        ScanResult classNames = scanner.scan();
+        assertNotNull( classNames );
+        assertEquals( 2, classNames.size() );
+
+        Map<String, String> props = new HashMap<String, String>();
+        classNames.writeTo( props );
+        assertEquals( 2, props.size() );
+    }
+
+    /**
+     * Test with type when two artifacts are present, should only find the class in jar with correct type
+     */
+    @Test
+    public void testLocateTestClassesFromMultipleArtifactsWithType()
+        throws Exception
+    {
+        File jarFile =
+            writeTestFile( "DependenciesScannerTest3-1.0.jar", "org/test/ClassA.class", "org/test/ClassB.class" );
+        Artifact mainArtifact = new DefaultArtifact( "org.surefire.dependency", "dependent-artifact3",
+                                                     VersionRange.createFromVersion( "1.0" ), "test", "jar", null,
+                                                     new DefaultArtifactHandler() );
+        mainArtifact.setFile( jarFile );
+
+        File testJarFile =
+            writeTestFile( "DependenciesScannerTest3-1.0-tests.jar", "org/test/TestA.class", "org/test/TestB.class" );
+        Artifact testArtifact = new DefaultArtifact( "org.surefire.dependency", "dependent-artifact3",
+                                                     VersionRange.createFromVersion( "1.0" ), "test", "test-jar", null,
+                                                     new DefaultArtifactHandler() );
+        testArtifact.setFile( testJarFile );
+
+        List<String> scanDependencies = new ArrayList<String>();
+        scanDependencies.add( "org.surefire.dependency:dependent-artifact3:test-jar" );
+
+        List<String> include = new ArrayList<String>();
+        include.add( "**/*A.java" );
+        List<String> exclude = new ArrayList<String>();
+
+        List<Artifact> artifacts = Arrays.asList( mainArtifact, testArtifact );
+
+        List<File> filesToScan = filterArtifactsAsFiles(scanDependencies, artifacts);
+
+        DependencyScanner scanner = new DependencyScanner( filesToScan, new TestListResolver( include, exclude ) );
+
+        ScanResult classNames = scanner.scan();
+        assertNotNull( classNames );
+        assertEquals( 1, classNames.size() );
+        assertEquals( "org.test.TestA", classNames.getClassName( 0 ) );
+
+        Map<String, String> props = new HashMap<String, String>();
+        classNames.writeTo( props );
+        assertEquals( 1, props.size() );
+    }
+
+    /**
+     * Test to pick the right version of an artifact to scan
+     */
+    @Test
+    public void testLocateTestClassesFromMultipleVersionsOfArtifact()
+        throws Exception
+    {
+        File jarFile10 =
+            writeTestFile( "DependenciesScannerTest4-1.0.jar", "org/test/ClassA.class", "org/test/ClassB.class" );
+        Artifact artifact10 = new DefaultArtifact( "org.surefire.dependency", "dependent-artifact4",
+                                                   VersionRange.createFromVersion( "1.0" ), "test", "jar", null,
+                                                   new DefaultArtifactHandler() );
+        artifact10.setFile( jarFile10 );
+
+        File jarFile20 =
+            writeTestFile( "DependenciesScannerTest4-2.0.jar", "org/test2/ClassA.class", "org/test2/ClassB.class" );
+        Artifact artifact20 = new DefaultArtifact( "org.surefire.dependency", "dependent-artifact4",
+                                                   VersionRange.createFromVersion( "2.0" ), "test", "jar", null,
+                                                   new DefaultArtifactHandler() );
+        artifact20.setFile( jarFile20 );
+
+        List<String> scanDependencies = new ArrayList<String>();
+        scanDependencies.add( "org.surefire.dependency:dependent-artifact4:*:2.0" );
+
+        List<String> include = new ArrayList<String>();
+        include.add( "**/*A.java" );
+        List<String> exclude = new ArrayList<String>();
+
+        List<Artifact> artifacts = Arrays.asList( artifact10, artifact20 );
+
+        List<File> filesToScan = filterArtifactsAsFiles(scanDependencies, artifacts);
+        DependencyScanner scanner = new DependencyScanner( filesToScan, new TestListResolver( include, exclude ) );
+
+        ScanResult classNames = scanner.scan();
+        assertNotNull( classNames );
+        assertEquals( 1, classNames.size() );
+        assertEquals( "org.test2.ClassA", classNames.getClassName( 0 ) );
+
+        Map<String, String> props = new HashMap<String, String>();
+        classNames.writeTo( props );
+        assertEquals( 1, props.size() );
+        assertFalse( props.values().contains( "org.test.ClassA" ) );
+    }
+
+    private static List<File> filterArtifactsAsFiles(List<String> scanDependencies, List<Artifact> artifacts) {
+        List<File> filesToScan = new ArrayList<>();
+        for (Artifact a : DependencyScanner.filter(artifacts, scanDependencies)) {
+            filesToScan.add(a.getFile());
+        }
+        return filesToScan;
+    }
+
+    private File writeTestFile( String fileName, String... entries )
+        throws Exception
+    {
+        File output = tempFolder.newFile( fileName );
 
         try ( ZipOutputStream out = new ZipOutputStream( new FileOutputStream( output ) ) )
         {
-            out.putNextEntry( new ZipEntry( "org/test/TestA.class" ) );
-            out.closeEntry();
-            out.putNextEntry( new ZipEntry( "org/test/TestB.class" ) );
-            out.closeEntry();
+            for ( String entry : entries )
+            {
+                out.putNextEntry( new ZipEntry( entry ) );
+                out.closeEntry();
+            }
             return output;
         }
     }

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/JUnit4SuiteTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/JUnit4SuiteTest.java
@@ -70,7 +70,7 @@ public class JUnit4SuiteTest extends TestCase
         suite.addTestSuite( SurefirePropertiesTest.class );
         suite.addTestSuite( SpecificFileFilterTest.class );
         suite.addTest( new JUnit4TestAdapter( DirectoryScannerTest.class ) );
-        suite.addTestSuite( DependenciesScannerTest.class );
+        suite.addTest( new JUnit4TestAdapter( DependenciesScannerTest.class ) );
         suite.addTestSuite( RunEntryStatisticsMapTest.class );
         suite.addTestSuite( WrappedReportEntryTest.class );
         suite.addTestSuite( StatelessXmlReporterTest.class );

--- a/maven-surefire-plugin/src/site/apt/examples/inclusion-exclusion.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/inclusion-exclusion.apt.vm
@@ -209,4 +209,44 @@ Inclusions and Exclusions of Tests
   Multiple formats can be additionally combined.
   This syntax can be used in parameters: <<<test>>>, <<<includes>>>, <<<excludes>>>, <<<includesFile>>>, <<<excludesFile>>>.
 
+* Tests from dependencies
+
+  By default, ${thisPlugin} will only scan for test classes to execute in the configured <<<testSourceDirectory>>>. To
+  have the plugin scan dependencies to find test classes to execute, use the <<<dependenciesToScan>>> configuration.
+  Dependencies can be specified using the <<<groupId[:artifactId[:type[:classifier][:version]]]>>> format, and must already
+  be <<<dependency>>> elements in scope.
+  
+  <Note:> Support for version, type and classifier was introduced in version <<<3.0.0-M4>>>. When using earlier versions,
+  ${thisPlugin} will fail with an <<<IllegalArgumentException>>> if more than groupId and artifactId are specified.
+  
++---+
+<project>
+  [...]
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>${project.artifactId}</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <dependenciesToScan>
+            <dependency>org.acme:project-a</dependency>
+            <dependency>org.acme:project-b:test-jar</dependency>
+            <dependency>org.acme:project-c:*:tests-jdk15</dependency>
+          </dependenciesToScan>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  [...]
+</project>
++---+
+
+  The configuration above will search for test classes in:
+
+    * All dependencies with the groupId <<<org.acme>>> and artifactId <<<project-a>>>
+
+    * All dependencies with the groupId <<<org.acme>>> and artifactId <<<project-b>>> and type <<<test-jar>>>
+
+    * All dependencies with the groupId <<<org.acme>>> and artifactId <<<project-c>>> and classifier <<<tests-jdk15>>>
 

--- a/maven-surefire-plugin/src/site/fml/faq.fml
+++ b/maven-surefire-plugin/src/site/fml/faq.fml
@@ -44,9 +44,8 @@ under the License.
       <answer>
         <p>
           Visit this link for your reference,
-          <a href="http://maven.apache.org/guides/mini/guide-attached-tests.html">
-         |   Attaching tests
-          </a>
+          <a href="http://maven.apache.org/guides/mini/guide-attached-tests.html"> Attaching tests</a>.
+          Also see the examples for <a href="examples/inclusion-exclusion.html">Inclusions and Exclusions of Tests</a>.
         </p>
       </answer>
     </faq>

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1004RunTestFromDependencyJarsTypeAndClassifierIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1004RunTestFromDependencyJarsTypeAndClassifierIT.java
@@ -1,0 +1,57 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.junit.Assert.*;
+
+import java.util.Collection;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Test;
+
+public class Surefire1004RunTestFromDependencyJarsTypeAndClassifierIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+    
+    @Test
+    public void shouldScanAndRunTestsInDependencyJars()
+        throws Exception
+    {
+        SurefireLauncher launcher = unpack( "surefire-1004-RunTestFromDependencyJarsTypeAndClassifier" );
+        launcher.addGoal("test").addGoal("install");
+        OutputValidator wholeExecValidator = launcher.executeCurrentGoals();
+        wholeExecValidator.verifyErrorFreeLog();
+
+        OutputValidator module1 = launcher.getSubProjectValidator("surefire-1004-module1");
+        module1.assertTestSuiteResults(3, 0, 0, 0);
+
+        // Tests from dependencies
+        wholeExecValidator.verifyTextInLog( "Running org.acme.tests.TestA" );
+        wholeExecValidator.verifyTextInLog( "Running org.acme.classifiedtests.ClassifiedTestA" );
+        // Tests from module1 to verify classpath
+        wholeExecValidator.verifyTextInLog( "Running org.acme.tests.ClasspathTest" );
+        // Should not run these tests
+        Collection<String> logLines = wholeExecValidator.loadLogLines();
+        assertFalse( logLines.contains( "org.acme.othertests.OtherTestA" ) );
+        assertFalse( logLines.contains( "org.acme.tests.TestB" ) );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.surefire</groupId>
+        <artifactId>it-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>surefire-1004-RunTestFromDependencyJarsTypeAndClassifier</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <modules>
+        <module>surefire-1004-testjar</module>
+        <module>surefire-1004-module1</module>
+    </modules>
+</project>

--- a/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-module1/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-module1/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.surefire</groupId>
+        <artifactId>surefire-1004-RunTestFromDependencyJarsTypeAndClassifier</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.apache.maven.plugins.surefire.dependency-jar</groupId>
+    <artifactId>surefire-1004-module1</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.1</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugins.surefire.dependency-jar</groupId>
+            <artifactId>surefire-1004-testjar</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins.surefire.dependency-jar</groupId>
+            <artifactId>surefire-1004-testjar</artifactId>
+            <version>${project.version}</version>
+            <classifier>othertests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins.surefire.dependency-jar</groupId>
+            <artifactId>surefire-1004-testjar</artifactId>
+            <version>${project.version}</version>
+            <classifier>classifiedtests</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>*TestA*</include>
+                    </includes>
+                    <!-- Tests from othertests should not run -->
+                    <dependenciesToScan>
+                        <dependency>org.apache.maven.plugins.surefire.dependency-jar:surefire-1004-testjar:test-jar</dependency>
+                        <dependency>org.apache.maven.plugins.surefire.dependency-jar:surefire-1004-testjar:*:classifiedtests</dependency>
+                    </dependenciesToScan>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-module1/src/test/java/org/acme/tests/ClasspathTestA.java
+++ b/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-module1/src/test/java/org/acme/tests/ClasspathTestA.java
@@ -1,0 +1,36 @@
+package org.acme.tests;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+public class ClasspathTestA
+{
+
+    @Test
+    public void verifyAllTestClassesAreInClasspath()
+        throws Exception
+    {
+        Class.forName( "org.acme.tests.TestA" );
+        Class.forName( "org.acme.tests.TestB" );
+        Class.forName( "org.acme.othertests.OtherTestA" );
+        Class.forName( "org.acme.classifiedtests.ClassifiedTestA" );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.surefire</groupId>
+        <artifactId>surefire-1004-RunTestFromDependencyJarsTypeAndClassifier</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.apache.maven.plugins.surefire.dependency-jar</groupId>
+    <artifactId>surefire-1004-testjar</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.1</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>main-test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes><include>**/tests/**</include></includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>other-test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes><include>**/othertests/**</include></includes>
+                            <classifier>othertests</classifier>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>classified-test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes><include>**/classifiedtests/**</include></includes>
+                            <classifier>classifiedtests</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/src/test/java/org/acme/classifiedtests/ClassifiedTestA.java
+++ b/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/src/test/java/org/acme/classifiedtests/ClassifiedTestA.java
@@ -1,0 +1,31 @@
+package org.acme.classifiedtests;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+public class ClassifiedTestA
+{
+
+    @Test
+    public void shouldRun()
+    {
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/src/test/java/org/acme/othertests/OtherTestA.java
+++ b/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/src/test/java/org/acme/othertests/OtherTestA.java
@@ -1,0 +1,33 @@
+package org.acme.othertests;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class OtherTestA
+{
+
+    @Test
+    public void shouldNotRun()
+    {
+        fail( "This test should not run" );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/src/test/java/org/acme/tests/TestA.java
+++ b/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/src/test/java/org/acme/tests/TestA.java
@@ -1,0 +1,31 @@
+package org.acme.tests;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+public class TestA
+{
+
+    @Test
+    public void shouldRun()
+    {
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/src/test/java/org/acme/tests/TestB.java
+++ b/surefire-its/src/test/resources/surefire-1004-RunTestFromDependencyJarsTypeAndClassifier/surefire-1004-testjar/src/test/java/org/acme/tests/TestB.java
@@ -1,0 +1,31 @@
+package org.acme.tests;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+public class TestB
+{
+
+    @Test
+    public void shouldRun()
+    {
+    }
+}


### PR DESCRIPTION
This PR is a rebased version of #173 .

Personally, I am in favor of reusing the logic in `PatternIncludesArtifactFilter` from maven-common-artifact-filters as mentioned in the JIRA description and Robert Scholte's comment https://issues.apache.org/jira/browse/SUREFIRE-1004?focusedCommentId=16324706&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16324706 That format is more standardized. If you'd like that change to be incorporated, I'm willing to do that as part of this PR.