### PR TITLE
Change default debug options to not use legacy options

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -2570,8 +2570,7 @@ public abstract class AbstractSurefireMojo
         String debugForkedProcess = getDebugForkedProcess();
         if ( "true".equals( debugForkedProcess ) )
         {
-            return "-Xdebug -Xnoagent -Djava.compiler=NONE"
-                + " -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005";
+            return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005";
         }
         return debugForkedProcess;
     }

--- a/maven-surefire-plugin/src/site/apt/examples/debugging.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/debugging.apt.vm
@@ -54,11 +54,11 @@ mvn -Dmaven.${thisPlugin.toLowerCase()}.debug verify
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
 +---+
-mvn -Dmaven.${thisPlugin.toLowerCase()}.debug="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000 -Xnoagent -Djava.compiler=NONE" test
+mvn -Dmaven.${thisPlugin.toLowerCase()}.debug="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:8000" test
 +---+
 #{else}
 +---+
-mvn -Dmaven.${thisPlugin.toLowerCase()}.debug="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000 -Xnoagent -Djava.compiler=NONE" verify
+mvn -Dmaven.${thisPlugin.toLowerCase()}.debug="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:8000" verify
 +---+
 #{end}
 


### PR DESCRIPTION
Using the -Xdebug -Xnoagent -Djava.compiler=NONE causes the OpenJ9 JVM
to run the tests in interpreted mode, thus running them VERY slowly.
In Hotspot JVM these options are ignored.