### PR TITLE
SUREFIRE-1881 Adds additional debug log and fork connection timeout

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/LegacyForkChannel.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/LegacyForkChannel.java
@@ -22,6 +22,7 @@ package org.apache.maven.plugin.surefire.extensions;
 import org.apache.maven.surefire.api.event.Event;
 import org.apache.maven.surefire.extensions.CloseableDaemonThread;
 import org.apache.maven.surefire.extensions.CommandReader;
+import org.apache.maven.surefire.extensions.Completable;
 import org.apache.maven.surefire.extensions.EventHandler;
 import org.apache.maven.surefire.extensions.ForkChannel;
 import org.apache.maven.surefire.api.fork.ForkNodeArguments;
@@ -41,14 +42,18 @@ import java.nio.channels.WritableByteChannel;
  */
 final class LegacyForkChannel extends ForkChannel
 {
+    private CloseableDaemonThread commandReaderBindings;
+    private CloseableDaemonThread eventHandlerBindings;
+
     LegacyForkChannel( @Nonnull ForkNodeArguments arguments )
     {
         super( arguments );
     }
 
     @Override
-    public void connectToClient()
+    public Completable connectToClient()
     {
+        return Completable.EMPTY_COMPLETABLE;
     }
 
     @Override
@@ -64,20 +69,37 @@ final class LegacyForkChannel extends ForkChannel
     }
 
     @Override
-    public CloseableDaemonThread bindCommandReader( @Nonnull CommandReader commands,
-                                                    WritableByteChannel stdIn )
+    public void bindCommandReader( @Nonnull CommandReader commands, WritableByteChannel stdIn )
     {
-        return new StreamFeeder( "std-in-fork-" + getArguments().getForkChannelId(), stdIn, commands,
-            getArguments().getConsoleLogger() );
+        ForkNodeArguments args = getArguments();
+        String threadName = "commands-fork-" + args.getForkChannelId();
+        commandReaderBindings = new StreamFeeder( threadName, stdIn, commands, args.getConsoleLogger() );
+        commandReaderBindings.start();
     }
 
     @Override
-    public CloseableDaemonThread bindEventHandler( @Nonnull EventHandler<Event> eventHandler,
-                                                   @Nonnull CountdownCloseable countdownCloseable,
-                                                   ReadableByteChannel stdOut )
+    public void bindEventHandler( @Nonnull EventHandler<Event> eventHandler,
+                                  @Nonnull CountdownCloseable countdownCloseable,
+                                  ReadableByteChannel stdOut )
     {
-        return new EventConsumerThread( "fork-" + getArguments().getForkChannelId() + "-event-thread", stdOut,
-            eventHandler, countdownCloseable, getArguments() );
+        ForkNodeArguments args = getArguments();
+        String threadName = "fork-" + args.getForkChannelId() + "-event-thread";
+        eventHandlerBindings = new EventConsumerThread( threadName, stdOut, eventHandler, countdownCloseable, args );
+        eventHandlerBindings.start();
+    }
+
+    @Override
+    public void disable()
+    {
+        if ( eventHandlerBindings != null )
+        {
+            eventHandlerBindings.disable();
+        }
+
+        if ( commandReaderBindings != null )
+        {
+            commandReaderBindings.disable();
+        }
     }
 
     @Override

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/E2ETest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/E2ETest.java
@@ -170,8 +170,7 @@ public class E2ETest
 
         ThreadedStreamConsumer queue = new ThreadedStreamConsumer( h );
 
-        server.bindEventHandler( queue, new CountdownCloseable( new DummyCloseable(), 1 ), new DummyReadableChannel() )
-            .start();
+        server.bindEventHandler( queue, new CountdownCloseable( new DummyCloseable(), 1 ), new DummyReadableChannel() );
 
         assertThat( awaitHandlerFinished.await( 30L, TimeUnit.SECONDS ) )
             .isTrue();

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/extensions/ForkChannelTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/extensions/ForkChannelTest.java
@@ -158,10 +158,10 @@ public class ForkChannelTest
             client.start();
 
             channel.connectToClient();
-            channel.bindCommandReader( commandReader, null ).start();
+            channel.bindCommandReader( commandReader, null );
             ReadableByteChannel stdOut = mock( ReadableByteChannel.class );
             when( stdOut.read( any( ByteBuffer.class ) ) ).thenReturn( -1 );
-            channel.bindEventHandler( consumer, cc, stdOut ).start();
+            channel.bindEventHandler( consumer, cc, stdOut );
 
             commandReader.noop();
 

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/SurefireMasterProcessChannelProcessorFactory.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/SurefireMasterProcessChannelProcessorFactory.java
@@ -132,7 +132,7 @@ public class SurefireMasterProcessChannelProcessorFactory
         {
             if ( clientSocketChannel.supportedOptions().contains( option ) )
             {
-                clientSocketChannel.setOption( option, true );
+                // clientSocketChannel.setOption( option, true );
             }
         }
     }

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/Completable.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/Completable.java
@@ -19,16 +19,24 @@ package org.apache.maven.surefire.extensions;
  * under the License.
  */
 
