### PR TITLE
Remove deprecated sudo setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@
 # under the License.
 
 language: java
-sudo: false
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 language: java
-
+sudo: false
 cache:
   directories:
   - "$HOME/.m2"


### PR DESCRIPTION
[Travis are now recommending removing the sudo tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)

_"If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration"_