### PR TITLE
[SUREFIRE-1882] Fix failures when compiled on Java 9+ and run on Java 8

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireForkChannel.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireForkChannel.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
@@ -129,7 +130,7 @@ final class SurefireForkChannel extends ForkChannel
         {
             throw new IOException( "Channel closed while verifying the client." );
         }
-        buffer.flip();
+        ( (Buffer) buffer ).flip();
         String clientSessionId = new String( buffer.array(), US_ASCII );
         if ( !clientSessionId.equals( sessionId ) )
         {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/Utf8RecodingDeferredFileOutputStream.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/Utf8RecodingDeferredFileOutputStream.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.lang.ref.SoftReference;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -93,14 +94,14 @@ final class Utf8RecodingDeferredFileOutputStream
         }
         else
         {
-            cache.flip();
+            ( (Buffer) cache ).flip();
             int minLength = cache.remaining() + decodedString.length + NL_BYTES.length;
             byte[] buffer = getLargeCache( minLength );
             int bufferLength = 0;
-            System.arraycopy( cache.array(), cache.arrayOffset() + cache.position(),
+            System.arraycopy( cache.array(), cache.arrayOffset() + ( (Buffer) cache ).position(),
                 buffer, bufferLength, cache.remaining() );
             bufferLength += cache.remaining();
-            cache.clear();
+            ( (Buffer) cache ).clear();
 
             System.arraycopy( decodedString, 0, buffer, bufferLength, decodedString.length );
             bufferLength += decodedString.length;
@@ -180,11 +181,11 @@ final class Utf8RecodingDeferredFileOutputStream
 
         isDirty = false;
 
-        cache.flip();
+        ( (Buffer) cache ).flip();
         byte[] array = cache.array();
-        int offset = cache.arrayOffset() + cache.position();
+        int offset = cache.arrayOffset() + ( (Buffer) cache ).position();
         int length = cache.remaining();
-        cache.clear();
+        ( (Buffer) cache ).clear();
         storage.write( array, offset, length );
         // the data that you wrote with the mode "rw" may still only be kept in memory and may be read back
         // storage.getFD().sync();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/EventConsumerThreadTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/EventConsumerThreadTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.File;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -83,7 +84,7 @@ public class EventConsumerThreadTest
             ":0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789:"
                 .getBytes( UTF_8 ) );
 
-        event.flip();
+        ( (Buffer) event ).flip();
         byte[] frame = copyOfRange( event.array(), event.arrayOffset(), event.arrayOffset() + event.remaining() );
         ReadableByteChannel channel = new Channel( frame, 100 )
         {

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/StreamFeederTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/StreamFeederTest.java
@@ -30,6 +30,7 @@ import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.Iterator;
@@ -90,9 +91,9 @@ public class StreamFeederTest
                 public Object answer( InvocationOnMock invocation ) throws IOException
                 {
                     ByteBuffer bb = invocation.getArgument( 0 );
-                    bb.flip();
-                    out.write( bb.array(), 0, bb.limit() );
-                    return bb.limit();
+                    ( (Buffer) bb ).flip();
+                    out.write( bb.array(), 0, ( (Buffer) bb ).limit() );
+                    return ( (Buffer) bb ).limit();
                 }
             } );
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -380,8 +380,8 @@ public class StatelessXmlReporterTest
     public void testSyncOnDeferredFile() throws Exception
     {
         Utf8RecodingDeferredFileOutputStream out = new Utf8RecodingDeferredFileOutputStream( "test" );
-        ByteBuffer cache = ByteBuffer.wrap( new byte[] {1, 2, 3} );
-        ( (Buffer) cache ).position( 3 );
+        Buffer cache = ByteBuffer.wrap( new byte[] {1, 2, 3} );
+        cache.position( 3 );
         setInternalState( out, "cache", cache );
         assertThat( (boolean) getInternalState( out, "isDirty" ) ).isFalse();
         setInternalState( out, "isDirty", true );
@@ -397,8 +397,8 @@ public class StatelessXmlReporterTest
         assertThat( storage.read() ).isEqualTo( 3 );
         assertThat( storage.read() ).isEqualTo( -1 );
         assertThat( storage.length() ).isEqualTo( 3L );
-        assertThat( ( (Buffer) cache ).position() ).isEqualTo( 0 );
-        assertThat( ( (Buffer) cache ).limit() ).isEqualTo( 3 );
+        assertThat( cache.position() ).isEqualTo( 0 );
+        assertThat( cache.limit() ).isEqualTo( 3 );
         storage.seek( 3L );
         invokeMethod( out, "sync" );
         assertThat( (boolean) getInternalState( out, "isDirty" ) ).isFalse();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -34,6 +34,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.Deque;
@@ -380,7 +381,7 @@ public class StatelessXmlReporterTest
     {
         Utf8RecodingDeferredFileOutputStream out = new Utf8RecodingDeferredFileOutputStream( "test" );
         ByteBuffer cache = ByteBuffer.wrap( new byte[] {1, 2, 3} );
-        cache.position( 3 );
+        ( (Buffer) cache ).position( 3 );
         setInternalState( out, "cache", cache );
         assertThat( (boolean) getInternalState( out, "isDirty" ) ).isFalse();
         setInternalState( out, "isDirty", true );
@@ -396,8 +397,8 @@ public class StatelessXmlReporterTest
         assertThat( storage.read() ).isEqualTo( 3 );
         assertThat( storage.read() ).isEqualTo( -1 );
         assertThat( storage.length() ).isEqualTo( 3L );
-        assertThat( cache.position() ).isEqualTo( 0 );
-        assertThat( cache.limit() ).isEqualTo( 3 );
+        assertThat( ( (Buffer) cache ).position() ).isEqualTo( 0 );
+        assertThat( ( (Buffer) cache ).limit() ).isEqualTo( 3 );
         storage.seek( 3L );
         invokeMethod( out, "sync" );
         assertThat( (boolean) getInternalState( out, "isDirty" ) ).isFalse();

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoder.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoder.java
@@ -24,6 +24,7 @@ import org.apache.maven.surefire.api.util.internal.WritableBufferedByteChannel;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
@@ -112,17 +113,17 @@ public abstract class AbstractStreamEncoder<E extends Enum<E>>
     {
         String nonNullString = nonNull( string );
 
-        int counterPosition = result.position();
+        int counterPosition = ( (Buffer) result ).position();
 
         result.put( INT_BINARY ).put( (byte) ':' );
 
-        int msgStart = result.position();
+        int msgStart = ( (Buffer) result ).position();
         encoder.encode( wrap( nonNullString ), result, true );
-        int msgEnd = result.position();
+        int msgEnd = ( (Buffer) result ).position();
         int encodedMsgSize = msgEnd - msgStart;
         result.putInt( counterPosition, encodedMsgSize );
 
-        result.position( msgEnd );
+        ( (Buffer) result ).position( msgEnd );
 
         result.put( (byte) ':' );
     }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/AbstractNoninterruptibleWritableChannel.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/AbstractNoninterruptibleWritableChannel.java
@@ -20,6 +20,7 @@ package org.apache.maven.surefire.api.util.internal;
  */
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NonWritableChannelException;
@@ -64,12 +65,12 @@ abstract class AbstractNoninterruptibleWritableChannel implements WritableBuffer
 
         if ( src.remaining() != src.capacity() )
         {
-            src.flip();
+            ( (Buffer) src ).flip();
         }
 
         int countWrittenBytes = src.remaining();
         writeImpl( src );
-        src.position( src.limit() );
+        ( (Buffer) src ).position( ( (Buffer) src ).limit() );
         if ( flush )
         {
             flushImpl();

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/Channels.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/Channels.java
@@ -26,6 +26,7 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousByteChannel;
 import java.nio.channels.ClosedChannelException;
@@ -213,10 +214,10 @@ public final class Channels
             @Override
             protected int readImpl( ByteBuffer src ) throws IOException
             {
-                int count = bis.read( src.array(), src.arrayOffset() + src.position(), src.remaining() );
+                int count = bis.read( src.array(), src.arrayOffset() + ( (Buffer) src ).position(), src.remaining() );
                 if ( count > 0 )
                 {
-                    src.position( count + src.position() );
+                    ( (Buffer) src ).position( count + ( (Buffer) src ).position() );
                 }
                 return count;
             }
@@ -249,7 +250,7 @@ public final class Channels
             protected void writeImpl( ByteBuffer src ) throws IOException
             {
                 int count = src.remaining();
-                bos.write( src.array(), src.arrayOffset() + src.position(), count );
+                bos.write( src.array(), src.arrayOffset() + ( (Buffer) src ).position(), count );
                 bytesCounter.getAndAdd( count );
             }
 

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoderTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoderTest.java
@@ -35,6 +35,7 @@ import javax.annotation.Nonnull;
 import java.io.EOFException;
 import java.io.File;
 import java.math.BigInteger;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.channels.ReadableByteChannel;
@@ -147,7 +148,7 @@ public class AbstractStreamDecoderTest
     {
         CharsetDecoder decoder = UTF_8.newDecoder().onMalformedInput( REPLACE ).onUnmappableCharacter( REPLACE );
         ByteBuffer input = ByteBuffer.allocate( 1024 );
-        input.put( PATTERN2_BYTES ).flip();
+        ( (Buffer) input.put( PATTERN2_BYTES ) ).flip();
         int bytesToDecode = PATTERN2_BYTES.length;
         CharBuffer output = CharBuffer.allocate( 1024 );
         int readBytes = invokeMethod( AbstractStreamDecoder.class, "decodeString", decoder, input, output,
@@ -165,10 +166,10 @@ public class AbstractStreamDecoderTest
     {
         CharsetDecoder decoder = UTF_8.newDecoder().onMalformedInput( REPLACE ).onUnmappableCharacter( REPLACE );
         ByteBuffer input = ByteBuffer.allocate( 1024 );
-        input.put( PATTERN1.getBytes( UTF_8 ) )
+        ( (Buffer) input.put( PATTERN1.getBytes( UTF_8 ) )
             .put( 90, (byte) 'A' )
             .put( 91, (byte) 'B' )
-            .put( 92, (byte) 'C' )
+            .put( 92, (byte) 'C' ) )
             .position( 90 );
         CharBuffer output = CharBuffer.allocate( 1024 );
         int readBytes =
@@ -273,7 +274,7 @@ public class AbstractStreamDecoderTest
 
         Memento memento = thread.new Memento();
         // whatever position will be compacted to 0
-        memento.getByteBuffer().limit( 974 ).position( 974 );
+        ( (Buffer) ( (Buffer) memento.getByteBuffer() ).limit( 974 ) ).position( 974 );
         assertThat( invokeMethod( thread, "readString", memento, PATTERN1.length() + 3 ) )
             .isEqualTo( PATTERN1 + "012" );
     }
@@ -316,7 +317,7 @@ public class AbstractStreamDecoderTest
 
         Memento memento = thread.new Memento();
         // whatever position will be compacted to 0
-        memento.getByteBuffer().limit( 974 ).position( 974 );
+        ( (Buffer) ( (Buffer) memento.getByteBuffer().limit( 974 ) ) ).position( 974 );
 
         StringBuilder expected = new StringBuilder( "789" );
         for ( int i = 0; i < 11; i++ )
@@ -370,7 +371,7 @@ public class AbstractStreamDecoderTest
             decoder.reset()
                 .decode( buffer, chars, true ); // CharsetDecoder 71 nanos
             s = chars.flip().toString(); // CharsetDecoder + toString = 91 nanos
-            buffer.clear();
+            ( (Buffer) buffer ).clear();
             chars.clear();
         }
         long l2 = System.currentTimeMillis();

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoderTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoderTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
@@ -207,7 +208,7 @@ public class AbstractStreamEncoderTest
         Encoder streamEncoder = new Encoder( new DummyChannel() );
         ByteBuffer result = ByteBuffer.allocate( 4 );
         streamEncoder.encodeInteger( result, null );
-        assertThat( result.position() ).isEqualTo( 2 );
+        assertThat( ( (Buffer) result ).position() ).isEqualTo( 2 );
         assertThat( result.get( 0 ) ).isEqualTo( (byte) 0 );
         assertThat( result.get( 1 ) ).isEqualTo( (byte) ':' );
     }
@@ -218,8 +219,8 @@ public class AbstractStreamEncoderTest
         Encoder streamEncoder = new Encoder( new DummyChannel() );
         ByteBuffer result = ByteBuffer.allocate( 8 );
         streamEncoder.encodeInteger( result, 5 );
-        assertThat( result.position() ).isEqualTo( 6 );
-        result.position( 0 );
+        assertThat( ( (Buffer) result ).position() ).isEqualTo( 6 );
+        ( (Buffer) result ).position( 0 );
         assertThat( result.get() ).isEqualTo( (byte) 0xff );
         assertThat( result.getInt() ).isEqualTo( (byte) 5 );
         assertThat( result.get( 5 ) ).isEqualTo( (byte) ':' );
@@ -243,8 +244,8 @@ public class AbstractStreamEncoderTest
     private static String toString( ByteBuffer frame )
     {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        frame.flip();
-        os.write( frame.array(), frame.arrayOffset() + frame.position(), frame.remaining() );
+        ( (Buffer) frame ).flip();
+        os.write( frame.array(), frame.arrayOffset() + ( (Buffer) frame ).position(), frame.remaining() );
         return new String( os.toByteArray(), UTF_8 );
     }
 
@@ -327,5 +328,5 @@ public class AbstractStreamEncoderTest
         {
         }
     }
-  
+
 }

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/util/internal/ChannelsReaderTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/util/internal/ChannelsReaderTest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousByteChannel;
 import java.nio.channels.ClosedChannelException;
@@ -116,30 +117,30 @@ public class ChannelsReaderTest
         assertThat( bb.arrayOffset() )
             .isEqualTo( 0 );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 3 );
 
         assertThat( bb.remaining() )
             .isEqualTo( 0 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 3 );
 
         assertThat( bb.capacity() )
             .isEqualTo( 3 );
 
