### PR TITLE
Improved Documentation for "parallel" parameter value "none"

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -564,6 +564,10 @@ public abstract class AbstractSurefireMojo
      * Since version 2.16 (JUnit 4.7 provider), additional vales are available:
      * <br>
      * {@code suites}, {@code suitesAndClasses}, {@code suitesAndMethods}, {@code classesAndMethods}, {@code all}.
+     * <br>
+     * By default, Surefire does not execute tests in parallel. You can set the parameter {@code parallel} to
+     * {@code none} to explicitly disable parallel execution (e.g. when disabling parallel execution in special Maven
+     * profiles when executing coverage analysis).
      *
      * @since 2.2
      */


### PR DESCRIPTION
Added documentation to explicitly state that "none" can be used to disable parallel execution. There was no documentation at the "parallel" parameter before that also listed this special value. The value "none" could only be retrieved from the implementation and is implicitly documented at the description of "parallelTestsTimeoutInSeconds" and "parallelTestsTimeoutForcedInSeconds" in SurefirePlugin.

Knowing a way to disable parallel execution is useful if you need to override a previously parallel exection. We usually declare our surefire tests to be executed in parallel. This is usually defined in the <pluginManagement>-Section of our parent pom.
Nevertheless when execting the tests with Coverage - JaCoCo in our case - the coverage data will be inaccurate if the tests are executed in parallel. JaCoCo even warns in those situations and sometimes even fails tests.

We use the value "none" to disable parallel test execution using a special "coverage" profile that also enables JaCoCo.