### PR TITLE
Investigation of test results in XML vs Console

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformRerunFailingTestsIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformRerunFailingTestsIT.java
@@ -19,6 +19,8 @@ package org.apache.maven.surefire.its;
  * under the License.
  */
 
+import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.plugin.surefire.log.api.PrintStreamLogger;
 import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.apache.maven.surefire.its.fixture.SurefireLauncher;
@@ -52,27 +54,31 @@ public class JUnitPlatformRerunFailingTestsIT extends SurefireJUnit4IntegrationT
     @Test
     public void testRerunFailingErrorTestsWithOneRetry()
     {
+        // here should be total tests on 3 -> reruns shouldn't count to this sum
+        // if so, there should be another information about test count
+        // so it should be like this: Test count: 3, Tests run: 5, Errors: 1, Failures: 1, Skipped: 0, Flakes: 0
         OutputValidator outputValidator = unpack().setJUnitVersion( VERSION ).maven().addGoal(
                 "-Dsurefire.rerunFailingTestsCount=1" )
                 .withFailure()
                 .debugLogging()
                 .executeTest()
-                .assertTestSuiteResults( 5, 1, 1, 0, 0 );
+                .assertTestSuiteResults( 3, 1, 1, 0, 0 );
+
         verifyFailuresOneRetryAllClasses( outputValidator );
 
         outputValidator = unpack().setJUnitVersion( VERSION ).maven().debugLogging().addGoal(
                 "-Dsurefire.rerunFailingTestsCount=1" ).addGoal(
-                "-DforkCount=2" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+                "-DforkCount=2" ).withFailure().executeTest().assertTestSuiteResults( 3, 1, 1, 0, 0 );
         verifyFailuresOneRetryAllClasses( outputValidator );
 
         outputValidator = unpack().setJUnitVersion( VERSION ).maven().debugLogging().addGoal(
                 "-Dsurefire.rerunFailingTestsCount=1" ).addGoal( "-Dparallel=methods" ).addGoal(
-                "-DuseUnlimitedThreads=true" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+                "-DuseUnlimitedThreads=true" ).withFailure().executeTest().assertTestSuiteResults( 3, 1, 1, 0, 0 );
         verifyFailuresOneRetryAllClasses( outputValidator );
 
         outputValidator = unpack().setJUnitVersion( VERSION ).maven().debugLogging().addGoal(
                 "-Dsurefire.rerunFailingTestsCount=1" ).addGoal( "-Dparallel=classes" ).addGoal(
-                "-DuseUnlimitedThreads=true" ).withFailure().executeTest().assertTestSuiteResults( 5, 1, 1, 0, 0 );
+                "-DuseUnlimitedThreads=true" ).withFailure().executeTest().assertTestSuiteResults( 3, 1, 1, 0, 0 );
         verifyFailuresOneRetryAllClasses( outputValidator );
     }
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This is more discussion or issue description than real PR with some changes.

How you can see in this code, I changed a little bit asserts in rerun suite. The main problem that I found is (from my POV) wrong counting of tests count. Or not displaying the real tests run count.

When we take a suite (class) where we have 3 tests, that 2 of them will run twice (one rerun), the count will be like this (how is it in current tests) : `Tests run: 5, errors: 1, failures: 1, skipped: 0 ...` -> but this is not really the truth. It can be problem in translation, but I would like to know how many tests (not with reruns) I ran -> 3. Then if failures > 0 the test should be flaky etc.

So I assume to add something like `tests count: 3, tests run: 5 ...` to the console reporter and `tests: 3, runs: 5` to the XML reporter. 

Second problem that I found is that results from XML file != results from console reporter. I have some examples when I was talking to @Tibor17.

WDYT?