-        bb.flip();
+        ( (Buffer) bb ).flip();
 
         assertThat( bb.arrayOffset() )
             .isEqualTo( 0 );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 0 );
 
         assertThat( bb.remaining() )
             .isEqualTo( 3 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 3 );
 
         assertThat( bb.capacity() )
@@ -172,30 +173,30 @@ public class ChannelsReaderTest
         assertThat( bb.arrayOffset() )
             .isEqualTo( 0 );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 3 );
 
         assertThat( bb.remaining() )
             .isEqualTo( 1 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 4 );
 
         assertThat( bb.capacity() )
             .isEqualTo( 4 );
 
-        bb.flip();
+        ( (Buffer) bb ).flip();
 
         assertThat( bb.arrayOffset() )
             .isEqualTo( 0 );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 0 );
 
         assertThat( bb.remaining() )
             .isEqualTo( 3 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 3 );
 
         assertThat( bb.capacity() )
@@ -228,30 +229,30 @@ public class ChannelsReaderTest
         assertThat( bb.arrayOffset() )
             .isEqualTo( 0 );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 3 );
 
         assertThat( bb.remaining() )
             .isEqualTo( 1 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 4 );
 
         assertThat( bb.capacity() )
             .isEqualTo( 4 );
 
-        bb.flip();
+        ( (Buffer) bb ).flip();
 
         assertThat( bb.arrayOffset() )
             .isEqualTo( 0 );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 0 );
 
         assertThat( bb.remaining() )
             .isEqualTo( 3 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 3 );
 
         assertThat( bb.capacity() )
