### PR TITLE
Put XML example for "includes" inside its pre tag

### DIFF
--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefirePlugin.java
@@ -196,10 +196,9 @@ public class SurefirePlugin
      * &nbsp;&lt;include&gt; entries.<br>
      * Since 2.19 a complex syntax is supported in one parameter (JUnit 4, JUnit 4.7+, TestNG):
      * <pre><code>
-     *
-     * </code></pre>
      * {@literal <include>}%regex[.*[Cat|Dog].*], Basic????, !Unstable*{@literal </include>}
      * {@literal <include>}%regex[.*[Cat|Dog].*], !%regex[pkg.*Slow.*.class], pkg{@literal /}**{@literal /}*Fast*.java{@literal </include>}
+     * </code></pre>
      * <br>
      * This parameter is ignored if the TestNG {@code suiteXmlFiles} parameter is specified.<br>
      * <br>


### PR DESCRIPTION
Somehow, the example code found its way outside of the `<pre><code></code></pre>` block. This commit fixes that.