### PR TITLE
[SUREFIRE-1628] fix compatibility with maven 3.0.5

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -765,9 +765,6 @@ public abstract class AbstractSurefireMojo
     private ToolchainManager toolchainManager;
 
     @Component
-    private LocationManager locationManager;
-
-    @Component
     private RepositorySystem repositorySystem;
 
     @Component
@@ -1858,7 +1855,7 @@ public abstract class AbstractSurefireMojo
      */
     private LocationManager getLocationManager()
     {
-        return locationManager;
+        return new LocationManager();
     }
 
     private StartupConfiguration newStartupConfigWithModularPath(


### PR DESCRIPTION
As  advised by @rfscholte and suggested by @Tibor17  I created this pull request to fix compatibility with maven 3.0.5 by replacing injection of LocationManager with instantiation.