@@ -322,30 +323,30 @@ public class ChannelsReaderTest
         assertThat( bb.arrayOffset() )
             .isEqualTo( 0 );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 3 );
 
         assertThat( bb.remaining() )
             .isEqualTo( 1 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 4 );
 
         assertThat( bb.capacity() )
             .isEqualTo( 4 );
 
-        bb.flip();
+        ( (Buffer) bb ).flip();
 
         assertThat( bb.arrayOffset() )
             .isEqualTo( 0 );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 0 );
 
         assertThat( bb.remaining() )
             .isEqualTo( 3 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 3 );
 
         assertThat( bb.capacity() )

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/util/internal/ChannelsWriterTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/util/internal/ChannelsWriterTest.java
@@ -33,6 +33,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousByteChannel;
 import java.nio.channels.ClosedChannelException;
@@ -95,10 +96,10 @@ public class ChannelsWriterTest
             .hasSize( 1 )
             .containsOnly( true );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 3 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 3 );
 
         assertThat( bb.capacity() )
@@ -123,10 +124,10 @@ public class ChannelsWriterTest
             .hasSize( 3 )
             .isEqualTo( new byte[] {1, 2, 3} );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 3 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 3 );
 
         assertThat( bb.capacity() )
@@ -199,10 +200,10 @@ public class ChannelsWriterTest
             .hasSize( 4 )
             .isEqualTo( new byte[] {1, 2, 3, 4} );
 
