### PR TITLE
Faster queue

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ThreadedStreamConsumer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ThreadedStreamConsumer.java
@@ -156,7 +156,6 @@ public final class ThreadedStreamConsumer
         }
 
         int count = queueSize.get();
-        // System.out.println( "count = " + count );
         if ( count == 0 || count >= QUEUE_MAX_ITEMS )
         {
             try

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/output/ThreadedStreamConsumerTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/output/ThreadedStreamConsumerTest.java
@@ -1,0 +1,74 @@
+package org.apache.maven.plugin.surefire.booterclient.output;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.api.event.Event;
+import org.apache.maven.surefire.api.event.StandardStreamOutWithNewLineEvent;
+import org.apache.maven.surefire.extensions.EventHandler;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
+
+/**
+ *
+ */
+@SuppressWarnings( "checkstyle:magicnumber" )
+public class ThreadedStreamConsumerTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        EventHandler<Event> handler = new EventHandler<Event>()
+        {
+            private int i;
+
+            @Override
+            public void handleEvent( @Nonnull Event event )
+            {
+                try
+                {
+                    System.out.println( Thread.currentThread() );
+                    if ( i++ % 5000 == 0 )
+                    {
+                        TimeUnit.MILLISECONDS.sleep( 500L );
+                    }
+                }
+                catch ( InterruptedException e )
+                {
+                    e.printStackTrace();
+                }
+            }
+        };
+
+        ThreadedStreamConsumer streamConsumer = new ThreadedStreamConsumer( handler );
+
+        for ( int i = 0; i < 11_000; i++ )
+        {
+            System.out.println( i );
+            streamConsumer.handleEvent( new StandardStreamOutWithNewLineEvent( NORMAL_RUN, "" ) );
+        }
+
+        streamConsumer.close();
+    }
+}

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/output/ThreadedStreamConsumerTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/output/ThreadedStreamConsumerTest.java
@@ -22,13 +22,18 @@ package org.apache.maven.plugin.surefire.booterclient.output;
 import org.apache.maven.surefire.api.event.Event;
 import org.apache.maven.surefire.api.event.StandardStreamOutWithNewLineEvent;
 import org.apache.maven.surefire.extensions.EventHandler;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
-
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
 
 import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  *
