### PR TITLE
[SUREFIRE-1865] ChecksumCalculator getSha1 does not compute checksums correctly.

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ChecksumCalculator.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ChecksumCalculator.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author Kristian Rosenvold
@@ -155,7 +155,8 @@ public class ChecksumCalculator
         {
             MessageDigest md = MessageDigest.getInstance( "SHA-1" );
             String configValue = getConfig();
-            md.update( configValue.getBytes( ISO_8859_1 ), 0, configValue.length() );
+            byte[] configBytes = configValue.getBytes( UTF_8 );
+            md.update( configBytes );
             byte[] sha1hash = md.digest();
             return asHexString( sha1hash );
         }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ChecksumCalculatorTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ChecksumCalculatorTest.java
@@ -1,0 +1,38 @@
+package org.apache.maven.plugin.surefire.booterclient;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link ChecksumCalculator}.
+ */
+public class ChecksumCalculatorTest
+{
+    @Test
+    public void testGetSha1()
+    {
+        final ChecksumCalculator calculator = new ChecksumCalculator();
+        calculator.add( "foö 🔥 Россия 한국 中国" );
+        assertEquals( "3421557EBE66A4741CA51C8D610AB1AB41D1693B", calculator.getSha1() );
+    }
+}

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/JUnit4SuiteTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/JUnit4SuiteTest.java
@@ -32,6 +32,7 @@ import org.apache.maven.plugin.surefire.SurefireHelperTest;
 import org.apache.maven.plugin.surefire.SurefirePropertiesTest;
 import org.apache.maven.plugin.surefire.booterclient.BooterDeserializerProviderConfigurationTest;
 import org.apache.maven.plugin.surefire.booterclient.BooterDeserializerStartupConfigurationTest;
+import org.apache.maven.plugin.surefire.booterclient.ChecksumCalculatorTest;
 import org.apache.maven.plugin.surefire.booterclient.DefaultForkConfigurationTest;
 import org.apache.maven.plugin.surefire.booterclient.ForkConfigurationTest;
 import org.apache.maven.plugin.surefire.booterclient.ForkStarterTest;
@@ -116,6 +117,7 @@ public class JUnit4SuiteTest extends TestCase
         suite.addTest( new JUnit4TestAdapter( E2ETest.class ) );
         suite.addTest( new JUnit4TestAdapter( ThreadedStreamConsumerTest.class ) );
         suite.addTest( new JUnit4TestAdapter( EventConsumerThreadTest.class ) );
+        suite.addTest( new JUnit4TestAdapter( ChecksumCalculatorTest.class ) );
         return suite;
     }
 }


### PR DESCRIPTION
Two changes:

1) Fix length computation to use bytes, not characters.

2) Use UTF_8 instead of ISO_8859_1 for encoding, because configs can contain
   characters that fall outside the ISO_8859_1 character set.

JIRA: https://issues.apache.org/jira/browse/SUREFIRE-1865