### PR TITLE
(doc) add static modifier to signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ cache:
   directories:
   - "$HOME/.m2"
 
-install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -DskipITs=true
-script: mvn clean verify  -nsu -Dit.test=PojoSimpleIT -Dtest=xxx -DfailIfNoTests=false
+install: true
+script: mvn clean package -nsu -DskipITs
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ cache:
   directories:
   - "$HOME/.m2"
 
-install: true
-script: mvn clean package -nsu -DskipITs
+install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -DskipITs=true
+script: mvn clean verify  -nsu -Dit.test=PojoSimpleIT -Dtest=xxx -DfailIfNoTests=false
 
 branches:
   only:

--- a/maven-surefire-plugin/src/site/apt/examples/pojo-test.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/pojo-test.apt.vm
@@ -41,8 +41,8 @@ Using POJO Tests
   to be recognized and executed before and after each test method:
      
 +---+
-public void setUp();
-public void tearDown();
+public static void setUp();
+public static void tearDown();
 +---+
 
   These fixture methods can also throw any exception and will still be valid.

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/PojoSimpleIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/PojoSimpleIT.java
@@ -33,6 +33,6 @@ public class PojoSimpleIT
     @Test
     public void testit()
     {
-        unpack( "pojo-simple" ).executeTest().assertTestSuiteResults( 2, 0, 1, 0 );
+        unpack( "pojo-simple" ).executeTest().assertTestSuiteResults( 3, 0, 2, 0 );
     }
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/PojoSimpleIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/PojoSimpleIT.java
@@ -33,6 +33,6 @@ public class PojoSimpleIT
     @Test
     public void testit()
     {
-        unpack( "pojo-simple" ).executeTest().assertTestSuiteResults( 3, 0, 2, 0 );
+        unpack( "pojo-simple" ).executeTest().assertTestSuiteResults( 3, 0, 1, 0 );
     }
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/PojoSimpleIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/PojoSimpleIT.java
@@ -19,8 +19,13 @@ package org.apache.maven.surefire.its;
  * under the License.
  */
 
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Test support for POJO tests.
@@ -31,8 +36,13 @@ public class PojoSimpleIT
     extends SurefireJUnit4IntegrationTestCase
 {
     @Test
-    public void testit()
+    public void testit() throws VerificationException
     {
-        unpack( "pojo-simple" ).executeTest().assertTestSuiteResults( 3, 0, 1, 0 );
+        int expectedTotalTests = 3;
+
+        OutputValidator validator = unpack( "pojo-simple" ).executeTest();
+
+        validator.assertTestSuiteResults( expectedTotalTests, 0, 1, 0 );
+        validator.assertThatLogLine( containsString( "PR234, tearDown" ), is( expectedTotalTests ) );
     }
 }

--- a/surefire-its/src/test/resources/pojo-simple/src/test/java/PojoTest.java
+++ b/surefire-its/src/test/resources/pojo-simple/src/test/java/PojoTest.java
@@ -19,6 +19,7 @@
 
 public class PojoTest
 {
+    private static boolean setUpCalled = false;
 
     public void testSuccess()
     {
@@ -28,6 +29,11 @@ public class PojoTest
     public void testFailure()
     {
         assert false;
+    }
+
+    public void testSetUpCall()
+    {
+        assert setUpCalled;
     }
 
 }

--- a/surefire-its/src/test/resources/pojo-simple/src/test/java/PojoTest.java
+++ b/surefire-its/src/test/resources/pojo-simple/src/test/java/PojoTest.java
@@ -21,7 +21,7 @@ public class PojoTest
 {
     private static boolean setUpCalled = false;
 
-    public void setUp()
+    public static void setUp()
     {
         setUpCalled = true;
     }

--- a/surefire-its/src/test/resources/pojo-simple/src/test/java/PojoTest.java
+++ b/surefire-its/src/test/resources/pojo-simple/src/test/java/PojoTest.java
@@ -21,6 +21,11 @@ public class PojoTest
 {
     private static boolean setUpCalled = false;
 
+    public void setUp()
+    {
+        setUpCalled = true;
+    }
+
     public void testSuccess()
     {
         assert true;

--- a/surefire-its/src/test/resources/pojo-simple/src/test/java/PojoTest.java
+++ b/surefire-its/src/test/resources/pojo-simple/src/test/java/PojoTest.java
@@ -26,6 +26,10 @@ public class PojoTest
         setUpCalled = true;
     }
 
+    public static void tearDown() {
+        System.out.println( "PR234, tearDown" );
+    }
+
     public void testSuccess()
     {
         assert true;


### PR DESCRIPTION
Encountered the problem of not firing `setUp`/`tearDown` instance methods of POJO test - in [2.22.2](https://github.com/apache/maven-surefire/releases/tag/surefire-2.22.2), but checked the same happens for [3.0.0-M3](https://github.com/apache/maven-surefire/releases/tag/surefire-3.0.0-M3).

Thanks to http://maven.40175.n5.nabble.com/Using-POJO-Tests-setUp-and-tearDown-methods-td5946127.html for pointing out they shall be (surprisingly) class methods.