### PR TITLE
[SUREFIRE-1894] Add missing "version" attribute to report XSD

### DIFF
--- a/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report-3.0.xsd
+++ b/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report-3.0.xsd
@@ -124,6 +124,7 @@
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>
+            <xs:attribute name="version" type="xs:string"/>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="time" type="SUREFIRE_TIME"/>
             <xs:attribute name="tests" type="xs:string" use="required"/>

--- a/maven-surefire-report-plugin/src/test/resources/surefire-1894/TEST-surefire.MyTest.xml
+++ b/maven-surefire-report-plugin/src/test/resources/surefire-1894/TEST-surefire.MyTest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="surefire.MyTest" version="3.0" time="0" tests="1" errors="1" skipped="0" failures="0">
+  <properties>
+    <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"/>
+  </properties>
+  <testcase name="test" classname="surefire.MyTest" time="0.1">
+    <error type="java.lang.RuntimeException" message="java.lang.IndexOutOfBoundsException: msg">java.lang.RuntimeException: java.lang.IndexOutOfBoundsException: msg
+      at surefire.MyTest.rethrownDelegate(MyTest.java:24)
+      at surefire.MyTest.newRethrownDelegate(MyTest.java:17)
+      at surefire.MyTest.test(MyTest.java:13)
+      at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+      at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
+      at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+      at java.lang.reflect.Method.invoke(Method.java:606)
+      at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+      at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+      at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+      at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+      at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+      at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+      at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+      at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+      at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+      at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+      at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+      at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+      at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+      at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:272)
+      at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:167)
+      at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:147)
+      at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:130)
+      at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:211)
+      at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:163)
+      at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:105)
+      Caused by: java.lang.IndexOutOfBoundsException
+      at surefire.MyTest.failure(MyTest.java:33)
+      at surefire.MyTest.access$100(MyTest.java:9)
+      at surefire.MyTest$Nested.run(MyTest.java:38)
+      at surefire.MyTest.delegate(MyTest.java:29)
+      at surefire.MyTest.rethrownDelegate(MyTest.java:22)
+      ... 26 more
+</error>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
This adds the missing version attribute for the `<testsuite/>` element to the schema. As a test, I've just added a copy of the `surefire-597/TEST-surefire.MyTest.xml` with the additional `version="3.0"` attribute in `<testsuite/>`. It will be picked up by the existing `SurefireSchemaValidationTest`. To catch similar errors in the future, a further validation using a freshly created XML report, instead of static ones, would probably be better. However, I'm not familiar enough with the build setup to implement such a check.