@@ -37,38 +42,146 @@ import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 public class ThreadedStreamConsumerTest
 {
     @Test
+    @Ignore
     public void test() throws Exception
     {
+        final CountDownLatch countDown = new CountDownLatch( 100_000 );
         EventHandler<Event> handler = new EventHandler<Event>()
         {
-            private int i;
+            private final AtomicInteger i = new AtomicInteger();
 
             @Override
             public void handleEvent( @Nonnull Event event )
             {
+                //System.out.println(i.get());
+                countDown.countDown();
                 try
                 {
-                    System.out.println( Thread.currentThread() );
-                    if ( i++ % 5000 == 0 )
+                    if ( i.incrementAndGet() % 11_000 == 0 )
                     {
-                        TimeUnit.MILLISECONDS.sleep( 500L );
+                        TimeUnit.MILLISECONDS.sleep( 10L );
                     }
                 }
                 catch ( InterruptedException e )
                 {
-                    e.printStackTrace();
+                    throw new IllegalStateException( e );
                 }
             }
         };
 
         ThreadedStreamConsumer streamConsumer = new ThreadedStreamConsumer( handler );
 
-        for ( int i = 0; i < 11_000; i++ )
+        for ( int i = 0; i < 100_000; i++ )
         {
-            System.out.println( i );
             streamConsumer.handleEvent( new StandardStreamOutWithNewLineEvent( NORMAL_RUN, "" ) );
         }
 
+        assertThat( countDown.await( 10L, TimeUnit.MINUTES ) ).isTrue();
+
         streamConsumer.close();
+    }
+
+    @Test
+    public void test3() throws Exception
+    {
+        QueueSynchronizer<String> sync = new QueueSynchronizer<>( 2 );
+        sync.pushNext( "1" );
+        sync.pushNext( "2" );
+        //sync.pushNext( "3" );
+        String s1 = sync.awaitNext();
+        String s2 = sync.awaitNext();
+        //String s3 = sync.awaitNext();
+    }
+
+    static class QueueSynchronizer<T>
+    {
+        private final AtomicInteger queueSize = new AtomicInteger();
+
+        QueueSynchronizer( int max )
+        {
+            this.max = max;
+        }
+
+        private class SyncT1 extends AbstractQueuedSynchronizer
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected int tryAcquireShared( int arg )
+            {
+                return queueSize.get() == 0 ? -1 : 1;
+            }
+
+            @Override
+            protected boolean tryReleaseShared( int arg )
+            {
+                return true;
+            }
+
+            void waitIfZero() throws InterruptedException
+            {
+                acquireSharedInterruptibly( 1 );
+            }
+
+            void release()
+            {
+                releaseShared( 0 );
+            }
+        }
+
+        private class SyncT2 extends AbstractQueuedSynchronizer
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected int tryAcquireShared( int arg )
+            {
+                return queueSize.get() < max ? 1 : -1;
+            }
+
+            @Override
+            protected boolean tryReleaseShared( int arg )
+            {
+                return true;
+            }
+
+            void awaitMax()
+            {
+                acquireShared( 1 );
+            }
+
+            void tryRelease()
+            {
+                if ( queueSize.get() == 0 )
+                {
+                    releaseShared( 0 );
+                }
+            }
+        }
+
+        private final SyncT1 t1 = new SyncT1();
+        private final SyncT2 t2 = new SyncT2();
+        private final ConcurrentLinkedDeque<T> queue = new ConcurrentLinkedDeque<>();
+        private final int max;
+
+        void pushNext( T t )
+        {
+            queue.addLast( t );
+            int previousCount = queueSize.get();
+            t2.awaitMax();
+            queueSize.incrementAndGet();
+            if ( previousCount == 0 )
+            {
+                t1.release();
+            }
+        }
+
+        T awaitNext() throws InterruptedException
+        {
+            t2.tryRelease();
+            t1.waitIfZero();
+            queueSize.decrementAndGet();
+            return queue.pollFirst();
+        }
     }
 }

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/JUnit4SuiteTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/JUnit4SuiteTest.java
@@ -41,6 +41,7 @@ import org.apache.maven.plugin.surefire.booterclient.ModularClasspathForkConfigu
 import org.apache.maven.plugin.surefire.booterclient.lazytestprovider.TestLessInputStreamBuilderTest;
 import org.apache.maven.plugin.surefire.booterclient.lazytestprovider.TestProvidingInputStreamTest;
 import org.apache.maven.plugin.surefire.booterclient.output.ForkClientTest;
+import org.apache.maven.plugin.surefire.booterclient.output.ThreadedStreamConsumerTest;
 import org.apache.maven.plugin.surefire.extensions.ConsoleOutputReporterTest;
 import org.apache.maven.plugin.surefire.extensions.E2ETest;
 import org.apache.maven.plugin.surefire.extensions.ForkedProcessEventNotifierTest;
@@ -112,6 +113,7 @@ public class JUnit4SuiteTest extends TestCase
         suite.addTest( new JUnit4TestAdapter( ForkChannelTest.class ) );
         suite.addTest( new JUnit4TestAdapter( StreamFeederTest.class ) );
         suite.addTest( new JUnit4TestAdapter( E2ETest.class ) );
+        suite.addTest( new JUnit4TestAdapter( ThreadedStreamConsumerTest.class ) );
         return suite;
     }
 }


### PR DESCRIPTION
It requires some talk beforehand. The improvements done in `ThreadedStreamConsumer` are using the package `java.util.concurrent.locks` which makes it however working but not easy to understand. Since all there Java Locks are built using the superclass `AbstractQueuedSynchronizer` in Java we can utilize this class and create our own helper with synchronization stuff and there is `QueueSynchronizer` for such a reason. Very straightforward. The threads T1 and T2 have some rules. These threads are always two instances. The T1 drains the queue and T2 feeds the events to the queue.
The rules for concurrency are:

- T1 is waiting while the queue is empty

- If T2 has reached the QUEUE_MAX_ITEMS, the thread is disabled for scheduling and waiting for the notification from T1

- T2 resumes after T1 has drained the queue