### PR TITLE
Refer to correct property in skipping-tests doc

### DIFF
--- a/maven-surefire-plugin/src/site/apt/examples/skipping-tests.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/skipping-tests.apt.vm
@@ -85,7 +85,7 @@ mvn install -DskipTests
  You can also skip the tests via the command line by executing the following command:
 
 +---+
-mvn install -DskipITs
+mvn install -DskipTests
 +---+
 
  Since <<<skipTests>>> is also supported by the ${thatPlugin} Plugin, this will have the effect


### PR DESCRIPTION
I found a little error when reading https://maven.apache.org/surefire/maven-failsafe-plugin/examples/skipping-tests.html :

> You can also skip the tests via the command line by executing the following command:
>
>     mvn install -DskipITs
>
> Since skipTests is also supported by the Surefire Plugin, this will have the effect of not running any tests. If, instead, you want to skip only the integration tests being run by the Failsafe Plugin, you would use the skipITs property instead:
>
>     mvn install -DskipITs

The former command should refer to ` skipTests` instead.