### PR TITLE
enable to flush regularly output of the forked process

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -817,7 +817,7 @@ public abstract class AbstractSurefireMojo
      *
      * @since 3.0.0-M6
      */
-    @Parameter( defaultValue = "0" )
+    @Parameter( property = "outputFlushInterval", defaultValue = "0" )
     private long outputFlushInterval;
 
     /**

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -809,6 +809,18 @@ public abstract class AbstractSurefireMojo
     private Map<String, String> jdkToolchain;
 
     /**
+     * How often output is forced to be flushed.
+     * Useful when there is no output for N ms but some data are buffered.
+     * It will trigger a flush each configured interval to ensure
+     * data don't stay blocked in a buffer.
+     * Setting it to 0 disable that feature.
+     *
+     * @since 3.0.0-M6
+     */
+    @Parameter( defaultValue = "0" )
+    private long outputFlushInterval;
+
+    /**
      *
      */
     @Component
@@ -1850,7 +1862,8 @@ public abstract class AbstractSurefireMojo
                                           testSuiteDefinition, providerProperties, null,
                                           false, cli, getSkipAfterFailureCount(),
                                           Shutdown.parameterOf( getShutdown() ),
-                                          getForkedProcessExitTimeoutInSeconds() );
+                                          getForkedProcessExitTimeoutInSeconds(),
+                                          outputFlushInterval );
     }
 
     private static Map<String, String> toStringProperties( Properties properties )

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
@@ -53,6 +53,7 @@ import static org.apache.maven.surefire.booter.BooterConstants.FORKTESTSET_PREFE
 import static org.apache.maven.surefire.booter.BooterConstants.INCLUDES_PROPERTY_PREFIX;
 import static org.apache.maven.surefire.booter.BooterConstants.ISTRIMSTACKTRACE;
 import static org.apache.maven.surefire.booter.BooterConstants.MAIN_CLI_OPTIONS;
+import static org.apache.maven.surefire.booter.BooterConstants.OUTPUT_FLUSH_INTERVAL_MS;
 import static org.apache.maven.surefire.booter.BooterConstants.PLUGIN_PID;
 import static org.apache.maven.surefire.booter.BooterConstants.PROCESS_CHECKER;
 import static org.apache.maven.surefire.booter.BooterConstants.PROVIDER_CONFIGURATION;
@@ -181,6 +182,10 @@ class BooterSerializer
             properties.addList( mainCliOptions, MAIN_CLI_OPTIONS );
         }
         properties.setNullableProperty( SYSTEM_EXIT_TIMEOUT, toString( providerConfiguration.getSystemExitTimeout() ) );
+        properties.setNullableProperty(
+            OUTPUT_FLUSH_INTERVAL_MS,
+            providerConfiguration.getOutputFlushInterval() == null
+                ? "0" : toString( providerConfiguration.getOutputFlushInterval() ) );
 
         File surefireTmpDir = forkConfiguration.getTempDirectory();
         boolean debug = forkConfiguration.isDebug();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
@@ -279,7 +279,7 @@ public class BooterDeserializerProviderConfigurationTest
         RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(), TEST_TYPED,
-                readTestsFromInStream, cli, 0, Shutdown.DEFAULT, 0 );
+                readTestsFromInStream, cli, 0, Shutdown.DEFAULT, 0, 0L );
     }
 
     private StartupConfiguration getTestStartupConfiguration( ClassLoaderConfiguration classLoaderConfiguration )

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
@@ -200,7 +200,7 @@ public class BooterDeserializerStartupConfigurationTest
         RunOrderParameters runOrderParameters = new RunOrderParameters( RunOrder.DEFAULT, null );
         return new ProviderConfiguration( directoryScannerParameters, runOrderParameters, true, reporterConfiguration,
                 new TestArtifactInfo( "5.0", "ABC" ), testSuiteDefinition, new HashMap<String, String>(),
-                BooterDeserializerProviderConfigurationTest.TEST_TYPED, true, cli, 0, Shutdown.DEFAULT, 0 );
+                BooterDeserializerProviderConfigurationTest.TEST_TYPED, true, cli, 0, Shutdown.DEFAULT, 0, 0L );
     }
 
     private StartupConfiguration getTestStartupConfiguration( ClassLoaderConfiguration classLoaderConfiguration )

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/AbstractNoninterruptibleWritableChannel.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/AbstractNoninterruptibleWritableChannel.java
@@ -39,6 +39,12 @@ abstract class AbstractNoninterruptibleWritableChannel implements WritableBuffer
     protected abstract void flushImpl() throws IOException;
 
     @Override
