### PR TITLE
[SUREFIRE-1783] Fork JVM defined by Toolchain should not inherit JAVA_HOME from Maven process

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -89,6 +89,7 @@ import org.apache.maven.surefire.util.RunOrder;
 import org.apache.maven.toolchain.DefaultToolchain;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
+import org.apache.maven.toolchain.java.DefaultJavaToolChain;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.languages.java.jpms.LocationManager;
 import org.codehaus.plexus.languages.java.jpms.ResolvePathsRequest;
@@ -2553,6 +2554,15 @@ public abstract class AbstractSurefireMojo
                     DefaultToolchain defaultToolchain = (DefaultToolchain) toolchain;
                     javaVersion9 = defaultToolchain.matchesRequirements( JAVA_9_MATCHER )
                                              || defaultToolchain.matchesRequirements( JAVA_9_MATCHER_OLD_NOTATION );
+                }
+
+                if ( toolchain instanceof DefaultJavaToolChain )
+                {
+                    DefaultJavaToolChain defaultJavaToolChain = (DefaultJavaToolChain) toolchain;
+                    if ( !environmentVariables.containsKey( "JAVA_HOME" ) )
+                    {
+                        environmentVariables.put( "JAVA_HOME", defaultJavaToolChain.getJavaHome() );
+                    }
                 }
 
                 if ( !javaVersion9 )

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -44,6 +44,7 @@ import org.apache.maven.surefire.booter.Classpath;
 import org.apache.maven.surefire.booter.StartupConfiguration;
 import org.apache.maven.surefire.extensions.ForkNodeFactory;
 import org.apache.maven.surefire.suite.RunResult;
+import org.apache.maven.toolchain.Toolchain;
 import org.codehaus.plexus.logging.Logger;
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,6 +62,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -2173,6 +2175,13 @@ public class AbstractSurefireMojoTest
         public void setSystemPropertiesFile( File systemPropertiesFile )
         {
 
+        }
+
+        public void setToolchain( Toolchain toolchain ) throws Exception
+        {
+            Field toolchainField = AbstractSurefireMojo.class.getDeclaredField( "toolchain" );
+            toolchainField.setAccessible( true );
+            toolchainField.set( this, toolchain );
         }
     }
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoToolchainsTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoToolchainsTest.java
@@ -23,6 +23,8 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
+import org.apache.maven.toolchain.java.DefaultJavaToolChain;
+import org.fest.assertions.MapAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -133,6 +135,25 @@ public class AbstractSurefireMojoToolchainsTest
         assertThat( actual )
             .isSameAs( expected );
     }
+
+    /**
+     * Ensures that the environmentVariables map for launching a test jvm
+     * contains a Toolchain-driven entry when toolchain is set.
+     */
+    @Test
+    public void shouldChangeJavaHomeFromToolchain() throws Exception
+    {
+        AbstractSurefireMojoTest.Mojo mojo = new AbstractSurefireMojoTest.Mojo();
+        DefaultJavaToolChain toolchain = mock( DefaultJavaToolChain.class );
+        when( toolchain.findTool( "java" ) ).thenReturn( "/some/path/bin/java" );
+        when( toolchain.getJavaHome() ).thenReturn( "/some/path" );
+        mojo.setToolchain( toolchain );
+
+        assertThat( mojo.getEnvironmentVariables() ).isEmpty();
+        invokeMethod( mojo, "getEffectiveJvm" );
+        assertThat( mojo.getEnvironmentVariables() ).includes( MapAssert.entry( "JAVA_HOME", "/some/path" ) );
+    }
+
 
     /**
      * Mocks a ToolchainManager


### PR DESCRIPTION
When a toolchain is used to select a test jvm, also set the `JAVA_HOME` environment variable to the selected jvm instead of inheriting the environment variable from the invoking shell.

(Note: this PR is based on branch from #287 )