### PR TITLE
SUREFIRE-1584: Update example documentation

### DIFF
--- a/maven-surefire-plugin/src/site/apt/examples/rerun-failing-tests.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/rerun-failing-tests.apt.vm
@@ -32,7 +32,7 @@ Rerun Failing Tests
   To use this feature through Maven surefire, set the <<<rerunFailingTestsCount>>> property to be a value larger than 0.
   Tests will be run until they pass or the number of reruns has been exhausted.
 
-  << NOTE : This feature is supported only for JUnit 4.x. >>
+  << NOTE : This feature is supported for JUnit 4.x, and (since 3.0.0-M4) JUnit 5.x. >>
 
 
 +---+


### PR DESCRIPTION
Update example documentation for re-running failing test feature to indicate
that it also works for JUnit 5.x for versions since 3.0.0-M4.