### PR TITLE
[SUREFIRE-1647] Delay load testClass, but to use myown classLoader

### DIFF
--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -156,7 +156,7 @@ public class JUnitPlatformProvider
                         request().filters( filters ).configurationParameters( configurationParameters );
         for ( Class<?> testClass : testsToRun )
         {
-            builder.selectors( selectClass( testClass ) );
+            builder.selectors( selectClass( testClass.getName() ) );
         }
         return builder.build();
     }

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/TestPlanScannerFilter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/TestPlanScannerFilter.java
@@ -50,7 +50,7 @@ final class TestPlanScannerFilter
     public boolean accept( Class testClass )
     {
         LauncherDiscoveryRequest discoveryRequest = request()
-                        .selectors( selectClass( testClass ) )
+                        .selectors( selectClass( testClass.getName() ) )
                         .filters( includeAndExcludeFilters ).build();
 
         TestPlan testPlan = launcher.discover( discoveryRequest );


### PR DESCRIPTION
org.junit.platform.engine.discovery.DiscoverySelectors#selectClass(java.lang.String) and org.junit.platform.engine.discovery.DiscoverySelectors#selectClass(java.lang.Class<?>) are different. 

If you use selectClass(java.lang.String) , it will load class by org.junit.platform.engine.discovery.ClassSelector#getJavaClass. The code is as follow:
```
public Class<?> getJavaClass() {
		if (this.javaClass == null) {
			this.javaClass = ReflectionUtils.loadClass(this.className).orElseThrow(
				() -> new PreconditionViolationException("Could not load class with name: " + this.className));
		}
		return this.javaClass;
	}
```
And the classloader fetched by `Thread.currentThread().getContextClassLoader()`  will load this class.

But selectClass(java.lang.Class<?>) will get class directly.

------

Now I will describe what i need.

I will use my own DefaultLauncher, and we will use my own classLoader.  And I need the testClass is loaded by myClassLoader. So I wish the class is lazy load.
