### PR TITLE
defaulting trimStackTrace to false

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -650,7 +650,7 @@ public abstract class AbstractSurefireMojo
      *
      * @since 2.2
      */
-    @Parameter( property = "trimStackTrace", defaultValue = "true" )
+    @Parameter( property = "trimStackTrace", defaultValue = "false" )
     private boolean trimStackTrace;
 
     /**

--- a/surefire-its/src/test/resources/surefire-818-ignored-tests-on-npe/pom.xml
+++ b/surefire-its/src/test/resources/surefire-818-ignored-tests-on-npe/pom.xml
@@ -31,6 +31,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
+                <configuration>
+                    <trimStackTrace>true</trimStackTrace>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Hi all,

following [this discussion on reddit](https://www.reddit.com/r/java/comments/8my2i8/should_mavensurefire_trimstacktrace_be_disabled/) I would like to propose to change this default in the upcoming version 3.0. 


