### PR TITLE
ci: JDK 8, JDK 11, JDK 15

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,6 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
+        java: [8, 11, 15]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -39,10 +40,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Set up JDK 14
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: ${{ matrix.java }}
 
       - name: Build with Maven
         run: mvn clean install -e -B -V -nsu --no-transfer-progress -P run-its


### PR DESCRIPTION
enable Java build matrix in Github Actions CI.