### PR TITLE
[SUREFIRE-1741] JUnit5: Detect failed containers

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
@@ -192,6 +192,54 @@ public class JUnitPlatformEnginesIT extends SurefireJUnit4IntegrationTestCase
     }
 
     @Test
+    public void errorInBeforeAllMethod()
+    {
+        OutputValidator validator = unpack( "surefire-1741", "-" + jupiter )
+                .setTestToRun( "ErrorInBeforeAllJupiterTest" )
+                .sysProp( "junit5.version", jupiter )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog( "oneTimeSetUp() encountered an error" )
+                .assertTestSuiteResults( 1, 1, 0, 0 );
+
+        validator.getSurefireReportsFile( "jira1741.ErrorInBeforeAllJupiterTest.txt", UTF_8 )
+                .assertContainsText( "oneTimeSetUp() encountered an error" );
+    }
+
+    @Test
+    public void testJupiterEngineWithErrorInParameterizedSource()
+    {
+        OutputValidator validator = unpack( "surefire-1741", "-" + jupiter )
+                .setTestToRun( "ErrorInParameterizedSourceJupiterTest" )
+                .sysProp( "junit5.version", jupiter )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog( "args() method source encountered an error" )
+                .assertTestSuiteResults( 1, 1, 0, 0 );
+
+        validator.getSurefireReportsFile( "jira1741.ErrorInParameterizedSourceJupiterTest.txt", UTF_8 )
+                .assertContainsText( "args() method source encountered an error" );
+    }
+
+    @Test
+    public void testJupiterEngineWithFailureInParameterizedSource()
+    {
+        OutputValidator validator = unpack( "surefire-1741", "-" + jupiter )
+                .setTestToRun( "FailureInParameterizedSourceJupiterTest" )
+                .sysProp( "junit5.version", jupiter )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog( "args() method source failed" )
+                .assertTestSuiteResults( 1, 0, 1, 0 );
+
+        validator.getSurefireReportsFile( "jira1741.FailureInParameterizedSourceJupiterTest.txt", UTF_8 )
+                .assertContainsText( "args() method source failed" );
+    }
+
+    @Test
     public void testJupiterEngineWithDisplayNames()
     {
         OutputValidator validator = unpack( "junit-platform-engine-jupiter", "-" + jupiter )

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
@@ -240,6 +240,70 @@ public class JUnitPlatformEnginesIT extends SurefireJUnit4IntegrationTestCase
     }
 
     @Test
