### PR TITLE
[SUREFIRE-1851] Prevent NPE in SmartStackTraceParser

### DIFF
--- a/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/SmartStackTraceParser.java
+++ b/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/SmartStackTraceParser.java
@@ -22,6 +22,7 @@ package org.apache.maven.surefire.report;
 import org.apache.maven.surefire.api.report.SafeThrowable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.lang.Math.min;
@@ -185,11 +186,15 @@ public class SmartStackTraceParser
 
     private boolean rootIsInclass()
     {
-        return stackTrace.length > 0 && stackTrace[0].getClassName().equals( testClassName );
+        return stackTrace != null && stackTrace.length > 0 && stackTrace[0].getClassName().equals( testClassName );
     }
 
     private static List<StackTraceElement> focusOnClass( StackTraceElement[] stackTrace, Class<?> clazz )
     {
+        if ( stackTrace == null )
+        {
+            return Collections.emptyList();
+        }
         List<StackTraceElement> result = new ArrayList<>();
         for ( StackTraceElement element : stackTrace )
         {

--- a/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/SmartStackTraceParserTest.java
+++ b/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/SmartStackTraceParserTest.java
@@ -340,6 +340,21 @@ public class SmartStackTraceParserTest
         }
     }
 
+    public void testNullStackTrace()
+    {
+        try
+        {
+            new ATestClass().aMockedException();
+        }
+        catch ( Exception e )
+        {
+            SmartStackTraceParser smartStackTraceParser =
+                new SmartStackTraceParser( ATestClass.class.getName(), e, null );
+            String res = smartStackTraceParser.getString();
+            assertEquals( "ATestClass » SomeMocked", res );
+        }
+    }
+
     private ExecutionException getSingleNested()
     {
         FutureTask<Object> futureTask = new FutureTask<>( new RunnableTestClass2() );

--- a/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/SomeMockedException.java
+++ b/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/SomeMockedException.java
@@ -19,53 +19,42 @@ package org.apache.maven.surefire.report;
  * under the License.
  */
 
-import java.io.File;
-
 /**
- *
+ * @author Adam Jones
  */
-@SuppressWarnings( "UnusedDeclaration" )
-public class ATestClass
+public class SomeMockedException extends RuntimeException
 {
-
-    public void failInAssert()
+    public SomeMockedException()
     {
-        throw new AssertionError( "X is not Z" );
     }
 
-    public void nestedFailInAssert()
+    @Override
+    public String getMessage()
     {
-        failInAssert();
+        return null;
     }
 
-    public void npe()
+    @Override
+    public String getLocalizedMessage()
     {
-        throw new NullPointerException( "It was null" );
+        return null;
     }
 
-    public void nestedNpe()
+    @Override
+    public Throwable getCause()
     {
-        npe();
+        return null;
     }
 
-    public void npeOutsideTest()
+    @Override
+    public String toString()
     {
-        File file = new File( (String) null );
+        return null;
     }
 
-    public void nestedNpeOutsideTest()
+    @Override
+    public StackTraceElement[] getStackTrace()
     {
-        npeOutsideTest();
-    }
-
-    public void aLongTestErrorMessage()
-    {
-        throw new RuntimeException( "This message will be truncated, somewhere over the rainbow. "
-                                    + "Gangnam style, Gangnam style, Gangnam style, , Gangnam style, Gangnam style" );
-    }
-
-    public void aMockedException()
-    {
-        throw new SomeMockedException();
+        return null;
     }
 }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SUREFIRE-1851

SmartStackTraceParser is used in various places to parse throwables. However, if the throwable stack trace is null it will throw an NPE itself. This can cause test runners to fail in unexpected ways, which in the worst case can lead to false success test results and passing builds despite the test actually failing.

An exception with a null stacktrace sounds odd, but is easy to do by mocking an exception with frameworks like Mockito. While people probably shouldn't be mocking exceptions, it definitely can and does happen. Can be reproduced with https://github.com/domdomegg/surefire-1851-demo

This is my first PR to the Apache project, apologies if I've gotten anything wrong - I've tried to follow the contributing guidelines as best I can, but do let me know if something needs changing :)