### PR TITLE
[SUREFIRE-1688] Add failing test case for failure in BeforeAll method

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformIT.java
@@ -88,6 +88,20 @@ public class JUnitPlatformIT
     }
 
     @Test
+    public void testJupiterEngineWithFailingBeforeAllMethod()
+    {
+        OutputValidator validator = unpack( "junit-platform-engine-jupiter", "-" + junit5Version + "-" + jqwikVersion )
+                .setTestToRun( "FailingBeforeAllJupiterTest" )
+                .sysProp( "junit5.version", junit5Version )
+                .sysProp( "jqwik.version", jqwikVersion )
+                .executeTest()
+                .verifyTextInLog( "oneTimeSetUp() failed" );
+
+        validator.getSurefireReportsFile( "junitplatformenginejupiter.FailingBeforeAllJupiterTest.txt", UTF_8 )
+                .assertContainsText( "oneTimeSetUp() failed" );
+    }
+
+    @Test
     public void testJupiterEngineWithDisplayNames()
     {
         OutputValidator validator = unpack( "junit-platform-engine-jupiter", "-" + junit5Version + "-" + jqwikVersion )

--- a/surefire-its/src/test/resources/junit-platform-engine-jupiter/src/test/java/junitplatformenginejupiter/FailingBeforeAllJupiterTest.java
+++ b/surefire-its/src/test/resources/junit-platform-engine-jupiter/src/test/java/junitplatformenginejupiter/FailingBeforeAllJupiterTest.java
@@ -1,0 +1,42 @@
+package junitplatformenginejupiter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class FailingBeforeAllJupiterTest
+{
+
+    @BeforeAll
+    static void oneTimeSetUp()
+    {
+        fail( "oneTimeSetUp() failed" );
+    }
+
+    @Test
+    void test()
+    {
+        // do nothing
+    }
+
+}


### PR DESCRIPTION
The failure used to be reported with 3.0.0-M3 but not with 3.0.0-M4.

As requested in https://issues.apache.org/jira/browse/SUREFIRE-1688?focusedCommentId=16914062&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16914062