### PR TITLE
Support running tests until failure or N test runs

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -385,6 +385,15 @@ public class IntegrationTestMojo
     @Parameter( property = "failsafe.useModulePath", defaultValue = "true" )
     private boolean useModulePath;
 
+    /**
+     * Continuously run tests until failure happens.
+     * At a maximum, it tries to run as many times as the value of this attribute.
+     *
+     * @since 3.0.0-M4
+     */
+    @Parameter( property = "surefire.untilFailureLoopCount", defaultValue = "0" )
+    private long untilFailureLoopCount;
+
     @Override
     protected int getRerunFailingTestsCount()
     {
@@ -826,6 +835,18 @@ public class IntegrationTestMojo
     protected void setUseModulePath( boolean useModulePath )
     {
         this.useModulePath = useModulePath;
+    }
+
+    @Override
+    protected long getUntilFailureLoopCount()
+    {
+        return untilFailureLoopCount;
+    }
+
+    @Override
+    protected void setUntilFailureLoopCount( long untilFailureLoopCount )
+    {
+        this.untilFailureLoopCount = untilFailureLoopCount;
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -791,6 +791,10 @@ public abstract class AbstractSurefireMojo
 
     protected abstract void setUseModulePath( boolean useModulePath );
 
+    protected abstract long getUntilFailureLoopCount();
+
+    protected abstract void setUntilFailureLoopCount( long untilFailureLoopCount );
+
     /**
      * This plugin MOJO artifact.
      *
@@ -1624,7 +1628,8 @@ public abstract class AbstractSurefireMojo
         final TestRequest testSuiteDefinition = new TestRequest( suiteXmlFiles(),
                                                                  getTestSourceDirectory(),
                                                                  getSpecificTests(),
-                                                                 getRerunFailingTestsCount() );
+                                                                 getRerunFailingTestsCount(),
+                                                                 getUntilFailureLoopCount() );
 
         final boolean actualFailIfNoTests;
         DirectoryScannerParameters directoryScannerParameters = null;

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
@@ -67,6 +67,7 @@ import static org.apache.maven.surefire.booter.BooterConstants.TEST_CLASSES_DIRE
 import static org.apache.maven.surefire.booter.BooterConstants.TEST_SUITE_XML_FILES;
 import static org.apache.maven.surefire.booter.BooterConstants.TESTARTIFACT_CLASSIFIER;
 import static org.apache.maven.surefire.booter.BooterConstants.TESTARTIFACT_VERSION;
+import static org.apache.maven.surefire.booter.BooterConstants.UNTIL_FAILURE_LOOP_COUNT;
 import static org.apache.maven.surefire.booter.BooterConstants.USEMANIFESTONLYJAR;
 import static org.apache.maven.surefire.booter.BooterConstants.USESYSTEMCLASSLOADER;
 import static org.apache.maven.surefire.booter.SystemPropertyManager.writePropertiesFile;
@@ -139,6 +140,8 @@ class BooterSerializer
             properties.setProperty( REQUESTEDTEST, testFilter == null ? "" : testFilter.getPluginParameterTest() );
             int rerunFailingTestsCount = testSuiteDefinition.getRerunFailingTestsCount();
             properties.setNullableProperty( RERUN_FAILING_TESTS_COUNT, toString( rerunFailingTestsCount ) );
+            long untilFailureLoopCount = testSuiteDefinition.getUntilFailureLoopCount();
+            properties.setNullableProperty( UNTIL_FAILURE_LOOP_COUNT, toString( untilFailureLoopCount ) );
         }
 
         DirectoryScannerParameters directoryScannerParameters = booterConfiguration.getDirScannerParams();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
@@ -600,6 +600,17 @@ public class AbstractSurefireMojoJava7PlusTest
         }
 
         @Override
+        protected long getUntilFailureLoopCount()
+        {
+            return 0;
+        }
+
+        @Override
+        protected void setUntilFailureLoopCount(long untilFailureLoopCount)
+        {
+        }
+
+        @Override
         protected Artifact getMojoArtifact()
         {
             return null;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -724,6 +724,17 @@ public class AbstractSurefireMojoTest
         }
 
         @Override
+        protected long getUntilFailureLoopCount()
+        {
+            return 0;
+        }
+
+        @Override
+        protected void setUntilFailureLoopCount( long untilFailureLoopCount )
+        {
+        }
+
+        @Override
         protected Artifact getMojoArtifact()
         {
             return null;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
@@ -624,6 +624,17 @@ public class MojoMocklessTest
         }
 
         @Override
+        protected long getUntilFailureLoopCount()
+        {
+            return 0;
+        }
+
+        @Override
+        protected void setUntilFailureLoopCount( long untilFailureLoopCount )
+        {
+        }
+
+        @Override
         protected Artifact getMojoArtifact()
         {
             return null;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
@@ -53,6 +53,8 @@ public class BooterDeserializerProviderConfigurationTest
 
     private static final int rerunFailingTestsCount = 3;
 
+    private static final int untilFailureLoopCount = 6;
+
     private final List<CommandLineOption> cli =
         Arrays.asList( LOGGING_LEVEL_DEBUG, SHOW_ERRORS, REACTOR_FAIL_FAST );
 
@@ -136,6 +138,7 @@ public class BooterDeserializerProviderConfigurationTest
         Assert.assertEquals( "**/" + aUserRequestedTest, filter.getTestClassPattern() );
         Assert.assertEquals( aUserRequestedTestMethod, filter.getTestMethodPattern() );
         Assert.assertEquals( rerunFailingTestsCount, testSuiteDefinition.getRerunFailingTestsCount() );
+        Assert.assertEquals( untilFailureLoopCount, testSuiteDefinition.getUntilFailureLoopCount() );
         assertEquals( cli, reloaded.getMainCliOptions() );
     }
 
@@ -234,7 +237,7 @@ public class BooterDeserializerProviderConfigurationTest
         TestRequest testSuiteDefinition =
             new TestRequest( getSuiteXmlFileStrings(), getTestSourceDirectory(),
                              new TestListResolver( aUserRequestedTest + "#aUserRequestedTestMethod" ),
-                             rerunFailingTestsCount );
+                             rerunFailingTestsCount, untilFailureLoopCount );
         RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(), aTestTyped,

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -364,6 +364,15 @@ public class SurefirePlugin
     @Parameter( property = "surefire.useModulePath", defaultValue = "true" )
     private boolean useModulePath;
 
