### PR TITLE
[SUREFIRE-1659] Log4j logger in TestExecutionListener corrupts Surefire's STDOUT

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformStreamCorruptionIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformStreamCorruptionIT.java
@@ -57,4 +57,34 @@ public class JUnitPlatformStreamCorruptionIT
         assertThat( lines )
                 .isEmpty();
     }
+
+    @Test
+    public void warningIsNotEmittedWithJulToSlf4j() throws VerificationException
+    {
+        OutputValidator validator = unpack( "/surefire-1659-stream-corruption" )
+                .activateProfile( "junit-platform-with-jul-to-slf4j" )
+                .executeTest()
+                .verifyErrorFree( 1 );
+
+        List<String> lines = validator.loadLogLines(
+                startsWith( "[WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM" ) );
+
+        assertThat( lines )
+                .isEmpty();
+    }
+
+    @Test
+    public void warningIsNotEmittedWithJulToLog4j() throws VerificationException
+    {
+        OutputValidator validator = unpack( "/surefire-1659-stream-corruption" )
+                .activateProfile( "junit-platform-with-jul-to-log4j" )
+                .executeTest()
+                .verifyErrorFree( 1 );
+
+        List<String> lines = validator.loadLogLines(
+                startsWith( "[WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM" ) );
+
+        assertThat( lines )
+                .isEmpty();
+    }
 }

--- a/surefire-its/src/test/resources/surefire-1659-stream-corruption/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1659-stream-corruption/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit-platform-1.0.0</artifactId>
+    <version>1.0</version>
+    <name>[SUREFIRE-1659] Log4j logger in TestExecutionListener corrupts Surefire's STDOUT.</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+        <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>junit-platform-with-jul-to-slf4j</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.version}</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <java.util.logging.config.file>${project.basedir}/src/test/resources/jul-to-slf4j.properties</java.util.logging.config.file>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jul-to-slf4j</artifactId>
+                    <version>1.7.25</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                    <version>1.2.3</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>junit-platform-with-jul-to-log4j</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.version}</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                    <version>2.13.1</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-jul</artifactId>
+                    <version>2.13.1</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/java/com/example/demo/JUnitPlatformSampleTest.java
+++ b/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/java/com/example/demo/JUnitPlatformSampleTest.java
@@ -1,0 +1,17 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Logger;
+
+public class JUnitPlatformSampleTest
+{
+
+    @Test
+    public void sampleTest()
+    {
+        Logger.getLogger( getClass().getName() ).info( "running test" );
+        Assertions.assertTrue( true );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/resources/jul-to-slf4j.properties
+++ b/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/resources/jul-to-slf4j.properties
@@ -1,0 +1,1 @@
+handlers = org.slf4j.bridge.SLF4JBridgeHandler

--- a/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/resources/junit-platform.properties
+++ b/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+# This file is needed in order for JUnit to log something early on org.junit.platform.launcher.core.LauncherConfigurationParameters

--- a/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/resources/log4j2.xml
+++ b/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info" additivity="false">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/resources/logback-test.xml
+++ b/surefire-its/src/test/resources/surefire-1659-stream-corruption/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -65,7 +65,6 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TagFilter;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
-import org.junit.platform.launcher.core.LauncherFactory;
 
 /**
  * JUnit 5 Platform Provider.
@@ -87,7 +86,7 @@ public class JUnitPlatformProvider
 
     public JUnitPlatformProvider( ProviderParameters parameters )
     {
-        this( parameters, LauncherFactory.create() );
+        this( parameters, new LazyLauncher() );
     }
 
     JUnitPlatformProvider( ProviderParameters parameters, Launcher launcher )

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/LazyLauncher.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/LazyLauncher.java
@@ -1,0 +1,64 @@
+package org.apache.maven.surefire.junitplatform;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+/**
+ * Launcher proxy which delays the most possible the initialization of the real JUnit
+ * Launcher in order to avoid stream/stdout corruption due to early logging.
+ */
+class LazyLauncher implements Launcher
+{
+
+    private Launcher launcher;
+
+    @Override
+    public void registerTestExecutionListeners( TestExecutionListener... testExecutionListeners )
+    {
+        launcher().registerTestExecutionListeners( testExecutionListeners );
+    }
+
+    @Override
+    public TestPlan discover( LauncherDiscoveryRequest launcherDiscoveryRequest )
+    {
+        return launcher().discover( launcherDiscoveryRequest );
+    }
+
+    @Override
+    public void execute( LauncherDiscoveryRequest launcherDiscoveryRequest,
+                         TestExecutionListener... testExecutionListeners )
+    {
+        launcher().execute( launcherDiscoveryRequest, testExecutionListeners );
+    }
+
+    private Launcher launcher()
+    {
+        if ( launcher == null )
+        {
+            launcher = LauncherFactory.create();
+        }
+        return launcher;
+    }
+}


### PR DESCRIPTION
Fix candidate for SUREFIRE-1659