### PR TITLE
[SUREFIRE-1800] SurefireForkChannel: use LoopbackAddress

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireForkChannel.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireForkChannel.java
@@ -86,7 +86,7 @@ final class SurefireForkChannel extends ForkChannel
         super( arguments );
         server = open( withThreadPool( THREAD_POOL ) );
         setTrueOptions( SO_REUSEADDR, TCP_NODELAY, SO_KEEPALIVE );
-        InetAddress ip = InetAddress.getLocalHost();
+        InetAddress ip = InetAddress.getLoopbackAddress();
         server.bind( new InetSocketAddress( ip, 0 ), 1 );
         InetSocketAddress localAddress = (InetSocketAddress) server.getLocalAddress();
         localHost = localAddress.getHostString();

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/extensions/ForkChannelTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/extensions/ForkChannelTest.java
@@ -108,7 +108,7 @@ public class ForkChannelTest
             assertThat( channel.getCountdownCloseablePermits() )
                 .isEqualTo( 3 );
 
-            String localHost = InetAddress.getLocalHost().getHostAddress();
+            String localHost = InetAddress.getLoopbackAddress().getHostAddress();
             assertThat( channel.getForkNodeConnectionString() )
                 .startsWith( "tcp://" + localHost + ":" )
                 .isNotEqualTo( "tcp://" + localHost + ":" )
@@ -185,7 +185,7 @@ public class ForkChannelTest
         @Override
         public void run()
         {
-            try ( Socket socket = new Socket( InetAddress.getLocalHost().getHostAddress(), port ) )
+            try ( Socket socket = new Socket( InetAddress.getLoopbackAddress().getHostAddress(), port ) )
             {
                 socket.getOutputStream().write( sessionId.getBytes( US_ASCII ) );
                 byte[] data = new byte[128];


### PR DESCRIPTION
The first PR:
> I can see two mentioned requests. The first is the default IP adress used to bind the server socket, and the second request is a new configuration with bindAddress.

https://issues.apache.org/jira/browse/SUREFIRE-1800?focusedCommentId=17140020&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17140020

cc @Tibor17 