### PR TITLE
[SUREFIRE-1843] - Trademarks / privacy policy footer displays broken

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -64,12 +64,7 @@
     
     <footer>
 		<![CDATA[
-		<div class="row pull-left">
-		  <p>Apache ${project.name}, ${project.name}, Apache, the Apache feather logo, and the Apache ${project.name} project logos are trademarks of The Apache Software Foundation.</p>
-		</div>
-		<div class="row pull-left">
-		  <a href="${project.url}privacy-policy.html">Privacy Policy</a>
-        </div>
+		  <p>Apache ${project.name}, ${project.name}, Apache, the Apache feather logo, and the Apache ${project.name} project logos are trademarks of The Apache Software Foundation. <a href="${project.url}privacy-policy.html">Privacy Policy</a></p>
         ]]>
     </footer>
   </body>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SUREFIRE-1843 

I think the original author was trying to get these on 2 different lines.  I checked other Maven plugins, everything I saw used a single line. So I just put privacy policy link on the end.