### PR TITLE
(doc) improved readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
  limitations under the License.
 -->
 
-<img src="https://maven.apache.org/images/maven-logo-black-on-white.png" width="100%" height="30%" alt="Maven"/>
+<img src="https://maven.apache.org/images/maven-logo-black-on-white.png" alt="Maven"/>
 
 Contributing to [Apache Maven Surefire](https://maven.apache.org/surefire/)
 ======================
@@ -49,12 +49,22 @@ Usage of [maven-surefire-plugin], [maven-failsafe-plugin], [maven-surefire-repor
 Build the Surefire project using **Maven 3.1.0+** and **JDK 1.8+**.  
 
 * In order to run tests for a release check during the Vote, the following memory requirements are needed:   
-  **(on Linux/Unix)** *export MAVEN_OPTS="-server -Xmx512m -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:SoftRefLRUPolicyMSPerMB=50 -Djava.awt.headless=true -Dhttps.protocols=TLSv1"*  
-  **(on Windows)** *set MAVEN_OPTS="-server -Xmx256m -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:SoftRefLRUPolicyMSPerMB=50 -Djava.awt.headless=true -Dhttps.protocols=TLSv1"*    
+  On Linux/Unix:
+  ```
+  export MAVEN_OPTS="-server -Xmx512m -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:SoftRefLRUPolicyMSPerMB=50 -Djava.awt.headless=true -Dhttps.protocols=TLSv1"
+  ```
+  On Windows:
+  ```
+  set MAVEN_OPTS="-server -Xmx256m -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:SoftRefLRUPolicyMSPerMB=50 -Djava.awt.headless=true -Dhttps.protocols=TLSv1"
+  ```
 * In order to run the tests with **JDK 1.7** (on Linux/Unix modify the system property **jdk.home**):  
-  *mvn install site site:stage -P reporting,run-its "-Djdk.home=e:\Program Files\Java\jdk1.7.0_80\"*
+  ```
+  mvn install site site:stage -P reporting,run-its "-Djdk.home=e:\Program Files\Java\jdk1.7.0_80\"
+  ```
 * In order to run the build and the tests with **JDK 1.8+**, e.g. JDK 11:    
-  *mvn install site site:stage -P reporting,run-its "-Djdk.home=e:\Program Files\Java\jdk11\"*
+  ```
+  mvn install site site:stage -P reporting,run-its "-Djdk.home=e:\Program Files\Java\jdk11\"
+  ```
   
 
 ### Deploying web site


### PR DESCRIPTION
The Apache logo is only ~300px so scaling to 100% makes it double its native size, on desktop at least, and it becomes pixelated 

Also used code blocks instead of italic text for the run commands

Not sure if PR will show the preview, so if not then you can view it here: https://github.com/michaelboyles/maven-surefire/blob/readme/README.md 