+    /**
+     * Continuously run tests until failure happens.
+     * At a maximum, it tries to run as many times as the value of this attribute.
+     *
+     * @since 3.0.0-M4
+     */
+    @Parameter( property = "surefire.untilFailureLoopCount", defaultValue = "0" )
+    private long untilFailureLoopCount;
+
     @Override
     protected int getRerunFailingTestsCount()
     {
@@ -739,5 +748,17 @@ public class SurefirePlugin
     protected final boolean hasSuiteXmlFiles()
     {
         return suiteXmlFiles != null && suiteXmlFiles.length != 0;
+    }
+
+    @Override
+    protected long getUntilFailureLoopCount()
+    {
+        return untilFailureLoopCount;
+    }
+
+    @Override
+    protected void setUntilFailureLoopCount( long untilFailureLoopCount )
+    {
+        this.untilFailureLoopCount = untilFailureLoopCount;
     }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/booter/SurefireReflector.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/booter/SurefireReflector.java
@@ -187,7 +187,8 @@ public class SurefireReflector
                                 suiteDefinition.getSuiteXmlFiles(),
                                 suiteDefinition.getTestSourceDirectory(),
                                 resolver,
-                                suiteDefinition.getRerunFailingTestsCount() );
+                                suiteDefinition.getRerunFailingTestsCount(),
+                                suiteDefinition.getUntilFailureLoopCount() );
         }
     }
 

--- a/surefire-api/src/main/java/org/apache/maven/surefire/testset/TestRequest.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/testset/TestRequest.java
@@ -38,18 +38,21 @@ public class TestRequest
 
     private final int rerunFailingTestsCount;
 
+    private final long untilFailureLoopCount;
+
     public TestRequest( List suiteXmlFiles, File testSourceDirectory, TestListResolver requestedTests )
     {
-        this( createFiles( suiteXmlFiles ), testSourceDirectory, requestedTests, 0 );
+        this( createFiles( suiteXmlFiles ), testSourceDirectory, requestedTests, 0, 0 );
     }
 
     public TestRequest( List suiteXmlFiles, File testSourceDirectory, TestListResolver requestedTests,
-                        int rerunFailingTestsCount )
+                        int rerunFailingTestsCount, long untilFailureLoopCount )
     {
         this.suiteXmlFiles = createFiles( suiteXmlFiles );
         this.testSourceDirectory = testSourceDirectory;
         this.requestedTests = requestedTests;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
+        this.untilFailureLoopCount = untilFailureLoopCount;
     }
 
     /**
@@ -90,6 +93,17 @@ public class TestRequest
     public int getRerunFailingTestsCount()
     {
         return rerunFailingTestsCount;
+    }
+
+    /**
+     * How many times to run tests until a failure occurs,
+     * issued with -Dsurefire.untilFailureLoopCount from the command line.
+     *
+     * @return The long parameter to indicate how many times to rerun until a failure occurs
+     */
+    public long getUntilFailureLoopCount()
+    {
+        return untilFailureLoopCount;
     }
 
     private static List<File> createFiles( List suiteXmlFiles )

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
@@ -52,6 +52,7 @@ public final class BooterConstants
     public static final String FORKTESTSET = "forkTestSet";
     public static final String FORKTESTSET_PREFER_TESTS_FROM_IN_STREAM = "preferTestsFromInStream";
     public static final String RERUN_FAILING_TESTS_COUNT = "rerunFailingTestsCount";