+    public final void flush() throws IOException
+    {
+        flushImpl();
+    }
+
+    @Override
     public final int write( ByteBuffer src ) throws IOException
     {
         return write( src, true );

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/WritableBufferedByteChannel.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/WritableBufferedByteChannel.java
@@ -33,4 +33,6 @@ import java.nio.channels.WritableByteChannel;
 public interface WritableBufferedByteChannel extends WritableByteChannel
 {
     void writeBuffered( ByteBuffer src ) throws IOException;
+
+    void flush() throws IOException;
 }

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
@@ -59,4 +59,5 @@ public final class BooterConstants
     public static final String PLUGIN_PID = "pluginPid";
     public static final String PROCESS_CHECKER = "processChecker";
     public static final String FORK_NODE_CONNECTION_STRING = "forkNodeConnectionString";
+    public static final String OUTPUT_FLUSH_INTERVAL_MS = "outputFlushInterval";
 }

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
@@ -131,11 +131,13 @@ public class BooterDeserializer
         Integer systemExitTimeout =
                 systemExitTimeoutAsString == null ? null : Integer.valueOf( systemExitTimeoutAsString );
 
+        long outputFlushIntervalMs = properties.getLongProperty( OUTPUT_FLUSH_INTERVAL_MS );
+
         return new ProviderConfiguration( dirScannerParams, runOrderParameters,
                                           properties.getBooleanProperty( FAILIFNOTESTS ), reporterConfiguration, testNg,
                                           testSuiteDefinition, properties.getProperties(), typeEncodedTestForFork,
                                           preferTestsFromInStream, fromStrings( cli ), failFastCount, shutdown,
-                                          systemExitTimeout );
+                                          systemExitTimeout, outputFlushIntervalMs );
     }
 
     public StartupConfiguration getStartupConfiguration()

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
@@ -139,13 +139,14 @@ public final class ForkedBooter
             && LegacyMasterProcessChannelEncoder.class.isInstance( eventChannel ) )
         {
             final LegacyMasterProcessChannelEncoder enc = LegacyMasterProcessChannelEncoder.class.cast( eventChannel );
-            flusher = Executors.newSingleThreadScheduledExecutor( DaemonThreadFactory.newDaemonThreadFactory() );
+            flusher = Executors.newSingleThreadScheduledExecutor( DaemonThreadFactory.newDaemonThreadFactory(
+                "surefire-forkedbooter-flusher" ) );
+            final WritableBufferedByteChannel c = WritableBufferedByteChannel.class.cast( enc.getOut() );
             flusher.scheduleAtFixedRate( new Runnable()
             {
                 @Override
                 public void run()
                 {
-                    final WritableBufferedByteChannel c = WritableBufferedByteChannel.class.cast( enc.getOut() );
                     try
                     {
                         if ( c.isOpen() )

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProviderConfiguration.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProviderConfiguration.java
@@ -68,6 +68,8 @@ public class ProviderConfiguration
 
     private final Integer systemExitTimeout;
 
+    private final Long outputFlushInterval;
+
     @SuppressWarnings( "checkstyle:parameternumber" )
     public ProviderConfiguration( DirectoryScannerParameters directoryScannerParameters,
                                   RunOrderParameters runOrderParameters, boolean failIfNoTests,
@@ -75,7 +77,7 @@ public class ProviderConfiguration
                                   TestRequest testSuiteDefinition, Map<String, String> providerProperties,
                                   TypeEncodedValue typeEncodedTestSet, boolean readTestsFromInStream,
                                   List<CommandLineOption> mainCliOptions, int skipAfterFailureCount,
-                                  Shutdown shutdown, Integer systemExitTimeout )
+                                  Shutdown shutdown, Integer systemExitTimeout, Long outputFlushInterval )
     {
         this.runOrderParameters = runOrderParameters;
         this.providerProperties = providerProperties;
@@ -90,6 +92,12 @@ public class ProviderConfiguration
         this.skipAfterFailureCount = skipAfterFailureCount;
         this.shutdown = shutdown;
         this.systemExitTimeout = systemExitTimeout;
+        this.outputFlushInterval = outputFlushInterval;
+    }
+
+    public Long getOutputFlushInterval()
+    {
+        return outputFlushInterval;
     }
 
     public ReporterConfiguration getReporterConfiguration()

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/LegacyMasterProcessChannelEncoder.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/LegacyMasterProcessChannelEncoder.java
@@ -275,6 +275,11 @@ public class LegacyMasterProcessChannelEncoder implements MasterProcessChannelEn
         error( stackTraceWriter, trimStackTraces, BOOTERCODE_JVM_EXIT_ERROR, true );
     }
 
+    public WritableBufferedByteChannel getOut()
+    {
+        return out;
+    }
+
     private void error( StackTraceWriter stackTraceWriter, boolean trimStackTraces, ForkedProcessEventType event,
                         @SuppressWarnings( "SameParameterValue" ) boolean sendImmediately )
     {


### PR DESCRIPTION
Workaround for M5 regression on test outputs. Enables to configure a flushing interval in surefire config:

    <outputFlushInterval>250</outputFlushInterval>

This enables to stay interactive when working with tests with surefire and not await for minutes when test output frequency is slow (IT, E2E)