### PR TITLE
Surefire-1701: Fix @DisplayName breaking reruns

### DIFF
--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.HashSet;
 import java.util.logging.Logger;
 
 import org.apache.maven.surefire.providerapi.AbstractProvider;
@@ -187,12 +188,12 @@ public class JUnitPlatformProvider
         LauncherDiscoveryRequestBuilder builder = request().filters( filters ).configurationParameters(
                 configurationParameters );
         // Iterate over recorded failures
-        for ( TestIdentifier identifier : adapter.getFailures().keySet() )
+        for ( TestIdentifier identifier : new HashSet<>( adapter.getFailures().keySet() ) )
         {
             // Extract quantified test name data
             String[] classMethodName = adapter.toClassMethodNameWithoutPlan( identifier );
-            String className = classMethodName[1];
-            String methodName = classMethodName[3];
+            String className = classMethodName[0];
+            String methodName = classMethodName[2];
             // Add filter for the specific failing method
             builder.selectors( selectMethod( className, methodName ) );
         }

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -43,6 +43,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -211,6 +212,15 @@ public class JUnitPlatformProviderTest
         assertEquals( 1, summary.getTestsSucceededCount() );
         assertEquals( 1, summary.getTestsAbortedCount() );
         assertEquals( 3, summary.getTestsFailedCount() );
+        Set<String> failDisplays = new HashSet<>();
+        for ( TestExecutionSummary.Failure failure : summary.getFailures() )
+        {
+            failDisplays.add( failure.getTestIdentifier().getDisplayName() );
+        }
+        assertEquals( 3, failDisplays.size() );
+        assertTrue( failDisplays.contains( "Fails twice" ) );
+        assertTrue( failDisplays.contains( "testAlwaysFail()" ) );
+        assertTrue( failDisplays.contains( "testAlwaysError()" ) );
 
         // Should rerun both of the failures
         summary = executionListener.summaries.get( 1 );
@@ -220,6 +230,15 @@ public class JUnitPlatformProviderTest
         assertEquals( 0, summary.getTestsSucceededCount() );
         assertEquals( 0, summary.getTestsAbortedCount() );
         assertEquals( 3, summary.getTestsFailedCount() );
+        failDisplays.clear();
+        for ( TestExecutionSummary.Failure failure : summary.getFailures() )
+        {
+            failDisplays.add( failure.getTestIdentifier().getDisplayName() );
+        }
+        assertEquals( 3, failDisplays.size() );
+        assertTrue( failDisplays.contains( "Fails twice" ) );
+        assertTrue( failDisplays.contains( "testAlwaysFail()" ) );
+        assertTrue( failDisplays.contains( "testAlwaysError()" ) );
 
         // now only one failure should remain
         summary = executionListener.summaries.get( 2 );
@@ -229,6 +248,14 @@ public class JUnitPlatformProviderTest
         assertEquals( 1, summary.getTestsSucceededCount() );
         assertEquals( 0, summary.getTestsAbortedCount() );
         assertEquals( 2, summary.getTestsFailedCount() );
+        failDisplays.clear();
+        for ( TestExecutionSummary.Failure failure : summary.getFailures() )
+        {
+            failDisplays.add( failure.getTestIdentifier().getDisplayName() );
+        }
+        assertEquals( 2, failDisplays.size() );
+        assertTrue( failDisplays.contains( "testAlwaysFail()" ) );
+        assertTrue( failDisplays.contains( "testAlwaysError()" ) );
     }
 
     @Test
@@ -834,6 +861,7 @@ public class JUnitPlatformProviderTest
     {
         static int count;
 
+        @org.junit.jupiter.api.DisplayName( "Always passes" )
         @org.junit.jupiter.api.Test
         void testPass()
         {
@@ -843,7 +871,7 @@ public class JUnitPlatformProviderTest
         void testAborted()
         {
             assumeFalse( true );
-            throw new IllegalStateException( "this exception should neve happen" );
+            throw new IllegalStateException( "this exception should never happen" );
         }
 
         @org.junit.jupiter.api.Test
@@ -865,6 +893,7 @@ public class JUnitPlatformProviderTest
             throw new IllegalStateException( "this test should be never called" );
         }
 
+        @org.junit.jupiter.api.DisplayName( "Fails twice" )
         @org.junit.jupiter.api.Test
         void testFailTwice()
         {


### PR DESCRIPTION
As discussed in [Surefire-1584](https://github.com/apache/maven-surefire/pull/245#issuecomment-543702810) there was a bug where `@DisplayName` would break rerun logic. This PR resolves both this bug and addresses another potential issue _(No triggering sample found though)_ where the `adapter` was treated as if it were stateless, but it is stateful.

The platform provider unit test has been updated with `@DisplayName` usages to verify the correctness of this solution.