### PR TITLE
Upgrade Surefire 2.22.x to junit-platform-launcher 1.6.1

### DIFF
--- a/surefire-providers/surefire-junit-platform/pom.xml
+++ b/surefire-providers/surefire-junit-platform/pom.xml
@@ -86,12 +86,12 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.3.1</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.3.1</version>
+            <version>5.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The JUnit team improved error reporting for engine discovery/execution failures. The relevant changes are in `DefaultLauncher` which is contained in the `junit-platform-launcher` artifact.

This commit upgrades the version to `1.6.1`.

See also https://issues.apache.org/jira/browse/SUREFIRE-1764 and https://github.com/junit-team/junit5/issues/2028