### PR TITLE
Fix build error with latest Maven 4.0 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -731,7 +731,7 @@
       </reporting>
     </profile>
     <profile>
-      <id>jdk9+</id>
+      <id>jdk9</id>
       <activation>
         <jdk>[9, )</jdk>
       </activation>


### PR DESCRIPTION
With the latest Maven snapshot version based on https://github.com/apache/maven/commit/eae3074c63dbba24680d7049dc36217323c7d00b, the build fails with the following exception:

    $ mvn validate
    [INFO] Scanning for projects...
    [ERROR] [ERROR] Some problems were encountered while processing the POMs:
    [ERROR] 'profiles.profile[jdk9+].id' with value 'jdk9+' does not match a valid id pattern. @ line 20, column 205

    [ERROR] The build could not read 1 project -> [Help 1]
    [ERROR]
    [ERROR]   The project org.apache.maven.surefire:surefire:3.0.0-M6-SNAPSHOT (/Users/marc/Repositories/maven/plugins/core/surefire/pom.xml) has 1 error
    [ERROR]     'profiles.profile[jdk9+].id' with value 'jdk9+' does not match a valid id pattern. @ line 20, column 205
    [ERROR]
    [ERROR] To see the full stack trace of the errors, re-run Maven with the '-e' switch.
    [ERROR] Re-run Maven using the '-X' switch to enable full debug logging.
    [ERROR]
    [ERROR] For more information about the errors and possible solutions, please read the following articles:
    [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException

Removing the `+` from the profile name solves the issue.