### PR TITLE
[SUREFIRE-1840] Distinguish commands in docs for testing with docker

### DIFF
--- a/maven-surefire-plugin/src/site/markdown/docker.md
+++ b/maven-surefire-plugin/src/site/markdown/docker.md
@@ -24,9 +24,16 @@ In current `.` directory is your project which starts with root POM.
 
 (including `.` at the end of next line)
 
+For Windows/macOS Users:
+
+    $ docker build --no-cache -t my-image:1 -f ./Dockerfile .
+    $ docker run -it --rm my-image:1 /bin/sh
+
+For Linux Users:
+
     $ sudo docker build --no-cache -t my-image:1 -f ./Dockerfile .
     $ sudo docker run -it --rm my-image:1 /bin/sh
-    
+
 Run the command `mvn test` in the shell console of docker.
 
 Dockerfile in current directory


### PR DESCRIPTION
sudo, which provides root/ administrator level priviledges on *nix
systems, should be only used when required. Given that docker uses the
kernel of the host system for Linux while docker uses a virtual machine
for Windows/macOS, it is omitted for the latter. This was clarified for
the documentation concerning testing Maven Surefire with docker.