### PR TITLE
[SUREFIRE-1711] Support @ParameterizedTest for JUnit 5 test reruns

### DIFF
--- a/surefire-providers/surefire-junit-platform/pom.xml
+++ b/surefire-providers/surefire-junit-platform/pom.xml
@@ -96,6 +96,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -31,7 +31,7 @@ import static org.apache.maven.surefire.report.ConsoleOutputCapture.startCapture
 import static org.apache.maven.surefire.util.TestsToRun.fromClass;
 import static org.junit.platform.commons.util.StringUtils.isBlank;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
-import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
 
 import java.io.IOException;
@@ -190,12 +190,7 @@ public class JUnitPlatformProvider
         // Iterate over recorded failures
         for ( TestIdentifier identifier : new HashSet<>( adapter.getFailures().keySet() ) )
         {
-            // Extract quantified test name data
-            String[] classMethodName = adapter.toClassMethodNameWithoutPlan( identifier );
-            String className = classMethodName[0];
-            String methodName = classMethodName[2];
-            // Add filter for the specific failing method
-            builder.selectors( selectMethod( className, methodName ) );
+            builder.selectors( selectUniqueId( identifier.getUniqueId() ) );
         }
         return builder.build();
     }

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -214,16 +214,6 @@ final class RunListenerAdapter
         return new PojoStackTraceWriter( realClassName, realMethodName, throwable );
     }
 
-    private String[] toClassMethodName( TestIdentifier testIdentifier )
-    {
-        return toClassMethodName( testIdentifier, true );
-    }
-
-    String[] toClassMethodNameWithoutPlan( TestIdentifier testIdentifier )
-    {
-        return toClassMethodName( testIdentifier, false );
-    }
-
     /**
      * <ul>
      *     <li>[0] class name - used in stacktrace parser</li>
@@ -233,11 +223,9 @@ final class RunListenerAdapter
      * </ul>
      *
      * @param testIdentifier a class or method
-     * @param usePlan {@code true} for using the test-plan to fetch sources.
-     *                {@code false} to rely on fallbacks.
      * @return 4 elements string array
      */
-    private String[] toClassMethodName( TestIdentifier testIdentifier, boolean usePlan )
+    private String[] toClassMethodName( TestIdentifier testIdentifier )
     {
         Optional<TestSource> testSource = testIdentifier.getSource();
         String display = testIdentifier.getDisplayName();
@@ -247,18 +235,10 @@ final class RunListenerAdapter
             MethodSource methodSource = testSource.map( MethodSource.class::cast ).get();
             String realClassName = methodSource.getClassName();
 
-            String[] source;
-            if ( usePlan )
-            {
-               source = testPlan.getParent( testIdentifier )
-                        .map( i -> toClassMethodName( i, usePlan ) )
-                        .map( s -> new String[] { s[0], s[1] } )
-                        .orElse( new String[] { realClassName, realClassName } );
-            }
-            else
-            {
-                source = new String[] { realClassName, realClassName };
-            }
+            String[] source = testPlan.getParent( testIdentifier )
+                    .map( i -> toClassMethodName( i ) )
+                    .map( s -> new String[] { s[0], s[1] } )
+                    .orElse( new String[] { realClassName, realClassName } );
 
             String methodName = methodSource.getMethodName();
             boolean useMethod = display.equals( methodName ) || display.equals( methodName + "()" );
@@ -276,7 +256,7 @@ final class RunListenerAdapter
         }
         else
         {
-            String source = !usePlan ? display : testPlan.getParent( testIdentifier )
+            String source = testPlan.getParent( testIdentifier )
                     .map( TestIdentifier::getDisplayName ).orElse( display );
             return new String[] {source, source, display, display};
         }


### PR DESCRIPTION
This change fixes the issue discussed in #245 where `@ParameterizedTest` were not supported by the JUnitPlatformProvider.

The fix is rather simple, moving from `DiscoverySelectors.selectMethod` to `DiscoverySelectors.selectUniqueId`. Included are additions to `JUnitPlatformProviderTest` showing this feature is now supported. 

I have detailed why this is a good alternative to parsing the legacy name in a gist: ["The case for UniqueId over Legacy Name "](https://gist.github.com/Col-E/47e0d7cd7267965dada899d4d5e11888)

As mentioned in the gist, using `selectUniqueId` allows us to undo the changes made to [`RunListenerAdapter.toClassMethodName`](https://github.com/apache/maven-surefire/pull/245/files#diff-ad07b0c74885ecb3d687dcc85495e390R240) that were made in #245, which I've also included in this PR.