+    public static final String UNTIL_FAILURE_LOOP_COUNT = "untilFailureLoopCount";
     public static final String MAIN_CLI_OPTIONS = "mainCliOptions";
     public static final String FAIL_FAST_COUNT = "failFastCount";
     public static final String SHUTDOWN = "shutdown";

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
@@ -89,6 +89,7 @@ public class BooterDeserializer
         final String runStatisticsFile = properties.getProperty( RUN_STATISTICS_FILE );
 
         final int rerunFailingTestsCount = properties.getIntProperty( RERUN_FAILING_TESTS_COUNT );
+        final Long untilFailureLoopCount = properties.getLongProperty( UNTIL_FAILURE_LOOP_COUNT );
 
         DirectoryScannerParameters dirScannerParams =
             new DirectoryScannerParameters( testClassesDirectory, includes, excludes, specificTests,
@@ -100,7 +101,7 @@ public class BooterDeserializer
         TestArtifactInfo testNg = new TestArtifactInfo( testNgVersion, testArtifactClassifier );
         TestRequest testSuiteDefinition =
             new TestRequest( testSuiteXmlFiles, sourceDirectory, new TestListResolver( requestedTest ),
-                             rerunFailingTestsCount );
+                             rerunFailingTestsCount, untilFailureLoopCount == null ? 0L : untilFailureLoopCount );
 
         ReporterConfiguration reporterConfiguration =
             new ReporterConfiguration( reportsDirectory, properties.getBooleanProperty( ISTRIMSTACKTRACE ) );

--- a/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
+++ b/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
@@ -92,6 +92,8 @@ public class JUnit4Provider
 
     private final int rerunFailingTestsCount;
 
+    private final long untilFailureLoopCount;
+
     private final CommandReader commandsReader;
 
     private TestsToRun testsToRun;
@@ -109,6 +111,7 @@ public class JUnit4Provider
         TestRequest testRequest = bootParams.getTestRequest();
         testResolver = testRequest.getTestListResolver();
         rerunFailingTestsCount = testRequest.getRerunFailingTestsCount();
+        untilFailureLoopCount = testRequest.getUntilFailureLoopCount();
     }
 
     @Override
@@ -154,9 +157,12 @@ public class JUnit4Provider
                     commandsReader.awaitStarted();
                 }
 
-                for ( Class<?> testToRun : testsToRun )
+                for ( int i = 0; i <= untilFailureLoopCount && result.getFailures().size() == 0; i++ )
                 {
-                    executeTestSet( testToRun, reporter, notifier );
+                    for ( Class<?> testToRun : testsToRun )
+                    {
+                        executeTestSet( testToRun, reporter, notifier );
+                    }
                 }
             }
             finally


### PR DESCRIPTION
This is an initial proposal to add surefire/failsafe property called `untilFailureLoopCount`.

I often find myself in the situation where there's a random test failure happening in CI, and have to run the one or several tests continuously until it fails, maybe running them with TRACE logging.

Normally, I'd wrap the `mvn test...` call with a script that calls it in a loop, but this can be quite "slow" since each iteration is a new JVM launch...etc.

The idea behind `untilFailureLoopCount` is that you've give it a positive number, say 1000, and the test(s) would run continuously until either a failure happens or the test is executed that many times.

I've created [this randomly failing test](https://github.com/galderz/surefire-until-failure-loop-count/blob/master/src/test/java/com/acme/maven/surefire/untilfailure/UntilFailureLoopCountTest.java) and I've run it with `mvn -Dsurefire.untilFailureLoopCount=10 test` and the output would be something like:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.034 s - in com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[INFO] Running com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[INFO] Running com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[INFO] Running com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[INFO] Running com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest
[ERROR] com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest.testEventualFailure  Time elapsed: 0.001 s  <<< FAILURE!
java.lang.AssertionError: Just messing with your testing
	at com.acme.maven.surefire.untilfailure.UntilFailureLoopCountTest.testEventualFailure(UntilFailureLoopCountTest.java:16)
```

If maintainers are interested in this, I can complete the PR with tests, documentation and support for other providers. 