### PR TITLE
[SUREFIRE-1679] Prevent classpath caching from causing pollution

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/ClasspathCache.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/ClasspathCache.java
@@ -32,6 +32,7 @@ import javax.annotation.Nonnull;
 /**
  * @author Kristian Rosenvold
  */
+@Deprecated
 public class ClasspathCache
 {
     private static final ConcurrentHashMap<String, Classpath> CLASSPATHS =


### PR DESCRIPTION
This pull request backports the changes made in https://github.com/apache/maven-surefire/pull/243 to 2.22.x. The main source changes are the same. The test has be modified to align with the small differences in the implementation. Most notably, I have introduced the use of `TemporaryFolder` as the use of a mocked `File` resulted in an NPE as the `path` field of the mocked `File` was `null`. I hope that's OK.