-import javax.annotation.Nonnull;
+import java.io.IOException;
 
 /**
- * The base thread class used to handle a stream, transforms the stream to an object.
+ * Forks the execution of task and the task completion.
+ * The method {@link #complete()} waits for the task to complete or fails.
+ *
+ * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
+ * @since 3.0.0-M5
  */
-public abstract class CloseableDaemonThread extends Thread implements Stoppable
+public interface Completable
 {
-    protected CloseableDaemonThread( @Nonnull String threadName )
+    Completable EMPTY_COMPLETABLE = new Completable()
     {
-        setName( threadName );
-        setDaemon( true );
-    }
+        @Override
+        public void complete()
+        {
+        }
+    };
+
+    void complete() throws IOException, InterruptedException;
 }

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/ForkChannel.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/ForkChannel.java
@@ -53,7 +53,7 @@ public abstract class ForkChannel implements Closeable
         this.arguments = arguments;
     }
 
-    public abstract void connectToClient() throws IOException;
+    public abstract Completable connectToClient() throws IOException, InterruptedException;
 
     /**
      * This is server related class, which if binds to a TCP port, determines the connection string for the client.
@@ -68,28 +68,26 @@ public abstract class ForkChannel implements Closeable
     public abstract int getCountdownCloseablePermits();
 
     /**
-     * Binds command handler to the channel.
+     * Binds command handler to the channel. Starts a Thread streaming out the commands.
      *
      * @param commands command reader, see {@link CommandReader#readNextCommand()}
      * @param stdIn    optional standard input stream of the JVM to write the encoded commands into it
-     * @return the thread instance to start up in order to stream out the data
      * @throws IOException if an error in the fork channel
      */
-    public abstract CloseableDaemonThread bindCommandReader( @Nonnull CommandReader commands,
-                                                             WritableByteChannel stdIn )
+    public abstract void bindCommandReader( @Nonnull CommandReader commands, WritableByteChannel stdIn )
         throws IOException;
 
     /**
+     * Starts a Thread reading the events.
      *
      * @param eventHandler       event eventHandler
      * @param countdownCloseable count down of the final call of {@link Closeable#close()}
      * @param stdOut             optional standard output stream of the JVM
-     * @return the thread instance to start up in order to stream out the data
      * @throws IOException if an error in the fork channel
      */
-    public abstract CloseableDaemonThread bindEventHandler( @Nonnull EventHandler<Event> eventHandler,
-                                                            @Nonnull CountdownCloseable countdownCloseable,
-                                                            ReadableByteChannel stdOut )
+    public abstract void bindEventHandler( @Nonnull EventHandler<Event> eventHandler,
+                                           @Nonnull CountdownCloseable countdownCloseable,
+                                           ReadableByteChannel stdOut )
         throws IOException;
 
     @Nonnull
@@ -97,4 +95,6 @@ public abstract class ForkChannel implements Closeable
     {
         return arguments;
     }
+
+    public abstract void disable();
 }

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/Stoppable.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/Stoppable.java
@@ -19,16 +19,12 @@ package org.apache.maven.surefire.extensions;
  * under the License.
  */
 
-import javax.annotation.Nonnull;
+import java.io.Closeable;
 
 /**
- * The base thread class used to handle a stream, transforms the stream to an object.
+ * Used in {@link CloseableDaemonThread}.
  */
-public abstract class CloseableDaemonThread extends Thread implements Stoppable
+public interface Stoppable extends Closeable
 {
-    protected CloseableDaemonThread( @Nonnull String threadName )
-    {
-        setName( threadName );
-        setDaemon( true );
-    }
+    void disable();
 }

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/util/CountDownLauncher.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/util/CountDownLauncher.java
@@ -1,4 +1,4 @@
-package org.apache.maven.surefire.extensions;
+package org.apache.maven.surefire.extensions.util;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,16 +19,35 @@ package org.apache.maven.surefire.extensions;
  * under the License.
  */
 
-import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * The base thread class used to handle a stream, transforms the stream to an object.
+ * Counts down the calls {@link #countDown()} and the last reaching zero executes the {@link #job()}.
+ *
+ * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
+ * @since 3.0.0-M5
  */
-public abstract class CloseableDaemonThread extends Thread implements Stoppable
+public abstract class CountDownLauncher
 {
-    protected CloseableDaemonThread( @Nonnull String threadName )
+    private final AtomicInteger countDown;
+
+    public CountDownLauncher( int count )
     {
-        setName( threadName );
-        setDaemon( true );
+        if ( count <= 0 )
+        {
+            throw new IllegalStateException( "count=" + count + " should be greater than zero" );
+        }
+
+        countDown = new AtomicInteger( count );
+    }
+
+    protected abstract void job();
+
+    public void countDown()
+    {
+        if ( countDown.decrementAndGet() == 0 )
+        {
+            job();
+        }
     }
 }


### PR DESCRIPTION
Added some additional debug log to better see where the process exactly stalls. Also a maximum time-out for the fork process to connect has been added in order to catch that case, where the forked process does not respond or terminates before a connection could be made to the main Maven process.