-        assertThat( bb.position() )
+        assertThat( ( (Buffer) bb ).position() )
             .isEqualTo( 3 );
 
-        assertThat( bb.limit() )
+        assertThat( ( (Buffer) bb ).limit() )
             .isEqualTo( 3 );
 
         assertThat( bb.capacity() )

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/EventChannelEncoder.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/EventChannelEncoder.java
@@ -32,6 +32,7 @@ import org.apache.maven.surefire.booter.stream.EventEncoder;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.CharsetEncoder;
@@ -139,7 +140,7 @@ public class EventChannelEncoder extends EventEncoder implements MasterProcessCh
             int bufferLength =
                 estimateBufferLength( BOOTERCODE_SYSPROPS.getOpcode().length(), runMode, encoder, 0, key, value );
             result = result != null && result.capacity() >= bufferLength ? result : ByteBuffer.allocate( bufferLength );
-            result.clear();
+            ( (Buffer) result ).clear();
             // :maven-surefire-event:sys-prop:rerun-test-after-failure:UTF-8:<integer>:<key>:<integer>:<value>:
             encode( encoder, result, BOOTERCODE_SYSPROPS, runMode, key, value );
             boolean sync = !it.hasNext();
@@ -336,7 +337,7 @@ public class EventChannelEncoder extends EventEncoder implements MasterProcessCh
         {
             if ( !onExit )
             {
-                String event = new String( frame.array(), frame.arrayOffset() + frame.position(), frame.remaining(),
+                String event = new String( frame.array(), frame.arrayOffset() + ( (Buffer) frame ).position(), frame.remaining(),
                     getCharset() );
 
                 DumpErrorSingleton.getSingleton()

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/ForkedBooterMockTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/ForkedBooterMockTest.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
@@ -457,7 +458,7 @@ public class ForkedBooterMockTest
                             int read = channel.read( bb );
                             assertThat( read )
                                 .isEqualTo( uuid.length() );
-                            bb.flip();
+                            ( (Buffer) bb ).flip();
                             assertThat( new String( bb.array(), US_ASCII ) )
                                 .isEqualTo( uuid );
                             return true;

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/EventChannelEncoderTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/EventChannelEncoderTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -129,7 +130,7 @@ public class EventChannelEncoderTest
         expectedFrame.write( ':' );
         expectedFrame.write( stackTrace.getBytes( UTF_8 ) );
         expectedFrame.write( ':' );
-        encoded.flip();
+        ( (Buffer) encoded ).flip();
 
         assertThat( toArray( encoded ) )
             .isEqualTo( expectedFrame.toByteArray() );
@@ -184,7 +185,7 @@ public class EventChannelEncoderTest
         expectedFrame.write( ':' );
         expectedFrame.write( trimmedStackTrace.getBytes( UTF_8 ) );
         expectedFrame.write( ':' );
-        encoded.flip();
+        ( (Buffer) encoded ).flip();
 
         assertThat( toArray( encoded ) )
             .isEqualTo( expectedFrame.toByteArray() );
@@ -1260,8 +1261,8 @@ public class EventChannelEncoderTest
     private static String toString( ByteBuffer frame )
     {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        frame.flip();
-        os.write( frame.array(), frame.arrayOffset() + frame.position(), frame.remaining() );
+        ( (Buffer) frame ).flip();
+        os.write( frame.array(), frame.arrayOffset() + ( (Buffer) frame ).position(), frame.remaining() );
         return new String( os.toByteArray(), UTF_8 );
     }
 


### PR DESCRIPTION
Cast to Buffer to avoid java.lang.NoSuchMethodError due to JDK API
breakage.

This was fixed in a similar way in apache/maven-wagon@92c0d2a.

See mongodb/mongo-java-driver@21c91bd for details.