### PR TITLE
SUREFIRE-1815: Interrupt state handling in output

### DIFF
--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/LegacyMasterProcessChannelEncoder.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/LegacyMasterProcessChannelEncoder.java
@@ -298,11 +298,9 @@ public class LegacyMasterProcessChannelEncoder implements MasterProcessChannelEn
 
     private void encodeAndPrintEvent( StringBuilder event, boolean sendImmediately )
     {
+        final boolean wasInterrupted = Thread.interrupted();
         try
         {
-            //noinspection ResultOfMethodCallIgnored
-            Thread.interrupted();
-
             byte[] array = event.append( '\n' )
                 .toString()
                 .getBytes( STREAM_ENCODING );
@@ -332,6 +330,13 @@ public class LegacyMasterProcessChannelEncoder implements MasterProcessChannelEn
             {
                 DumpErrorSingleton.getSingleton()
                     .dumpException( e );
+            }
+        }
+        finally
+        {
+            if ( wasInterrupted )
+            {
+                Thread.currentThread().interrupt();
             }
         }
     }


### PR DESCRIPTION
Added a restoration of thread interrupt state to LegacyMasterProcessChannelEncoder. Added a unit test to ensure this is indeed fixed and not reintroduced.

https://issues.apache.org/jira/projects/SUREFIRE/issues/SUREFIRE-1815