+    public void testJupiterEngineWithErrorInTestFactory()
+    {
+        OutputValidator validator = unpack( "surefire-1727", "-" + jupiter )
+                .setTestToRun( "ErrorInTestFactoryJupiterTest" )
+                .sysProp( "junit5.version", jupiter )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog( "Encountered error in TestFactory testFactory()" )
+                .assertTestSuiteResults( 1, 1, 0, 0 );
+
+        validator.getSurefireReportsFile( "jira1727.ErrorInTestFactoryJupiterTest.txt", UTF_8 )
+                .assertContainsText( "Encountered error in TestFactory testFactory()" );
+    }
+
+    @Test
+    public void testJupiterEngineWithFailureInTestFactory()
+    {
+        OutputValidator validator = unpack( "surefire-1727", "-" + jupiter )
+                .setTestToRun( "FailureInTestFactoryJupiterTest" )
+                .sysProp( "junit5.version", jupiter )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog( "Encountered failure in TestFactory testFactory()" )
+                .assertTestSuiteResults( 1, 0, 1, 0 );
+
+        validator.getSurefireReportsFile( "jira1727.FailureInTestFactoryJupiterTest.txt", UTF_8 )
+                .assertContainsText( "Encountered failure in TestFactory testFactory()" );
+    }
+
+    @Test
+    public void testJupiterEngineWithErrorInTestTemplateProvider()
+    {
+        OutputValidator validator = unpack( "surefire-1727", "-" + jupiter )
+                .setTestToRun( "ErrorInTestTemplateProviderTest" )
+                .sysProp( "junit5.version", jupiter )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog( "Encountered error in TestTemplate provideTestTemplateInvocationContexts()" )
+                .assertTestSuiteResults( 1, 1, 0, 0 );
+
+        validator.getSurefireReportsFile( "jira1727.ErrorInTestTemplateProviderTest.txt", UTF_8 )
+                .assertContainsText( "Encountered error in TestTemplate provideTestTemplateInvocationContexts()" );
+    }
+
+    @Test
+    public void testJupiterEngineWithFailureInTestTemplateProvider()
+    {
+        OutputValidator validator = unpack( "surefire-1727", "-" + jupiter )
+                .setTestToRun( "FailureInTestTemplateProviderTest" )
+                .sysProp( "junit5.version", jupiter )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog( "Encountered failure in TestTemplate provideTestTemplateInvocationContexts()" )
+                .assertTestSuiteResults( 1, 0, 1, 0 );
+
+        validator.getSurefireReportsFile( "jira1727.FailureInTestTemplateProviderTest.txt", UTF_8 )
+                .assertContainsText( "Encountered failure in TestTemplate provideTestTemplateInvocationContexts()" );
+    }
+
+    @Test
     public void testJupiterEngineWithDisplayNames()
     {
         OutputValidator validator = unpack( "junit-platform-engine-jupiter", "-" + jupiter )

--- a/surefire-its/src/test/resources/surefire-1727/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1727/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit-platform-engine-jupiter</artifactId>
+    <version>1.0</version>
+    <name>Test for JUnit 5: Platform + Jupiter</name>
+
+    <properties>
+        <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+        <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/ErrorInTestFactoryJupiterTest.java
+++ b/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/ErrorInTestFactoryJupiterTest.java
@@ -1,0 +1,33 @@
+package jira1727;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.stream.Stream;
+
+class ErrorInTestFactoryJupiterTest
+{
+    @TestFactory
+    Stream<DynamicTest> testFactory() {
+        throw new RuntimeException( "Encountered error in TestFactory testFactory()" );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/ErrorInTestProvider.java
+++ b/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/ErrorInTestProvider.java
@@ -1,0 +1,41 @@
+package jira1727;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import java.util.stream.Stream;
+
+class ErrorInTestProvider
+    implements TestTemplateInvocationContextProvider
+{
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+            ExtensionContext context) {
+        throw new RuntimeException( "Encountered error in TestTemplate provideTestTemplateInvocationContexts()" );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/ErrorInTestTemplateProviderTest.java
+++ b/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/ErrorInTestTemplateProviderTest.java
@@ -1,0 +1,31 @@
+package jira1727;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ErrorInTestProvider.class)
+class ErrorInTestTemplateProviderTest
+{
+    @TestTemplate
+    void templatedTest() {
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/FailureInTestFactoryJupiterTest.java
+++ b/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/FailureInTestFactoryJupiterTest.java
@@ -1,0 +1,36 @@
+package jira1727;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class FailureInTestFactoryJupiterTest
+{
+    @TestFactory
+    Stream<DynamicTest> testFactory() {
+        fail( "Encountered failure in TestFactory testFactory()" );
+        return Stream.of();
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/FailureInTestProvider.java
+++ b/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/FailureInTestProvider.java
@@ -1,0 +1,44 @@
+package jira1727;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class FailureInTestProvider
+    implements TestTemplateInvocationContextProvider
+{
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+            ExtensionContext context) {
+        fail( "Encountered failure in TestTemplate provideTestTemplateInvocationContexts()" );
+        return Stream.of();
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/FailureInTestTemplateProviderTest.java
+++ b/surefire-its/src/test/resources/surefire-1727/src/test/java/jira1727/FailureInTestTemplateProviderTest.java
@@ -1,0 +1,31 @@
+package jira1727;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(FailureInTestProvider.class)
+class FailureInTestTemplateProviderTest
+{
+    @TestTemplate
+    void templatedTest() {
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1741/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1741/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit-platform-engine-jupiter</artifactId>
+    <version>1.0</version>
+    <name>Test for JUnit 5: Platform + Jupiter</name>
+
+    <properties>
+        <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+        <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-1741/src/test/java/jira1741/ErrorInBeforeAllJupiterTest.java
+++ b/surefire-its/src/test/resources/surefire-1741/src/test/java/jira1741/ErrorInBeforeAllJupiterTest.java
@@ -1,0 +1,37 @@
+package jira1741;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ErrorInBeforeAllJupiterTest
+{
+    @BeforeAll
+    static void oneTimeSetUp()
+    {
+        throw new RuntimeException( "oneTimeSetUp() encountered an error" );
+    }
+
+    @Test
+    void test()
+    {
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1741/src/test/java/jira1741/ErrorInParameterizedSourceJupiterTest.java
+++ b/surefire-its/src/test/resources/surefire-1741/src/test/java/jira1741/ErrorInParameterizedSourceJupiterTest.java
@@ -1,0 +1,37 @@
+package jira1741;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+class ErrorInParameterizedSourceJupiterTest
+{
+    static Stream<Arguments> args() {
+        throw new RuntimeException( "args() method source encountered an error" );
+    }
+
+    @ParameterizedTest
+    @MethodSource("args")
+    void doTest() {
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1741/src/test/java/jira1741/FailureInParameterizedSourceJupiterTest.java
+++ b/surefire-its/src/test/resources/surefire-1741/src/test/java/jira1741/FailureInParameterizedSourceJupiterTest.java
@@ -1,0 +1,40 @@
+package jira1741;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class FailureInParameterizedSourceJupiterTest
+{
+    static Stream<Arguments> args() {
+        fail( "args() method source failed" );
+        return Stream.of();
+    }
+
+    @ParameterizedTest
+    @MethodSource("args")
+    void doTest() {
+    }
+}

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -97,7 +97,9 @@ final class RunListenerAdapter
 
         boolean isTest = testIdentifier.isTest();
 
-        if ( isClass || isTest )
+        boolean isFailedContainer = isFailedContainer( testIdentifier, testExecutionResult );
+
+        if ( isFailedContainer || isClass || isTest )
         {
             Integer elapsed = computeElapsedTime( testIdentifier );
             switch ( testExecutionResult.getStatus() )
@@ -173,8 +175,9 @@ final class RunListenerAdapter
         {
             classText = null;
         }
-        String methodName = testIdentifier.isTest() ? classMethodName[2] : null;
-        String methodText = testIdentifier.isTest() ? classMethodName[3] : null;
+        boolean isFailedContainer = isFailedContainer( testIdentifier, testExecutionResult );
+        String methodName = ( isFailedContainer || testIdentifier.isTest() ) ? classMethodName[2] : null;
+        String methodText = ( isFailedContainer || testIdentifier.isTest() ) ? classMethodName[3] : null;
         if ( Objects.equals( methodName, methodText ) )
         {
             methodText = null;
@@ -183,6 +186,13 @@ final class RunListenerAdapter
                 testExecutionResult == null ? null : toStackTraceWriter( className, methodName, testExecutionResult );
         return new SimpleReportEntry( className, classText, methodName, methodText,
                 stw, elapsedTime, reason, systemProperties );
+    }
+
+    private boolean isFailedContainer( TestIdentifier testIdentifier,
+                                      TestExecutionResult testExecutionResult )
+    {
+        return testIdentifier.isContainer() && testExecutionResult != null
+                && testExecutionResult.getStatus() == TestExecutionResult.Status.FAILED;
     }
 
     private SimpleReportEntry createReportEntry( TestIdentifier testIdentifier )

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -135,6 +135,53 @@ public class JUnitPlatformProviderTest
     }
 
     @Test
+    public void shouldErrorClassOnBeforeAll()
+            throws Exception
+    {
+        Launcher launcher = LauncherFactory.create();
+        JUnitPlatformProvider provider = new JUnitPlatformProvider( providerParametersMock(), launcher );
+        RunListener listener = mock( RunListener.class );
+
+        ArgumentCaptor<ReportEntry> testCaptor = ArgumentCaptor.forClass( ReportEntry.class );
+        ArgumentCaptor<TestSetReportEntry> testSetCaptor = ArgumentCaptor.forClass( TestSetReportEntry.class );
+
+        RunListenerAdapter adapter = new RunListenerAdapter( listener );
+        launcher.registerTestExecutionListeners( adapter );
+
+        TestsToRun testsToRun = newTestsToRun( FailingWithErrorBeforeAllJupiterTest.class );
+        invokeProvider( provider, testsToRun );
+        InOrder inOrder = inOrder( listener );
+        inOrder.verify( listener, times( 1 ) ).testSetStarting( testSetCaptor.capture() );
+        inOrder.verify( listener, never() ).testStarting( any( ReportEntry.class ) );
+        inOrder.verify( listener, times( 1 ) ).testError( testCaptor.capture() );
+        inOrder.verify( listener, times( 1 ) ).testSetCompleted( testSetCaptor.capture() );
+
+        assertThat( testSetCaptor.getAllValues() )
+                .hasSize( 2 );
+
+        assertThat( testSetCaptor.getAllValues().get( 0 ).getSourceName() )
+                .isEqualTo( FailingWithErrorBeforeAllJupiterTest.class.getName() );
+
+        assertThat( testSetCaptor.getAllValues().get( 0 ).getName() )
+                .isNull();
+
+        assertThat( testCaptor.getAllValues() )
+                .hasSize( 1 );
+
+        assertThat( testCaptor.getValue().getSourceName() )
+                .isEqualTo( FailingWithErrorBeforeAllJupiterTest.class.getName() );
+
+        assertThat( testCaptor.getValue().getName() )
+                .isNull();
+
+        assertThat( testSetCaptor.getAllValues().get( 1 ).getSourceName() )
+                .isEqualTo( FailingWithErrorBeforeAllJupiterTest.class.getName() );
+
+        assertThat( testSetCaptor.getAllValues().get( 1 ).getName() )
+                .isNull();
+    }
+
+    @Test
     public void getSuitesReturnsScannedClasses()
     {
         ProviderParameters providerParameters = providerParametersMock( TestClass1.class, TestClass2.class );
@@ -397,7 +444,7 @@ public class JUnitPlatformProviderTest
     }
 
     @Test
-    public void detectFailedParameterized()
+    public void detectErroredParameterized()
         throws Exception
     {
         Launcher launcher = LauncherFactory.create();
@@ -422,6 +469,44 @@ public class JUnitPlatformProviderTest
         List<ReportEntry> reportEntries = entryCaptor.getAllValues();
 
         assertEquals( TestClass8.class.getName(), reportEntries.get( 0 ).getSourceName() );
+        assertNull( reportEntries.get( 0 ).getSourceText() );
+        assertEquals( "testParameterizedTestCases", reportEntries.get( 0 ).getName() );
+        assertNull( reportEntries.get( 0 ).getNameText() );
+
+        TestExecutionSummary summary = executionListener.summaries.get( 0 );
+        assertEquals( 0, summary.getTestsFoundCount() );
+        assertEquals( 1, summary.getContainersFailedCount() );
+        assertEquals( 0, summary.getTestsStartedCount() );
+        assertEquals( 0, summary.getTestsSucceededCount() );
+        assertEquals( 0, summary.getTestsFailedCount() );
+    }
+
+    @Test
+    public void detectFailedParameterized()
+            throws Exception
+    {
+        Launcher launcher = LauncherFactory.create();
+        ProviderParameters parameters = providerParametersMock();
+
+        JUnitPlatformProvider provider = new JUnitPlatformProvider( parameters, launcher );
+
+        TestPlanSummaryListener executionListener = new TestPlanSummaryListener();
+
+        RunListener listener = mock( RunListener.class );
+        ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass( ReportEntry.class );
+        RunListenerAdapter adapter = new RunListenerAdapter( listener );
+
+        launcher.registerTestExecutionListeners( executionListener, adapter );
+
+        invokeProvider( provider, TestClass9.class );
+
+        assertThat( executionListener.summaries ).hasSize( 1 );
+
+        verify( listener, times( 1 ) ).testSetCompleted( any() );
+        verify( listener, times( 1 ) ).testFailed( entryCaptor.capture() );
+        List<ReportEntry> reportEntries = entryCaptor.getAllValues();
+
+        assertEquals( TestClass9.class.getName(), reportEntries.get( 0 ).getSourceName() );
         assertNull( reportEntries.get( 0 ).getSourceText() );
         assertEquals( "testParameterizedTestCases", reportEntries.get( 0 ).getName() );
         assertNull( reportEntries.get( 0 ).getNameText() );
@@ -1168,6 +1253,21 @@ public class JUnitPlatformProviderTest
         }
     }
 
+    static class TestClass9
+    {
+        static List<Object[]> params()
+        {
+            assertTrue( false );
+            return new ArrayList<>();
+        }
+
+        @org.junit.jupiter.params.ParameterizedTest
+        @org.junit.jupiter.params.provider.MethodSource( "params" )
+        void testParameterizedTestCases()
+        {
+        }
+    }
+
     @DisplayName( "<< ✨ >>" )
     static class DisplayNameTest
     {
@@ -1185,6 +1285,22 @@ public class JUnitPlatformProviderTest
         static void oneTimeSetUp()
         {
             fail( "oneTimeSetUp() failed" );
+        }
+
+        @org.junit.jupiter.api.Test
+        void test()
+        {
+        }
+
+    }
+
+    static class FailingWithErrorBeforeAllJupiterTest
+    {
+
+        @BeforeAll
+        static void oneTimeSetUp()
+        {
+            throw new RuntimeException( "oneTimeSetUp() threw an exception" );
         }
 
         @org.junit.jupiter.api.Test

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -417,7 +417,8 @@ public class JUnitPlatformProviderTest
 
         assertThat( executionListener.summaries ).hasSize( 1 );
 
-        verify( listener, times( 1 ) ).testFailed( entryCaptor.capture() );
+        verify( listener, times( 1 ) ).testSetCompleted( any() );
+        verify( listener, times( 1 ) ).testError( entryCaptor.capture() );
         List<ReportEntry> reportEntries = entryCaptor.getAllValues();
 
         assertEquals( TestClass8.class.getName(), reportEntries.get( 0 ).getSourceName() );

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -425,7 +425,7 @@ public class RunListenerAdapterTest
                     throws Exception
     {
         adapter.executionFinished( newContainerIdentifier(), failed( new RuntimeException() ) );
-        verify( listener ).testFailed( any() );
+        verify( listener ).testError( any() );
     }
 
     @Test
@@ -473,7 +473,7 @@ public class RunListenerAdapterTest
         adapter.testPlanExecutionStarted( testPlan );
 
         adapter.executionFinished( newContainerIdentifier(), failed( new RuntimeException() ) );
-        verify( listener ).testFailed( entryCaptor.capture() );
+        verify( listener ).testError( entryCaptor.capture() );
 
         ReportEntry entry = entryCaptor.getValue();
         assertEquals( MyTestClass.class.getTypeName(), entry.getSourceName() );

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -55,6 +55,7 @@ import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestSource;
@@ -420,6 +421,14 @@ public class RunListenerAdapterTest
     }
 
     @Test
+    public void notifiedOfContainerFailure()
+                    throws Exception
+    {
+        adapter.executionFinished( newContainerIdentifier(), failed( new RuntimeException() ) );
+        verify( listener ).testFailed( any() );
+    }
+
+    @Test
     public void notifiedWhenMethodExecutionFailed()
                     throws Exception
     {
@@ -453,6 +462,26 @@ public class RunListenerAdapterTest
         assertNotNull( entry.getStackTraceWriter().getThrowable() );
         assertThat( entry.getStackTraceWriter().getThrowable().getTarget() )
                 .isInstanceOf( AssertionError.class );
+    }
+
+    @Test
+    public void notifiedWithCorrectNamesWhenContainerFailed()
+                    throws Exception
+    {
+        ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass( ReportEntry.class );
+        TestPlan testPlan = TestPlan.from( singletonList( new EngineDescriptor( newId(), "Luke's Plan" ) ) );
+        adapter.testPlanExecutionStarted( testPlan );
+
+        adapter.executionFinished( newContainerIdentifier(), failed( new RuntimeException() ) );
+        verify( listener ).testFailed( entryCaptor.capture() );
+
+        ReportEntry entry = entryCaptor.getValue();
+        assertEquals( MyTestClass.class.getTypeName(), entry.getSourceName() );
+        assertEquals( MY_TEST_METHOD_NAME, entry.getName() );
+        assertNotNull( entry.getStackTraceWriter() );
+        assertNotNull( entry.getStackTraceWriter().getThrowable() );
+        assertThat( entry.getStackTraceWriter().getThrowable().getTarget() )
+                .isInstanceOf( RuntimeException.class );
     }
 
     @Test
@@ -647,6 +676,15 @@ public class RunListenerAdapterTest
         testPlan.add( parentId );
 
         return childId;
+    }
+
+    private static TestIdentifier newContainerIdentifier()
+        throws Exception
+    {
+        return TestIdentifier.from(
+                new TestTemplateTestDescriptor( UniqueId.forEngine( "method" ),
+                    MyTestClass.class,
+                    MyTestClass.class.getDeclaredMethod( MY_TEST_METHOD_NAME ) ) );
     }
 
     private static TestIdentifier newEngineIdentifier()


### PR DESCRIPTION
Failed JUnit5 containers will be reported as test failures. This is intended to address [SUREFIRE-1741](https://issues.apache.org/jira/browse/SUREFIRE-1741).

Note: I can't comment on the JIRA issue currently, but I will when I get in to work.

I just now noticed there's already a PR open that (in my opinion) addresses this issue better and more simply (https://github.com/apache/maven-surefire/pull/257), but since I already wrote it up I'm just gonna open this one anyways.