### PR TITLE
Setup a simpler Travis Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ cache:
 jobs:
   include:
   - stage: test
-    jdk: openjdk11
+    jdk: openjdk8
     script: mvn clean install -Prun-its
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 language: java
-jdk:
-  - oraclejdk8
-#  - oraclejdk9
+sudo: false
 
-script: "rm -rf .repository && mvn --show-version --no-snapshot-updates --errors --batch-mode -Prun-its clean install -Dmaven.repo.local=.repository -Denforcer.skip=true -e"
+cache:
+  directories:
+  - "$HOME/.m2"
 
-install: true
+jobs:
+  include:
+  - stage: test
+    jdk: openjdk11
+    script: mvn clean install -Prun-its
 
 branches:
-    except:
-        - gh-pages
+  only:
+  - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,8 @@ cache:
   directories:
   - "$HOME/.m2"
 
-jobs:
-  include:
-  - stage: test
-    jdk: openjdk8
-    script: mvn clean install -Prun-its
+install: true
+script: mvn clean package -DskipTests
 
 branches:
   only:

--- a/maven-failsafe-plugin/pom.xml
+++ b/maven-failsafe-plugin/pom.xml
@@ -286,7 +286,7 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>integration-test</id>
+                                <id>integration-testset1</id>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
@@ -298,11 +298,40 @@
                                         <goal>verify</goal>
                                         <goal>-nsu</goal>
                                     </goals>
-                                    <setupIncludes>
-                                        <setupInclude>dummy-*/pom.xml</setupInclude>
-                                    </setupIncludes>
+                                    <parallelThreads>3</parallelThreads>
                                     <pomIncludes>
-                                        <pomInclude>*/pom.xml</pomInclude>
+                                        <pomInclude>jetty-war-test-failing/pom.xml</pomInclude>
+                                        <pomInclude>multiple-summaries/pom.xml</pomInclude>
+                                        <pomInclude>multiple-summaries-failing/pom.xml</pomInclude>
+                                    </pomIncludes>
+                                    <postBuildHookScript>verify</postBuildHookScript>
+                                    <settingsFile>src/it/settings.xml</settingsFile>
+                                    <skipInvocation>${skipTests}</skipInvocation>
+                                    <streamLogs>false</streamLogs>
+                                    <showErrors>true</showErrors>
+                                    <properties>
+                                        <integration-test-port>${failsafe-integration-test-port}</integration-test-port>
+                                        <integration-test-stop-port>${failsafe-integration-test-stop-port}</integration-test-stop-port>
+                                    </properties>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>integration-testset2</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <projectsDirectory>src/it</projectsDirectory>
+                                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                                    <goals>
+                                        <goal>clean</goal>
+                                        <goal>verify</goal>
+                                        <goal>-nsu</goal>
+                                    </goals>
+                                    <parallelThreads>2</parallelThreads>
+                                    <pomIncludes>
+                                        <pomInclude>jetty-war-test-passing/pom.xml</pomInclude>
+                                        <pomInclude>working-directory/pom.xml</pomInclude>
                                     </pomIncludes>
                                     <postBuildHookScript>verify</postBuildHookScript>
                                     <settingsFile>src/it/settings.xml</settingsFile>

--- a/surefire-its/pom.xml
+++ b/surefire-its/pom.xml
@@ -164,10 +164,11 @@
                 <configuration>
                     <jvm>${jdk.home}/bin/java</jvm>
                     <runOrder>alphabetical</runOrder>
-                    <threadCount>1</threadCount>
+                    <parallel>classes</parallel>
+                    <threadCount>3</threadCount>
                     <perCoreThreadCount>false</perCoreThreadCount>
                     <forkMode>once</forkMode>
-                    <argLine>-server -Xmx64m -XX:+UseG1GC -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+                    <argLine>-server -Xmx256m -XX:+UseG1GC -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
                     <includes>
                         <include>org/apache/**/*IT*.java</include>
                     </includes>

--- a/surefire-its/pom.xml
+++ b/surefire-its/pom.xml
@@ -165,7 +165,7 @@
                     <jvm>${jdk.home}/bin/java</jvm>
                     <runOrder>alphabetical</runOrder>
                     <parallel>classes</parallel>
-                    <threadCount>3</threadCount>
+                    <threadCount>2</threadCount>
                     <perCoreThreadCount>false</perCoreThreadCount>
                     <forkMode>once</forkMode>
                     <argLine>-server -Xmx256m -XX:+UseG1GC -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>


### PR DESCRIPTION
Setup only a simple Travis script.
This way we will have PR validation working.
Tests and Integrations tests take too much time for Travis.
Currently for every PR contributors are seeing Travis failure  and this is not good 