### PR TITLE
use org.testng.TestNG.addListener(java.lang.Object)

### DIFF
--- a/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/TestNGExecutor.java
+++ b/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/TestNGExecutor.java
@@ -309,7 +309,8 @@ final class TestNGExecutor
             ClassLoader cl = Thread.currentThread().getContextClassLoader();
             testNG.addListener( instantiate( cl, "org.apache.maven.surefire.testng.utils.FailFastNotifier",
                                              Object.class ) );
-            testNG.addListener( new FailFastListener( createStoppable( reportManager, skipAfterFailureCount ) ) );
+            testNG.addListener( (Object)
+                                new FailFastListener( createStoppable( reportManager, skipAfterFailureCount ) ) );
         }
 
         // FIXME: use classifier to decide if we need to pass along the source dir (only for JDK14)


### PR DESCRIPTION
instead of org.testng.TestNG.addListener(org.testng.ITestListener) which
has been removed from testng 7.x+ (SUREFIRE-1762)