### PR TITLE
[SUREFIRE-1748] Fix reporting of empty stack trace messages

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkedChannelDecoder.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkedChannelDecoder.java
@@ -27,7 +27,6 @@ import org.apache.maven.surefire.report.StackTraceWriter;
 
 import java.nio.charset.Charset;
 import java.util.Collections;
-import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -189,8 +188,9 @@ public final class ForkedChannelDecoder
             return;
         }
 
-        StringTokenizer tokenizer = new StringTokenizer( line.substring( MAGIC_NUMBER.length() ), ":" );
-        String opcode = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
+        String[] tokens = line.substring( MAGIC_NUMBER.length() ).split( ":" );
+        int index = -1;
+        String opcode = tokens.length > ++index ? tokens[index] : null;
         ForkedProcessEvent event = opcode == null ? null : EVENTS.get( opcode );
         if ( event == null )
         {
@@ -211,65 +211,65 @@ public final class ForkedChannelDecoder
             else if ( event.isConsoleCategory() )
             {
                 ForkedProcessStringEventListener listener = consoleEventListeners.get( event );
-                Charset encoding = tokenizer.hasMoreTokens() ? Charset.forName( tokenizer.nextToken() ) : null;
+                Charset encoding = tokens.length > ++index ? Charset.forName( tokens[index] ) : null;
                 if ( listener != null && encoding != null )
                 {
-                    String msg = tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : "";
+                    String msg = tokens.length > ++index ? decode( tokens[index], encoding ) : "";
                     listener.handle( msg );
                 }
             }
             else if ( event.isConsoleErrorCategory() )
             {
-                Charset encoding = tokenizer.hasMoreTokens() ? Charset.forName( tokenizer.nextToken() ) : null;
+                Charset encoding = tokens.length > ++index ? Charset.forName( tokens[index] ) : null;
                 if ( consoleErrorEventListener != null && encoding != null )
                 {
-                    String msg = tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : null;
+                    String msg = tokens.length > ++index ? decode( tokens[index], encoding ) : null;
                     String smartStackTrace =
-                            tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : null;
-                    String stackTrace = tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : null;
+                            tokens.length > ++index ? decode( tokens[index], encoding ) : null;
+                    String stackTrace = tokens.length > ++index ? decode( tokens[index], encoding ) : null;
                     consoleErrorEventListener.handle( msg, smartStackTrace, stackTrace );
                 }
             }
             else if ( event.isStandardStreamCategory() )
             {
                 ForkedProcessStandardOutErrEventListener listener = stdOutErrEventListeners.get( event );
-                RunMode mode = tokenizer.hasMoreTokens() ? MODES.get( tokenizer.nextToken() ) : null;
-                Charset encoding = tokenizer.hasMoreTokens() ? Charset.forName( tokenizer.nextToken() ) : null;
+                RunMode mode = tokens.length > ++index ? MODES.get( tokens[index] ) : null;
+                Charset encoding = tokens.length > ++index ? Charset.forName( tokens[index] ) : null;
                 if ( listener != null && encoding != null && mode != null )
                 {
                     boolean newLine = event == BOOTERCODE_STDOUT_NEW_LINE || event == BOOTERCODE_STDERR_NEW_LINE;
-                    String output = tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : "";
+                    String output = tokens.length > ++index ? decode( tokens[index], encoding ) : "";
                     listener.handle( mode, output, newLine );
                 }
             }
             else if ( event.isSysPropCategory() )
             {
-                RunMode mode = tokenizer.hasMoreTokens() ? MODES.get( tokenizer.nextToken() ) : null;
-                Charset encoding = tokenizer.hasMoreTokens() ? Charset.forName( tokenizer.nextToken() ) : null;
-                String key = tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : "";
+                RunMode mode = tokens.length > ++index ? MODES.get( tokens[index] ) : null;
+                Charset encoding = tokens.length > ++index ? Charset.forName( tokens[index] ) : null;
+                String key = tokens.length > ++index ? decode( tokens[index], encoding ) : "";
                 if ( propertyEventListener != null && isNotBlank( key ) )
                 {
-                    String value = tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : "";
+                    String value = tokens.length > ++index ? decode( tokens[index], encoding ) : "";
                     propertyEventListener.handle( mode, key, value );
                 }
             }
             else if ( event.isTestCategory() )
             {
                 ForkedProcessReportEventListener listener = reportEventListeners.get( event );
-                RunMode mode = tokenizer.hasMoreTokens() ? MODES.get( tokenizer.nextToken() ) : null;
-                Charset encoding = tokenizer.hasMoreTokens() ? Charset.forName( tokenizer.nextToken() ) : null;
+                RunMode mode = tokens.length > ++index ? MODES.get( tokens[index] ) : null;
+                Charset encoding = tokens.length > ++index ? Charset.forName( tokens[index] ) : null;
                 if ( listener != null && encoding != null && mode != null )
                 {
-                    String sourceName = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
-                    String sourceText = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
-                    String name = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
-                    String nameText = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
-                    String group = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
-                    String message = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
-                    String elapsed = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
-                    String traceMessage = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
-                    String smartTrimmedStackTrace = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
-                    String stackTrace = tokenizer.hasMoreTokens() ? tokenizer.nextToken() : null;
+                    String sourceName = tokens.length > ++index ? tokens[index] : null;
+                    String sourceText = tokens.length > ++index ? tokens[index] : null;
+                    String name = tokens.length > ++index ? tokens[index] : null;
+                    String nameText = tokens.length > ++index ? tokens[index] : null;
+                    String group = tokens.length > ++index ? tokens[index] : null;
+                    String message = tokens.length > ++index ? tokens[index] : null;
+                    String elapsed = tokens.length > ++index ? tokens[index] : null;
+                    String traceMessage = tokens.length > ++index ? tokens[index] : null;
+                    String smartTrimmedStackTrace = tokens.length > ++index ? tokens[index] : null;
+                    String stackTrace = tokens.length > ++index ? tokens[index] : null;
                     ReportEntry reportEntry = toReportEntry( encoding, sourceName, sourceText, name, nameText,
                             group, message, elapsed, traceMessage, smartTrimmedStackTrace, stackTrace );
                     listener.handle( mode, reportEntry );
@@ -279,11 +279,11 @@ public final class ForkedChannelDecoder
             {
                 if ( exitErrorEventListener != null )
                 {
-                    Charset encoding = tokenizer.hasMoreTokens() ? Charset.forName( tokenizer.nextToken() ) : null;
-                    String message = tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : "";
+                    Charset encoding = tokens.length > ++index ? Charset.forName( tokens[index] ) : null;
+                    String message = tokens.length > ++index ? decode( tokens[index], encoding ) : "";
                     String smartTrimmedStackTrace =
-                            tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : "";
-                    String stackTrace = tokenizer.hasMoreTokens() ? decode( tokenizer.nextToken(), encoding ) : "";
+                            tokens.length > ++index ? decode( tokens[index], encoding ) : "";
+                    String stackTrace = tokens.length > ++index ? decode( tokens[index], encoding ) : "";
                     exitErrorEventListener.handle( message, smartTrimmedStackTrace, stackTrace );
                 }
             }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
@@ -304,6 +304,44 @@ public class JUnitPlatformEnginesIT extends SurefireJUnit4IntegrationTestCase
     }
 
     @Test
+    public void testJupiterEngineWithAssertionsFailNoParameters()
+    {
+        // `Assertions.fail()` not supported until 5.2.0
+        assumeThat( jupiter, is( not( "5.0.3" ) ) );
+        assumeThat( jupiter, is( not( "5.1.1" ) ) );
+
+        OutputValidator validator = unpack( "surefire-1748-fail-no-parameters", "-" + jupiter )
+                .setTestToRun( "AssertionsFailNoParametersJupiterTest" )
+                .sysProp( "junit5.version", jupiter )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog( "AssertionsFailNoParametersJupiterTest.doTest:31" )
+                .assertTestSuiteResults( 1, 0, 1, 0 );
+
+        validator.getSurefireReportsFile( "jira1748.AssertionsFailNoParametersJupiterTest.txt", UTF_8 )
+                .assertContainsText( "AssertionsFailNoParametersJupiterTest.doTest"
+                        + "(AssertionsFailNoParametersJupiterTest.java:31)" );
+    }
+
+    @Test
+    public void testJupiterEngineWithAssertionsFailEmptyStringParameters()
+    {
+        OutputValidator validator = unpack( "surefire-1748", "-" + jupiter )
+                .setTestToRun( "AssertionsFailEmptyStringParameterJupiterTest" )
+                .sysProp( "junit5.version", jupiter )
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextInLog( "AssertionsFailEmptyStringParameterJupiterTest.doTest:31" )
+                .assertTestSuiteResults( 1, 0, 1, 0 );
+
+        validator.getSurefireReportsFile( "jira1748.AssertionsFailEmptyStringParameterJupiterTest.txt", UTF_8 )
+                .assertContainsText( "AssertionsFailEmptyStringParameterJupiterTest.doTest"
+                        + "(AssertionsFailEmptyStringParameterJupiterTest.java:31)" );
+    }
+
+    @Test
     public void testJupiterEngineWithDisplayNames()
     {
         OutputValidator validator = unpack( "junit-platform-engine-jupiter", "-" + jupiter )

--- a/surefire-its/src/test/resources/surefire-1748-fail-no-parameters/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1748-fail-no-parameters/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit-platform-engine-jupiter</artifactId>
+    <version>1.0</version>
+    <name>Test for JUnit 5: Platform + Jupiter</name>
+
+    <properties>
+        <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+        <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-1748-fail-no-parameters/src/test/java/jira1748/AssertionsFailNoParametersJupiterTest.java
+++ b/surefire-its/src/test/resources/surefire-1748-fail-no-parameters/src/test/java/jira1748/AssertionsFailNoParametersJupiterTest.java
@@ -1,0 +1,33 @@
+package jira1748;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class AssertionsFailNoParametersJupiterTest
+{
+    @Test
+    void doTest()
+    {
+        fail();
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1748/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1748/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit-platform-engine-jupiter</artifactId>
+    <version>1.0</version>
+    <name>Test for JUnit 5: Platform + Jupiter</name>
+
+    <properties>
+        <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+        <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-1748/src/test/java/jira1748/AssertionsFailEmptyStringParameterJupiterTest.java
+++ b/surefire-its/src/test/resources/surefire-1748/src/test/java/jira1748/AssertionsFailEmptyStringParameterJupiterTest.java
@@ -1,0 +1,33 @@
+package jira1748;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class AssertionsFailEmptyStringParameterJupiterTest
+{
+    @Test
+    void doTest()
+    {
+        fail( "" );
+    }
+}


### PR DESCRIPTION
Empty string stack trace messages no longer break the reporting process. This is intended to address [SUREFIRE-1748](https://issues.apache.org/jira/browse/SUREFIRE-1748).