### PR TITLE
[SUREFIRE-1890] Support TestNG 7.4.0

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -576,7 +576,7 @@ public abstract class AbstractSurefireMojo
     /**
      * (TestNG provider) When you use the parameter {@code parallel}, TestNG will try to run all your test methods
      * in separate threads, except for methods that depend on each other, which will be run in the same thread in order
-     * to respect their order of execution.
+     * to respect their order of execution.  Supports two values: {@code classes} or {@code methods}.
      * <br>
      * (JUnit 4.7 provider) Supports values {@code classes}, {@code methods}, {@code both} to run
      * in separate threads been controlled by {@code threadCount}.
@@ -1528,10 +1528,15 @@ public abstract class AbstractSurefireMojo
                 }
                 return "org.apache.maven.surefire.testng.conf.TestNG5143Configurator";
             }
-            range = VersionRange.createFromVersionSpec( "[6.0,)" );
+            range = VersionRange.createFromVersionSpec( "[6.0,7.4.0)" );
             if ( range.containsVersion( version ) )
             {
                 return "org.apache.maven.surefire.testng.conf.TestNG60Configurator";
+            }
+            range = VersionRange.createFromVersionSpec( "[7.4.0,)" );
+            if ( range.containsVersion( version ) )
+            {
+                return "org.apache.maven.surefire.testng.conf.TestNG740Configurator";
             }
 
             throw new MojoExecutionException( "Unknown TestNG version " + version );

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/CheckTestNg740ParallelIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/CheckTestNg740ParallelIT.java
@@ -1,0 +1,37 @@
+package org.apache.maven.surefire.its;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
+
+/**
+ */
+public class CheckTestNg740ParallelIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+    @Test
+    public void withTestNG740AndParallelSet()
+    {
+        unpack( "testng-740-parallel" )
+            .executeTest()
+            .assertTestSuiteResults( 2, 0, 0, 0 );
+    }
+}

--- a/surefire-its/src/test/resources/testng-740-parallel/pom.xml
+++ b/surefire-its/src/test/resources/testng-740-parallel/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>testng-740-parallel</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>TestNG 7.4.0 parallel test</name>
+
+    <properties>
+        <surefire.testng.verbose>0</surefire.testng.verbose>
+        <argLine/>
+        <jacoco.agent/>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <argLine>${argLine} ${jacoco.agent}</argLine>
+                    <parallel>methods</parallel>
+                    <threadCount>10</threadCount>
+                    <properties>
+                        <property>
+                            <name>surefire.testng.verbose</name>
+                            <value>${surefire.testng.verbose}</value>
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.4.0</version>
+            <exclusions>
+                <exclusion>
+                    <!-- NOTE: Deliberaty excluding junit to enforce TestNG only tests, cf. SUREFIRE-642 -->
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/surefire-its/src/test/resources/testng-740-parallel/src/test/java/testng740/TestNG740ParallelTest.java
+++ b/surefire-its/src/test/resources/testng-740-parallel/src/test/java/testng740/TestNG740ParallelTest.java
@@ -1,0 +1,35 @@
+package testng.simple;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.testng.annotations.Test;
+
+
+public class TestNG740ParallelTest {
+    @Test
+    public void testOne() {
+
+    }
+
+    @Test
+    public void testTwo() {
+
+    }
+}

--- a/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/conf/TestNG740Configurator.java
+++ b/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/conf/TestNG740Configurator.java
@@ -1,0 +1,69 @@
+package org.apache.maven.surefire.testng.conf;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.api.testset.TestSetFailedException;
+import org.apache.maven.surefire.api.util.ReflectionUtils;
+import org.testng.xml.XmlSuite;
+
+import java.util.Map;
+
+import static java.lang.Integer.parseInt;
+import static org.apache.maven.surefire.api.booter.ProviderParameterNames.PARALLEL_PROP;
+import static org.apache.maven.surefire.api.booter.ProviderParameterNames.THREADCOUNT_PROP;
+
+/**
+ * TestNG 7.4.0 configurator. Changed setParallel type to enum value.
+ * Uses reflection since ParallelMode enum doesn't exist in supported
+ * TestNG 5.x versions.
+ *
+ * @since 3.0.0-M6
+ */
+public class TestNG740Configurator extends TestNG60Configurator
+{
+    @Override
+    public void configure( XmlSuite suite, Map<String, String> options )
+        throws TestSetFailedException
+    {
+        String threadCountAsString = options.get( THREADCOUNT_PROP );
+        int threadCount = threadCountAsString == null ? 1 : parseInt( threadCountAsString );
+        suite.setThreadCount( threadCount );
+
+        String parallel = options.get( PARALLEL_PROP );
+        if ( parallel != null )
+        {
+            if ( !"methods".equalsIgnoreCase( parallel ) && !"classes".equalsIgnoreCase( parallel ) )
+            {
+                throw new TestSetFailedException( "Unsupported TestNG parallel setting: "
+                    + parallel + " ( only METHODS or CLASSES supported )" );
+            }
+            Class enumClass = ReflectionUtils.tryLoadClass( XmlSuite.class.getClassLoader(),
+                "org.testng.xml.XmlSuite$ParallelMode" );
+            Object parallelEnum = Enum.valueOf( enumClass, parallel.toUpperCase() );
+            ReflectionUtils.invokeSetter( suite, "setParallel", enumClass, parallelEnum );
+        }
+
+        String dataProviderThreadCount = options.get( "dataproviderthreadcount" );
+        if ( dataProviderThreadCount != null )
+        {
+            suite.setDataProviderThreadCount( Integer.parseInt( dataProviderThreadCount ) );
+        }
+    }
+}


### PR DESCRIPTION
Use reflection to configure parallel arguments,
as the setParallel(String) method has been removed
and the enum equivalent doesn't exist in older
TestNG versions