### PR TITLE
[SUREFIRE-1679] Prevent classpath caching from causing pollution

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/ClasspathCache.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/ClasspathCache.java
@@ -32,6 +32,7 @@ import javax.annotation.Nonnull;
 /**
  * @author Kristian Rosenvold
  */
+@Deprecated
 public class ClasspathCache
 {
     private static final ConcurrentHashMap<String, Classpath> CLASSPATHS =


### PR DESCRIPTION
This PR should fix [SUREFIRE-1679](https://issues.apache.org/jira/browse/SUREFIRE-1679). Once the changes have been reviewed and approved, I'll open another PR to backport them to 2.x.