### PR TITLE
[SUREFIRE-1860] extend ReportEntry interface and SimpleReportEntry with mandatory properties runMode:String, id:long, forkId:int

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/CommonReflector.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/CommonReflector.java
@@ -66,8 +66,8 @@ public class CommonReflector
         }
     }
 
-    public Object createReportingReporterFactory( @Nonnull StartupReportConfiguration startupReportConfiguration,
-                                                  @Nonnull ConsoleLogger consoleLogger )
+    public Object createReporterFactory( @Nonnull StartupReportConfiguration startupReportConfiguration,
+                                         @Nonnull ConsoleLogger consoleLogger )
     {
         Class<?>[] args = { this.startupReportConfiguration, this.consoleLogger };
         Object src = createStartupReportConfiguration( startupReportConfiguration );

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/InPluginVMSurefireStarter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/InPluginVMSurefireStarter.java
@@ -80,7 +80,7 @@ public class InPluginVMSurefireStarter
 
         CommonReflector surefireReflector = new CommonReflector( testClassLoader );
 
-        Object factory = surefireReflector.createReportingReporterFactory( startupReportConfig, consoleLogger );
+        Object factory = surefireReflector.createReporterFactory( startupReportConfig, consoleLogger );
 
         try
         {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
@@ -770,7 +770,7 @@ public class ForkStarter
             ClassLoader unifiedClassLoader = classpathConfiguration.createMergedClassLoader();
 
             CommonReflector commonReflector = new CommonReflector( unifiedClassLoader );
-            Object reporterFactory = commonReflector.createReportingReporterFactory( startupReportConfiguration, log );
+            Object reporterFactory = commonReflector.createReporterFactory( startupReportConfiguration, log );
 
             ProviderFactory providerFactory =
                 new ProviderFactory( startupConfiguration, providerConfiguration, unifiedClassLoader, reporterFactory );

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClient.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClient.java
@@ -132,10 +132,11 @@ public class ForkClient
         public void handle( RunMode runMode, TestSetReportEntry reportEntry )
         {
             testsInProgress.clear();
-            TestSetReportEntry entry = reportEntry( reportEntry.getSourceName(), reportEntry.getSourceText(),
-                    reportEntry.getName(), reportEntry.getNameText(),
-                    reportEntry.getGroup(), reportEntry.getStackTraceWriter(), reportEntry.getElapsed(),
-                    reportEntry.getMessage(), getTestVmSystemProperties() );
+            TestSetReportEntry entry = reportEntry( reportEntry.getRunMode(),
+                reportEntry.getTestRunId(), reportEntry.getSourceName(), reportEntry.getSourceText(),
+                reportEntry.getName(), reportEntry.getNameText(),
+                reportEntry.getGroup(), reportEntry.getStackTraceWriter(), reportEntry.getElapsed(),
+                reportEntry.getMessage(), getTestVmSystemProperties() );
             getTestSetReporter().testSetCompleted( entry );
         }
     }
@@ -340,7 +341,7 @@ public class ForkClient
     {
         if ( forkedProcessTimeoutInSeconds > 0 )
         {
-            final long forkedProcessTimeoutInMillis = 1000 * forkedProcessTimeoutInSeconds;
+            final long forkedProcessTimeoutInMillis = 1000L * forkedProcessTimeoutInSeconds;
             final long startedAt = testSetStartedAt.get();
             if ( startedAt > START_TIME_ZERO && currentTimeMillis - startedAt >= forkedProcessTimeoutInMillis )
             {
@@ -380,7 +381,7 @@ public class ForkClient
     {
         if ( testSetReporter == null )
         {
-            testSetReporter = defaultReporterFactory.createReporter();
+            testSetReporter = defaultReporterFactory.getRunListener();
         }
         return testSetReporter;
     }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
@@ -23,6 +23,8 @@ import org.apache.maven.plugin.surefire.StartupReportConfiguration;
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.plugin.surefire.log.api.Level;
 import org.apache.maven.plugin.surefire.runorder.StatisticsReporter;
+import org.apache.maven.surefire.api.report.AbstractRunListener;
+import org.apache.maven.surefire.api.report.ConsoleStream;
 import org.apache.maven.surefire.shared.utils.logging.MessageBuilder;
 import org.apache.maven.surefire.extensions.ConsoleOutputReportEventListener;
 import org.apache.maven.surefire.extensions.StatelessReportEventListener;
@@ -97,7 +99,7 @@ public class DefaultReporterFactory
     }
 
     @Override
-    public RunListener createReporter()
+    public AbstractRunListener getRunListener()
     {
         TestSetRunListener testSetRunListener =
             new TestSetRunListener( createConsoleReporter(),
@@ -110,6 +112,18 @@ public class DefaultReporterFactory
                                     reportConfiguration.isBriefOrPlainFormat() );
         addListener( testSetRunListener );
         return testSetRunListener;
+    }
+
+    @Override
+    public ConsoleLogger getConsoleLogger()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConsoleStream getConsoleStream()
+    {
+        throw new UnsupportedOperationException();
     }
 
     public File getReportsDirectory()

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.plugin.surefire.runorder.StatisticsReporter;
+import org.apache.maven.surefire.api.report.AbstractRunListener;
 import org.apache.maven.surefire.extensions.ConsoleOutputReportEventListener;
 import org.apache.maven.surefire.extensions.StatelessReportEventListener;
 import org.apache.maven.surefire.extensions.StatelessTestsetInfoConsoleReportEventListener;
@@ -51,7 +52,8 @@ import static java.util.Objects.requireNonNull;
  * @author Kristian Rosenvold
  */
 public class TestSetRunListener
-    implements RunListener, ConsoleOutputReceiver, ConsoleLogger
+    extends AbstractRunListener
+    implements ConsoleOutputReceiver, ConsoleLogger
 {
     private final Queue<TestMethodStats> testMethodStats = new ConcurrentLinkedQueue<>();
 
@@ -77,7 +79,7 @@ public class TestSetRunListener
 
     @SuppressWarnings( "checkstyle:parameternumber" )
     public TestSetRunListener( StatelessTestsetInfoConsoleReportEventListener<WrappedReportEntry, TestSetStats>
-                                           consoleReporter,
+                                       consoleReporter,
                                StatelessTestsetInfoFileReportEventListener<WrappedReportEntry, TestSetStats>
                                        fileReporter,
                                StatelessReportEventListener<WrappedReportEntry, TestSetStats> simpleXMLReporter,
@@ -85,6 +87,7 @@ public class TestSetRunListener
                                StatisticsReporter statisticsReporter, boolean trimStackTrace,
                                boolean isPlainFormat, boolean briefOrPlainFormat )
     {
+        super(  );
         this.consoleReporter = consoleReporter;
         this.fileReporter = fileReporter;
         this.statisticsReporter = statisticsReporter;

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
@@ -20,9 +20,13 @@ package org.apache.maven.plugin.surefire.report;
  */
 
 import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.RunMode;
 import org.apache.maven.surefire.api.report.StackTraceWriter;
 import org.apache.maven.surefire.api.report.TestSetReportEntry;
 
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 
@@ -222,6 +226,21 @@ public class WrappedReportEntry
     public String getReportNameWithGroup()
     {
         return original.getReportNameWithGroup();
+    }
+
+    @Override
+    @Nonnull
+    public RunMode getRunMode()
+    {
+        return original.getRunMode();
+    }
+
+    @Override
+    @Nonnegative
+    @Nullable
+    public Long getTestRunId()
+    {
+        return original.getTestRunId();
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/surefire/stream/EventDecoder.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/surefire/stream/EventDecoder.java
@@ -312,35 +312,35 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
                 return new SystemPropertyEvent( runMode, key, value );
             case BOOTERCODE_TESTSET_STARTING:
                 checkArguments( runMode, memento, 10 );
-                return new TestsetStartingEvent( runMode, toReportEntry( memento.getData() ) );
+                return new TestsetStartingEvent( runMode, toReportEntry( runMode, , memento.getData() ) );
             case BOOTERCODE_TESTSET_COMPLETED:
                 checkArguments( runMode, memento, 10 );
-                return new TestsetCompletedEvent( runMode, toReportEntry( memento.getData() ) );
+                return new TestsetCompletedEvent( runMode, toReportEntry( runMode, , memento.getData() ) );
             case BOOTERCODE_TEST_STARTING:
                 checkArguments( runMode, memento, 10 );
-                return new TestStartingEvent( runMode, toReportEntry( memento.getData() ) );
+                return new TestStartingEvent( runMode, toReportEntry( runMode, , memento.getData() ) );
             case BOOTERCODE_TEST_SUCCEEDED:
                 checkArguments( runMode, memento, 10 );
-                return new TestSucceededEvent( runMode, toReportEntry( memento.getData() ) );
+                return new TestSucceededEvent( runMode, toReportEntry( runMode, , memento.getData() ) );
             case BOOTERCODE_TEST_FAILED:
                 checkArguments( runMode, memento, 10 );
-                return new TestFailedEvent( runMode, toReportEntry( memento.getData() ) );
+                return new TestFailedEvent( runMode, toReportEntry( runMode, , memento.getData() ) );
             case BOOTERCODE_TEST_SKIPPED:
                 checkArguments( runMode, memento, 10 );
-                return new TestSkippedEvent( runMode, toReportEntry( memento.getData() ) );
+                return new TestSkippedEvent( runMode, toReportEntry( runMode, , memento.getData() ) );
             case BOOTERCODE_TEST_ERROR:
                 checkArguments( runMode, memento, 10 );
-                return new TestErrorEvent( runMode, toReportEntry( memento.getData() ) );
+                return new TestErrorEvent( runMode, toReportEntry( runMode, , memento.getData() ) );
             case BOOTERCODE_TEST_ASSUMPTIONFAILURE:
                 checkArguments( runMode, memento, 10 );
-                return new TestAssumptionFailureEvent( runMode, toReportEntry( memento.getData() ) );
+                return new TestAssumptionFailureEvent( runMode, toReportEntry( runMode, , memento.getData() ) );
             default:
                 throw new IllegalArgumentException( "Missing a branch for the event type " + eventType );
         }
     }
 
     @Nonnull
-    private static TestSetReportEntry toReportEntry( List<Object> args )
+    private static TestSetReportEntry toReportEntry( RunMode runMode, Long testId, List<Object> args )
     {
         // ReportEntry:
         String source = (String) args.get( 0 );
@@ -354,7 +354,7 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
         String traceMessage = (String) args.get( 7 );
         String smartTrimmedStackTrace = (String) args.get( 8 );
         String stackTrace = (String) args.get( 9 );
-        return newReportEntry( source, sourceText, name, nameText, group, message, timeElapsed,
+        return newReportEntry( runMode, testId, source, sourceText, name, nameText, group, message, timeElapsed,
             traceMessage, smartTrimmedStackTrace, stackTrace );
     }
 
@@ -372,7 +372,8 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
         return exists ? new DeserializedStacktraceWriter( traceMessage, smartTrimmedStackTrace, stackTrace ) : null;
     }
 
-    static TestSetReportEntry newReportEntry( // ReportEntry:
+    static TestSetReportEntry newReportEntry( RunMode runMode, Long testId,
+                                              // ReportEntry:
                                               String source, String sourceText, String name,
                                               String nameText, String group, String message,
                                               Integer timeElapsed,
@@ -382,8 +383,8 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
         throws NumberFormatException
     {
         StackTraceWriter stackTraceWriter = toTrace( traceMessage, smartTrimmedStackTrace, stackTrace );
-        return reportEntry( source, sourceText, name, nameText, group, stackTraceWriter, timeElapsed, message,
-            Collections.<String, String>emptyMap() );
+        return reportEntry( runMode, testId, source, sourceText, name, nameText, group, stackTraceWriter,
+            timeElapsed, message, Collections.<String, String>emptyMap() );
     }
 
     private static Map<Segment, ForkedProcessEventType> segmentsToEvents()

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
@@ -59,7 +59,7 @@ public class CommonReflectorTest
     private File reportsDirectory;
     private File statistics;
     private SurefireStatelessReporter xmlReporter;
-    private SurefireConsoleOutputReporter consoleOutputReporter = new SurefireConsoleOutputReporter();
+    private final SurefireConsoleOutputReporter consoleOutputReporter = new SurefireConsoleOutputReporter();
     private SurefireStatelessTestsetInfoReporter infoReporter = new SurefireStatelessTestsetInfoReporter();
 
     @Before
@@ -82,7 +82,7 @@ public class CommonReflectorTest
     public void createReportingReporterFactory()
     {
         CommonReflector reflector = new CommonReflector( Thread.currentThread().getContextClassLoader() );
-        DefaultReporterFactory factory = (DefaultReporterFactory) reflector.createReportingReporterFactory(
+        DefaultReporterFactory factory = (DefaultReporterFactory) reflector.createReporterFactory(
                 startupReportConfiguration, consoleLogger );
 
         assertThat( factory )

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/MockReporter.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/MockReporter.java
@@ -20,9 +20,10 @@ package org.apache.maven.plugin.surefire.booterclient;
  */
 
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.surefire.api.report.AbstractRunListener;
 import org.apache.maven.surefire.api.report.ConsoleOutputReceiver;
 import org.apache.maven.surefire.api.report.ReportEntry;
-import org.apache.maven.surefire.api.report.RunListener;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.apache.maven.surefire.api.report.TestSetReportEntry;
 import org.apache.maven.surefire.api.report.RunMode;
 
@@ -34,7 +35,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Internal tests use only.
  */
 public class MockReporter
-    implements RunListener, ConsoleLogger, ConsoleOutputReceiver
+    extends AbstractRunListener
+    implements ConsoleLogger, ConsoleOutputReceiver
 {
     private final List<String> events = new ArrayList<>();
 
@@ -73,6 +75,11 @@ public class MockReporter
     private final AtomicInteger testIgnored = new AtomicInteger();
 
     private final AtomicInteger testFailed = new AtomicInteger();
+
+    public MockReporter()
+    {
+        super( new RunListenerContext( RunMode.NORMAL_RUN ) );
+    }
 
     @Override
     public void testSetStarting( TestSetReportEntry report )

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
@@ -25,6 +25,7 @@ import org.apache.maven.plugin.surefire.extensions.SurefireStatelessReporter;
 import org.apache.maven.plugin.surefire.extensions.SurefireStatelessTestsetInfoReporter;
 import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
 import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
+import org.apache.maven.surefire.api.report.AbstractRunListener;
 import org.apache.maven.surefire.api.report.RunListener;
 
 import java.io.File;
@@ -43,7 +44,7 @@ public class TestSetMockReporterFactory
     }
 
     @Override
-    public RunListener createReporter()
+    public AbstractRunListener getRunListener()
     {
         return new MockReporter();
     }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClientTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClientTest.java
@@ -478,14 +478,14 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
         client.handleEvent( new StandardStreamOutEvent( NORMAL_RUN, "msg" ) );
         verifyZeroInteractions( notifiableTestStream );
         verify( factory, times( 1 ) )
-                .createReporter();
+                .getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -520,14 +520,14 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
         client.handleEvent( new StandardStreamOutWithNewLineEvent( NORMAL_RUN, "msg" ) );
         verifyZeroInteractions( notifiableTestStream );
         verify( factory, times( 1 ) )
-                .createReporter();
+                .getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -562,14 +562,14 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
         client.handleEvent( new StandardStreamErrEvent( NORMAL_RUN, "msg" ) );
         verifyZeroInteractions( notifiableTestStream );
         verify( factory, times( 1 ) )
-                .createReporter();
+                .getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -604,14 +604,14 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
         client.handleEvent( new StandardStreamErrWithNewLineEvent( NORMAL_RUN, "msg" ) );
         verifyZeroInteractions( notifiableTestStream );
         verify( factory, times( 1 ) )
-                .createReporter();
+                .getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -642,7 +642,7 @@ public class ForkClientTest
     {
         DefaultReporterFactory factory = mock( DefaultReporterFactory.class );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
@@ -652,7 +652,7 @@ public class ForkClientTest
         client.handleEvent( event );
         verifyZeroInteractions( notifiableTestStream );
         verify( factory, times( 1 ) )
-                .createReporter();
+                .getRunListener();
         verify( factory, times( 1 ) )
             .getReportsDirectory();
         verifyNoMoreInteractions( factory );
@@ -734,14 +734,14 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
         client.handleEvent( new ConsoleWarningEvent( "s1" ) );
         verifyZeroInteractions( notifiableTestStream );
         verify( factory, times( 1 ) )
-                .createReporter();
+                .getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -776,14 +776,14 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
         client.handleEvent( new ConsoleDebugEvent( "s1" ) );
         verifyZeroInteractions( notifiableTestStream );
         verify( factory, times( 1 ) )
-                .createReporter();
+                .getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -818,14 +818,14 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
         client.handleEvent( new ConsoleInfoEvent( "s1" ) );
         verifyZeroInteractions( notifiableTestStream );
         verify( factory, times( 1 ) )
-                .createReporter();
+                .getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -860,7 +860,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
@@ -900,7 +900,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
 
@@ -933,7 +933,7 @@ public class ForkClientTest
         verify( notifiableTestStream )
                 .shutdown( Shutdown.KILL );
         verifyNoMoreInteractions( notifiableTestStream );
-        verify( factory ).createReporter();
+        verify( factory ).getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -995,7 +995,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
 
@@ -1027,7 +1027,7 @@ public class ForkClientTest
         client.tryToTimeout( System.currentTimeMillis(), 1 );
 
         verifyZeroInteractions( notifiableTestStream );
-        verify( factory ).createReporter();
+        verify( factory ).getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -1091,7 +1091,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
 
@@ -1120,7 +1120,7 @@ public class ForkClientTest
         client.handleEvent( new TestsetCompletedEvent( NORMAL_RUN, reportEntry ) );
 
         verifyZeroInteractions( notifiableTestStream );
-        verify( factory ).createReporter();
+        verify( factory ).getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -1184,7 +1184,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
 
@@ -1213,7 +1213,7 @@ public class ForkClientTest
         client.handleEvent( new TestStartingEvent( NORMAL_RUN, reportEntry ) );
 
         verifyZeroInteractions( notifiableTestStream );
-        verify( factory ).createReporter();
+        verify( factory ).getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.hasTestsInProgress() )
                 .isTrue();
@@ -1278,7 +1278,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
 
@@ -1304,7 +1304,8 @@ public class ForkClientTest
         when( reportEntry.getStackTraceWriter() ).thenReturn( stackTraceWriter );
 
         ForkClient client = new ForkClient( factory, notifiableTestStream,  0 );
-        SimpleReportEntry testStarted = new SimpleReportEntry( reportEntry.getSourceName(), null, null, null );
+        SimpleReportEntry testStarted =
+            new SimpleReportEntry( NORMAL_RUN, 0L, reportEntry.getSourceName(), null, null, null );
         client.handleEvent( new TestStartingEvent( NORMAL_RUN, testStarted ) );
 
         assertThat( client.testsInProgress() )
@@ -1314,7 +1315,7 @@ public class ForkClientTest
         client.handleEvent( new TestSucceededEvent( NORMAL_RUN, reportEntry ) );
 
         verifyZeroInteractions( notifiableTestStream );
-        verify( factory ).createReporter();
+        verify( factory ).getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -1382,7 +1383,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
 
@@ -1408,7 +1409,8 @@ public class ForkClientTest
         when( reportEntry.getStackTraceWriter() ).thenReturn( stackTraceWriter );
 
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
-        SimpleReportEntry testClass = new SimpleReportEntry( reportEntry.getSourceName(), null, null, null );
+        SimpleReportEntry testClass =
+            new SimpleReportEntry( NORMAL_RUN, 0L, reportEntry.getSourceName(), null, null, null );
         client.handleEvent( new TestStartingEvent( NORMAL_RUN, testClass ) );
 
         assertThat( client.testsInProgress() )
@@ -1418,7 +1420,7 @@ public class ForkClientTest
         client.handleEvent( new TestFailedEvent( NORMAL_RUN, reportEntry ) );
 
         verifyZeroInteractions( notifiableTestStream );
-        verify( factory ).createReporter();
+        verify( factory ).getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -1492,7 +1494,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
 
@@ -1518,7 +1520,8 @@ public class ForkClientTest
         when( reportEntry.getStackTraceWriter() ).thenReturn( stackTraceWriter );
 
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
-        SimpleReportEntry testStarted = new SimpleReportEntry( reportEntry.getSourceName(), null, null, null );
+        SimpleReportEntry testStarted =
+            new SimpleReportEntry( NORMAL_RUN, 0L, reportEntry.getSourceName(), null, null, null );
         client.handleEvent( new TestStartingEvent( NORMAL_RUN, testStarted ) );
 
         assertThat( client.testsInProgress() )
@@ -1528,7 +1531,7 @@ public class ForkClientTest
         client.handleEvent( new TestSkippedEvent( NORMAL_RUN, reportEntry ) );
 
         verifyZeroInteractions( notifiableTestStream );
-        verify( factory ).createReporter();
+        verify( factory ).getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -1600,7 +1603,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
 
@@ -1627,8 +1630,8 @@ public class ForkClientTest
         when( reportEntry.getStackTraceWriter() ).thenReturn( stackTraceWriter );
 
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
-        SimpleReportEntry testStarted =
-            new SimpleReportEntry( reportEntry.getSourceName(), reportEntry.getSourceText(), null, null );
+        SimpleReportEntry testStarted = new SimpleReportEntry( NORMAL_RUN, 0L, reportEntry.getSourceName(),
+            reportEntry.getSourceText(), null, null );
         client.handleEvent( new TestStartingEvent( NORMAL_RUN, testStarted ) );
 
         assertThat( client.testsInProgress() )
@@ -1638,7 +1641,7 @@ public class ForkClientTest
         client.handleEvent( new TestErrorEvent( NORMAL_RUN, reportEntry ) );
 
         verifyZeroInteractions( notifiableTestStream );
-        verify( factory ).createReporter();
+        verify( factory ).getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();
@@ -1706,7 +1709,7 @@ public class ForkClientTest
         when( factory.getReportsDirectory() )
                 .thenReturn( new File( target, "surefire-reports" ) );
         MockReporter receiver = new MockReporter();
-        when( factory.createReporter() )
+        when( factory.getRunListener() )
                 .thenReturn( receiver );
         NotifiableTestStream notifiableTestStream = mock( NotifiableTestStream.class );
 
@@ -1733,7 +1736,8 @@ public class ForkClientTest
         when( reportEntry.getStackTraceWriter() ).thenReturn( stackTraceWriter );
 
         ForkClient client = new ForkClient( factory, notifiableTestStream, 0 );
-        SimpleReportEntry testStarted = new SimpleReportEntry( reportEntry.getSourceName(), null, null, null );
+        SimpleReportEntry testStarted =
+            new SimpleReportEntry( NORMAL_RUN, 0L, reportEntry.getSourceName(), null, null, null );
         client.handleEvent( new TestStartingEvent( NORMAL_RUN, testStarted ) );
 
         assertThat( client.testsInProgress() )
@@ -1743,7 +1747,7 @@ public class ForkClientTest
         client.handleEvent( new TestAssumptionFailureEvent( NORMAL_RUN, reportEntry ) );
 
         verifyZeroInteractions( notifiableTestStream );
-        verify( factory ).createReporter();
+        verify( factory ).getRunListener();
         verifyNoMoreInteractions( factory );
         assertThat( client.getReporter() )
                 .isNotNull();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
@@ -286,7 +286,7 @@ public class DefaultReporterFactoryTest
 
         DefaultReporterFactory factory = new DefaultReporterFactory( reportConfig, reporter );
 
-        TestSetRunListener runListener = (TestSetRunListener) factory.createReporter();
+        TestSetRunListener runListener = (TestSetRunListener) factory.getRunListener();
 
         assertTrue( runListener.isDebugEnabled() );
         assertTrue( runListener.isInfoEnabled() );
@@ -358,7 +358,7 @@ public class DefaultReporterFactoryTest
         DefaultReporterFactory factory = new DefaultReporterFactory( reportConfig, reporter );
         assertEquals( reportsDirectory, factory.getReportsDirectory() );
 
-        TestSetRunListener runListener = (TestSetRunListener) factory.createReporter();
+        TestSetRunListener runListener = (TestSetRunListener) factory.getRunListener();
         Collection listeners = getInternalState( factory, "listeners" );
         assertEquals( 1, listeners.size() );
         assertTrue( listeners.contains( runListener ) );

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/WrappedReportEntryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/WrappedReportEntryTest.java
@@ -28,6 +28,7 @@ import static org.apache.maven.plugin.surefire.report.ReportEntryType.ERROR;
 import static org.apache.maven.plugin.surefire.report.ReportEntryType.FAILURE;
 import static org.apache.maven.plugin.surefire.report.ReportEntryType.SKIPPED;
 import static org.apache.maven.plugin.surefire.report.ReportEntryType.SUCCESS;
+import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 
 /**
  * @author Kristian Rosenvold
@@ -39,7 +40,8 @@ public class WrappedReportEntryTest
     {
         String className = "surefire.testcase.JunitParamsTest";
         WrappedReportEntry wr =
-            new WrappedReportEntry( new SimpleReportEntry( className, null, null, null ), SUCCESS, 12, null, null );
+            new WrappedReportEntry( new SimpleReportEntry( NORMAL_RUN, 1L, className, null, null, null ),
+                SUCCESS, 12, null, null );
         final String reportName = wr.getReportSourceName();
         assertEquals( "surefire.testcase.JunitParamsTest.null", wr.getClassMethodName() );
         assertEquals( "surefire.testcase.JunitParamsTest", reportName );
@@ -50,7 +52,8 @@ public class WrappedReportEntryTest
 
     public void testRegular()
     {
-        ReportEntry reportEntry = new SimpleReportEntry( "surefire.testcase.JunitParamsTest", null, "testSum", null );
+        ReportEntry reportEntry =
+            new SimpleReportEntry( NORMAL_RUN, 1L, "surefire.testcase.JunitParamsTest", null, "testSum", null );
         WrappedReportEntry wr = new WrappedReportEntry( reportEntry, null, 12, null, null );
         assertEquals( "surefire.testcase.JunitParamsTest.testSum", wr.getClassMethodName() );
         assertEquals( "surefire.testcase.JunitParamsTest", wr.getReportSourceName() );
@@ -69,8 +72,8 @@ public class WrappedReportEntryTest
 
     public void testDisplayNames()
     {
-        ReportEntry reportEntry =
-                new SimpleReportEntry( "surefire.testcase.JunitParamsTest", "dn1", "testSum", "dn2", "exception" );
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 0L,
+            "surefire.testcase.JunitParamsTest", "dn1", "testSum", "dn2", "exception" );
         WrappedReportEntry wr = new WrappedReportEntry( reportEntry, ERROR, 12, null, null );
         assertEquals( "surefire.testcase.JunitParamsTest.testSum", wr.getClassMethodName() );
         assertEquals( "dn1", wr.getReportSourceName() );
@@ -90,7 +93,7 @@ public class WrappedReportEntryTest
 
     public void testEqualDisplayNames()
     {
-        ReportEntry reportEntry = new SimpleReportEntry( "surefire.testcase.JunitParamsTest",
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 1L, "surefire.testcase.JunitParamsTest",
                 "surefire.testcase.JunitParamsTest", "testSum", "testSum" );
         WrappedReportEntry wr = new WrappedReportEntry( reportEntry, FAILURE, 12, null, null );
         assertEquals( "surefire.testcase.JunitParamsTest", wr.getReportSourceName() );
@@ -104,7 +107,7 @@ public class WrappedReportEntryTest
     public void testGetReportNameWithParams()
     {
         String className = "[0] 1\u002C 2\u002C 3 (testSum)";
-        ReportEntry reportEntry = new SimpleReportEntry( className, null, null, null );
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 1L, className, null, null, null );
         WrappedReportEntry wr = new WrappedReportEntry( reportEntry, SKIPPED, 12, null, null );
         final String reportName = wr.getReportSourceName();
         assertEquals( "[0] 1, 2, 3 (testSum)", reportName );
@@ -116,7 +119,7 @@ public class WrappedReportEntryTest
     public void testElapsed()
     {
         String className = "[0] 1\u002C 2\u002C 3 (testSum)";
-        ReportEntry reportEntry = new SimpleReportEntry( className, null, null, null );
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 1L, className, null, null, null );
         WrappedReportEntry wr = new WrappedReportEntry( reportEntry, null, 12, null, null );
         String elapsedTimeSummary = wr.getElapsedTimeSummary();
         assertEquals( "[0] 1, 2, 3 (testSum)  Time elapsed: 0.012 s",

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/runorder/RunEntryStatisticsMapTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/runorder/RunEntryStatisticsMapTest.java
@@ -38,6 +38,7 @@ import junit.framework.TestCase;
 import org.apache.maven.surefire.api.util.internal.ClassMethod;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 import static org.apache.maven.surefire.shared.io.IOUtils.readLines;
 import static org.apache.maven.surefire.api.util.internal.StringUtils.NL;
 import static org.fest.assertions.Assertions.assertThat;
@@ -86,7 +87,8 @@ public class RunEntryStatisticsMapTest
     {
         File data = File.createTempFile( "surefire-unit", "test" );
         RunEntryStatisticsMap newResults = new RunEntryStatisticsMap();
-        ReportEntry reportEntry = new SimpleReportEntry( "abc", null, null, null, 42 );
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 0L,
+            "abc", null, null, null, 42 );
         newResults.add( newResults.createNextGeneration( reportEntry ) );
         newResults.serialize( data );
         try ( InputStream io = new FileInputStream( data ) )
@@ -131,9 +133,12 @@ public class RunEntryStatisticsMapTest
         RunEntryStatisticsMap existingEntries = RunEntryStatisticsMap.fromFile( data );
         RunEntryStatisticsMap newResults = new RunEntryStatisticsMap();
 
-        ReportEntry reportEntry1 = new SimpleReportEntry( "abc", null, "method1", null, 42 );
-        ReportEntry reportEntry2 = new SimpleReportEntry( "abc", null, "willFail", null, 17 );
-        ReportEntry reportEntry3 = new SimpleReportEntry( "abc", null, "method3", null, 100 );
+        ReportEntry reportEntry1 = new SimpleReportEntry( NORMAL_RUN, 0L,
+            "abc", null, "method1", null, 42 );
+        ReportEntry reportEntry2 = new SimpleReportEntry( NORMAL_RUN, 0L,
+            "abc", null, "willFail", null, 17 );
+        ReportEntry reportEntry3 = new SimpleReportEntry( NORMAL_RUN, 0L,
+            "abc", null, "method3", null, 100 );
 
         newResults.add( existingEntries.createNextGeneration( reportEntry1 ) );
         newResults.add( existingEntries.createNextGeneration( reportEntry2 ) );
@@ -154,9 +159,12 @@ public class RunEntryStatisticsMapTest
         RunEntryStatisticsMap nextRun = RunEntryStatisticsMap.fromFile( data );
         newResults = new RunEntryStatisticsMap();
 
-        ReportEntry newRunReportEntry1 = new SimpleReportEntry( "abc", null, "method1", null, 52 );
-        ReportEntry newRunReportEntry2 = new SimpleReportEntry( "abc", null, "willFail", null, 27 );
-        ReportEntry newRunReportEntry3 = new SimpleReportEntry( "abc", null, "method3", null, 110 );
+        ReportEntry newRunReportEntry1 = new SimpleReportEntry( NORMAL_RUN, 0L,
+            "abc", null, "method1", null, 52 );
+        ReportEntry newRunReportEntry2 = new SimpleReportEntry( NORMAL_RUN, 0L,
+            "abc", null, "willFail", null, 27 );
+        ReportEntry newRunReportEntry3 = new SimpleReportEntry( NORMAL_RUN, 0L,
+            "abc", null, "method3", null, 110 );
 
         newResults.add( nextRun.createNextGeneration( newRunReportEntry1 ) );
         newResults.add( nextRun.createNextGenerationFailure( newRunReportEntry2 ) );
@@ -180,7 +188,8 @@ public class RunEntryStatisticsMapTest
     {
         File data = File.createTempFile( "surefire-unit", "test" );
         RunEntryStatisticsMap reportEntries = RunEntryStatisticsMap.fromFile( data );
-        ReportEntry reportEntry = new SimpleReportEntry( "abc", null, "line1\nline2" + NL + " line3", null, 42 );
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 0L,
+            "abc", null, "line1\nline2" + NL + " line3", null, 42 );
         reportEntries.add( reportEntries.createNextGeneration( reportEntry ) );
 
         reportEntries.serialize( data );
@@ -215,10 +224,10 @@ public class RunEntryStatisticsMapTest
     {
         File data = File.createTempFile( "surefire-unit", "test" );
         RunEntryStatisticsMap reportEntries = RunEntryStatisticsMap.fromFile( data );
-        reportEntries.add(
-                reportEntries.createNextGeneration( new SimpleReportEntry( "abc", null, "line1\nline2", null, 42 ) ) );
-        reportEntries.add(
-                reportEntries.createNextGeneration( new SimpleReportEntry( "abc", null, "test", null, 10 ) ) );
+        reportEntries.add( reportEntries.createNextGeneration( new SimpleReportEntry( NORMAL_RUN, 0L,
+                    "abc", null, "line1\nline2", null, 42 ) ) );
+        reportEntries.add( reportEntries.createNextGeneration( new SimpleReportEntry( NORMAL_RUN, 0L,
+            "abc", null, "test", null, 10 ) ) );
 
         reportEntries.serialize( data );
         try ( InputStream io = new FileInputStream( data ) )

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/BaseProviderFactory.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/BaseProviderFactory.java
@@ -22,8 +22,6 @@ package org.apache.maven.surefire.api.booter;
 import org.apache.maven.surefire.api.cli.CommandLineOption;
 import org.apache.maven.surefire.api.provider.CommandChainReader;
 import org.apache.maven.surefire.api.provider.ProviderParameters;
-import org.apache.maven.surefire.api.report.ConsoleStream;
-import org.apache.maven.surefire.api.report.DefaultDirectConsoleReporter;
 import org.apache.maven.surefire.api.report.ReporterConfiguration;
 import org.apache.maven.surefire.api.report.ReporterFactory;
 import org.apache.maven.surefire.api.testset.DirectoryScannerParameters;
@@ -52,8 +50,6 @@ public class BaseProviderFactory
     private final boolean insideFork;
 
     private ReporterFactory reporterFactory;
-
-    private MasterProcessChannelEncoder masterProcessChannelEncoder;
 
     private List<CommandLineOption> mainCliOptions = emptyList();
 
@@ -146,14 +142,6 @@ public class BaseProviderFactory
     public void setClassLoaders( ClassLoader testClassLoader )
     {
         this.testClassLoader = testClassLoader;
-    }
-
-    @Override
-    public ConsoleStream getConsoleLogger()
-    {
-        return insideFork
-            ? new ForkingRunListener( masterProcessChannelEncoder, reporterConfiguration.isTrimStackTrace() )
-            : new DefaultDirectConsoleReporter( reporterConfiguration.getOriginalSystemOut() );
     }
 
     public void setTestRequest( TestRequest testRequest )
@@ -259,10 +247,5 @@ public class BaseProviderFactory
     public void setSystemExitTimeout( Integer systemExitTimeout )
     {
         this.systemExitTimeout = systemExitTimeout;
-    }
-
-    public void setForkedChannelEncoder( MasterProcessChannelEncoder masterProcessChannelEncoder )
-    {
-        this.masterProcessChannelEncoder = masterProcessChannelEncoder;
     }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingReporterFactory.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingReporterFactory.java
@@ -19,8 +19,11 @@ package org.apache.maven.surefire.api.booter;
  * under the License.
  */
 
+import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.surefire.api.report.AbstractRunListener;
+import org.apache.maven.surefire.api.report.ConsoleStream;
 import org.apache.maven.surefire.api.report.ReporterFactory;
-import org.apache.maven.surefire.api.report.RunListener;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.apache.maven.surefire.api.suite.RunResult;
 
 /**
@@ -32,20 +35,30 @@ import org.apache.maven.surefire.api.suite.RunResult;
 public class ForkingReporterFactory
     implements ReporterFactory
 {
-    private final boolean trimstackTrace;
+    private final ForkingRunListener runListener;
 
-    private final MasterProcessChannelEncoder eventChannel;
-
-    public ForkingReporterFactory( boolean trimstackTrace, MasterProcessChannelEncoder eventChannel )
+    public ForkingReporterFactory( RunListenerContext ctx, boolean trimStackTrace,
+                                   MasterProcessChannelEncoder eventChannel )
     {
-        this.trimstackTrace = trimstackTrace;
-        this.eventChannel = eventChannel;
+        runListener = new ForkingRunListener( ctx, eventChannel, trimStackTrace );
     }
 
     @Override
-    public RunListener createReporter()
+    public AbstractRunListener getRunListener()
     {
-        return new ForkingRunListener( eventChannel, trimstackTrace );
+        return runListener;
+    }
+
+    @Override
+    public ConsoleLogger getConsoleLogger()
+    {
+        return runListener;
+    }
+
+    @Override
+    public ConsoleStream getConsoleStream()
+    {
+        return runListener;
     }
 
     @Override

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingRunListener.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ForkingRunListener.java
@@ -20,15 +20,16 @@ package org.apache.maven.surefire.api.booter;
  */
 
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
+import org.apache.maven.surefire.api.report.AbstractRunListener;
 import org.apache.maven.surefire.api.report.ConsoleOutputReceiver;
 import org.apache.maven.surefire.api.report.ConsoleStream;
 import org.apache.maven.surefire.api.report.ReportEntry;
-import org.apache.maven.surefire.api.report.RunListener;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.apache.maven.surefire.api.report.RunMode;
 import org.apache.maven.surefire.api.report.TestSetReportEntry;
 
-import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 import static java.util.Objects.requireNonNull;
+import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 
 /**
  * Encodes the full output of the test run to the stdout stream.
@@ -47,8 +48,9 @@ import static java.util.Objects.requireNonNull;
  *
  * @author Kristian Rosenvold
  */
-public class ForkingRunListener
-    implements RunListener, ConsoleLogger, ConsoleOutputReceiver, ConsoleStream
+public final class ForkingRunListener
+    extends AbstractRunListener
+    implements ConsoleLogger, ConsoleOutputReceiver, ConsoleStream
 {
     private final MasterProcessChannelEncoder target;
 
@@ -56,8 +58,9 @@ public class ForkingRunListener
 
     private volatile RunMode runMode = NORMAL_RUN;
 
-    public ForkingRunListener( MasterProcessChannelEncoder target, boolean trim )
+    public ForkingRunListener( RunListenerContext ctx, MasterProcessChannelEncoder target, boolean trim )
     {
+        super( ctx );
         this.target = target;
         this.trim = trim;
     }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/provider/ProviderParameters.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/provider/ProviderParameters.java
@@ -20,7 +20,6 @@ package org.apache.maven.surefire.api.provider;
  */
 
 import org.apache.maven.surefire.api.cli.CommandLineOption;
-import org.apache.maven.surefire.api.report.ConsoleStream;
 import org.apache.maven.surefire.api.report.ReporterConfiguration;
 import org.apache.maven.surefire.api.report.ReporterFactory;
 import org.apache.maven.surefire.api.testset.DirectoryScannerParameters;
@@ -76,16 +75,6 @@ public interface ProviderParameters
      * @return A ReporterFactory that allows the creation of one or more ReporterManagers
      */
     ReporterFactory getReporterFactory();
-
-    /**
-     * Gets a logger intended for console output.
-     * <br>
-     * This output is intended for provider-oriented messages that are not attached to a single test-set
-     * and will normally be written to something console-like immediately.
-     *
-     * @return A console stream logger
-     */
-    ConsoleStream getConsoleLogger();
 
     /**
      * The raw parameters used in creating the directory scanner

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/AbstractRunListener.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/AbstractRunListener.java
@@ -1,0 +1,40 @@
+package org.apache.maven.surefire.api.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.annotation.Nonnull;
+
+/**
+ * Base class for run-listeners used in providers and ForkingRunListener.
+ */
+public abstract class AbstractRunListener implements RunListener
+{
+    private final RunListenerContext ctx;
+
+    protected AbstractRunListener( @Nonnull RunListenerContext ctx )
+    {
+        this.ctx = ctx;
+    }
+
+    public final RunListenerContext getContext()
+    {
+        return ctx;
+    }
+}

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/CategorizedReportEntry.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/CategorizedReportEntry.java
@@ -19,6 +19,8 @@ package org.apache.maven.surefire.api.report;
  * under the License.
  */
 
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -35,42 +37,48 @@ public class CategorizedReportEntry
 
     private final String group;
 
-    public CategorizedReportEntry( String source, String name, String group )
+    public CategorizedReportEntry( @Nonnull RunMode runMode, @Nonnegative long testRunId,
+                                   String source, String name, String group )
     {
-        this( source, name, group, null, null );
+        this( runMode, testRunId, source, name, group, null, null );
     }
 
-    public CategorizedReportEntry( String source, String name, String group, StackTraceWriter stackTraceWriter,
+    public CategorizedReportEntry( @Nonnull RunMode runMode, @Nonnegative long testRunId,
+                                   String source, String name, String group, StackTraceWriter stackTraceWriter,
                                    Integer elapsed )
     {
-        super( source, null, name, null, stackTraceWriter, elapsed );
+        super( runMode, testRunId, source, null, name, null, stackTraceWriter, elapsed );
         this.group = group;
     }
 
-    public CategorizedReportEntry( String source, String name, String group, StackTraceWriter stackTraceWriter,
+    public CategorizedReportEntry( @Nonnull RunMode runMode, @Nonnegative long testRunId,
+                                   String source, String name, String group, StackTraceWriter stackTraceWriter,
                                    Integer elapsed, String message )
     {
-        this( source, null, name, null,
-                group, stackTraceWriter, elapsed, message, Collections.<String, String>emptyMap() );
+        this( runMode, testRunId, source, null, name, null,
+            group, stackTraceWriter, elapsed, message, Collections.<String, String>emptyMap() );
     }
 
-    public CategorizedReportEntry( String source, String sourceText, String name, String nameText,
+    public CategorizedReportEntry( @Nonnull RunMode runMode, @Nonnegative long testRunId,
+                                   String source, String sourceText, String name, String nameText,
                                    String group, StackTraceWriter stackTraceWriter,
                                    Integer elapsed, String message, Map<String, String> systemProperties )
     {
-        super( source, sourceText, name, nameText, stackTraceWriter, elapsed, message, systemProperties );
+        super( runMode, testRunId, source, sourceText, name, nameText, stackTraceWriter, elapsed, message,
+            systemProperties );
         this.group = group;
     }
 
-    public static TestSetReportEntry reportEntry( String source, String sourceText, String name, String nameText,
-                                                  String group,
+    public static TestSetReportEntry reportEntry( @Nonnull RunMode runMode, @Nonnegative Long testRunId,
+                                                  String source, String sourceText,
+                                                  String name, String nameText, String group,
                                                   StackTraceWriter stackTraceWriter, Integer elapsed, String message,
                                                   Map<String, String> systemProperties )
     {
         return group != null
-            ? new CategorizedReportEntry( source, sourceText, name, nameText,
+            ? new CategorizedReportEntry( runMode, testRunId, source, sourceText, name, nameText,
                 group, stackTraceWriter, elapsed, message, systemProperties )
-            : new SimpleReportEntry( source, sourceText, name, nameText,
+            : new SimpleReportEntry( runMode, testRunId, source, sourceText, name, nameText,
                 stackTraceWriter, elapsed, message, systemProperties );
     }
 

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReportEntry.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReportEntry.java
@@ -19,6 +19,10 @@ package org.apache.maven.surefire.api.report;
  * under the License.
  */
 
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * Describes a single entry for a test report
  *
@@ -105,4 +109,21 @@ public interface ReportEntry
      * @return A string with the test case text and group/category, or just the source text.
      */
     String getReportNameWithGroup();
+
+    /**
+     * Run mode.
+     *
+     * @return a normal run, or re-run.
+     */
+    @Nonnull
+    RunMode getRunMode();
+
+    /**
+     * This represents a reference pointing to a literal representation of test description or literal unique id.
+     *
+     * @return id
+     */
+    @Nonnegative
+    @Nullable
+    Long getTestRunId();
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReporterFactory.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReporterFactory.java
@@ -19,6 +19,7 @@ package org.apache.maven.surefire.api.report;
  * under the License.
  */
 
+import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.surefire.api.suite.RunResult;
 
 /**
@@ -29,11 +30,28 @@ import org.apache.maven.surefire.api.suite.RunResult;
 public interface ReporterFactory
 {
     /**
-     * Creates a reporter.
+     * Get a reporter.
      *
      * @return A reporter instance
      */
-    RunListener createReporter();
+    AbstractRunListener getRunListener();
+
+    /**
+     * Gets a logger intended for console output.
+     * <br>
+     * This output is intended for provider-oriented messages that are not attached to a single test-set
+     * and will normally be written to something console-like immediately.
+     *
+     * @return A console logger
+     */
+    ConsoleLogger getConsoleLogger();
+
+    /**
+     * Get a console stream (System.out) used by (forked) provider.
+     *
+     * @return A console stream
+     */
+    ConsoleStream getConsoleStream();
 
     /**
      * Closes the factory, freeing resources allocated in the factory.

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/RunListenerContext.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/RunListenerContext.java
@@ -1,0 +1,67 @@
+package org.apache.maven.surefire.api.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.annotation.Nonnull;
+
+/**
+ * Memento object handled by {@link RunListener} (and Providers) which carries a runtime status related
+ * to the listener important for the concrete implementations in the context of Provider where the listener is utilized.
+ */
+public final class RunListenerContext
+{
+    private final ThreadLocal<Long> currentTestIds = new ThreadLocal<>();
+    private volatile RunMode runMode;
+
+    public RunListenerContext( @Nonnull RunMode runMode )
+    {
+        this.runMode = runMode;
+    }
+
+    public void setRunMode( @Nonnull RunMode runMode )
+    {
+        this.runMode = runMode;
+    }
+
+    public RunMode getRunMode()
+    {
+        return runMode;
+    }
+
+    public void removeCurrentTestId()
+    {
+        currentTestIds.remove();
+    }
+
+    public void setCurrentTestId( long testId )
+    {
+        currentTestIds.set( testId );
+    }
+
+    public Long getCurrentTestId()
+    {
+        return currentTestIds.get();
+    }
+
+    public boolean hasCurrentTestId()
+    {
+        return currentTestIds.get() != null;
+    }
+}

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/SimpleReportEntry.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/SimpleReportEntry.java
@@ -21,6 +21,9 @@ package org.apache.maven.surefire.api.report;
 
 import org.apache.maven.surefire.api.util.internal.ImmutableMap;
 
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -33,6 +36,10 @@ import java.util.Objects;
 public class SimpleReportEntry
     implements TestSetReportEntry
 {
+    private final RunMode runMode;
+
+    private final Long testRunId;
+
     private final Map<String, String> systemProperties;
 
     private final String source;
@@ -49,37 +56,46 @@ public class SimpleReportEntry
 
     private final String message;
 
-    public SimpleReportEntry( String source, String sourceText, String name, String nameText )
+    public SimpleReportEntry( @Nonnull RunMode runMode, @Nonnegative Long testRunId,
+                              String source, String sourceText, String name, String nameText )
     {
-        this( source, sourceText, name, nameText, null, null );
+        this( runMode, testRunId, source, sourceText, name, nameText, null, null );
     }
 
-    public SimpleReportEntry( String source, String sourceText, String name, String nameText,
+    public SimpleReportEntry( @Nonnull RunMode runMode, @Nonnegative Long testRunId,
+                              String source, String sourceText, String name, String nameText,
                               Map<String, String> systemProperties )
     {
-        this( source, sourceText, name, nameText, null, null, systemProperties );
+        this( runMode, testRunId, source, sourceText, name, nameText, null, null, systemProperties );
     }
 
-    private SimpleReportEntry( String source, String sourceText, String name, String nameText,
+    private SimpleReportEntry( @Nonnull RunMode runMode, @Nonnegative Long testRunId,
+                               String source, String sourceText, String name, String nameText,
                                StackTraceWriter stackTraceWriter )
     {
-        this( source, sourceText, name, nameText, stackTraceWriter, null );
+        this( runMode, testRunId, source, sourceText, name, nameText, stackTraceWriter, null );
     }
 
-    public SimpleReportEntry( String source, String sourceText, String name, String nameText, Integer elapsed )
+    public SimpleReportEntry( @Nonnull RunMode runMode, @Nonnegative Long testRunId,
+                              String source, String sourceText, String name, String nameText, Integer elapsed )
     {
-        this( source, sourceText, name, nameText, null, elapsed );
+        this( runMode, testRunId, source, sourceText, name, nameText, null, elapsed );
     }
 
-    public SimpleReportEntry( String source, String sourceText, String name, String nameText, String message )
+    public SimpleReportEntry( @Nonnull RunMode runMode, @Nonnegative Long testRunId,
+                              String source, String sourceText, String name, String nameText, String message )
     {
-        this( source, sourceText, name, nameText, null, null, message, Collections.<String, String>emptyMap() );
+        this( runMode, testRunId,
+            source, sourceText, name, nameText, null, null, message, Collections.<String, String>emptyMap() );
     }
 
-    public SimpleReportEntry( String source, String sourceText, String name, String nameText,
-                                 StackTraceWriter stackTraceWriter, Integer elapsed, String message,
-                                 Map<String, String> systemProperties )
+    public SimpleReportEntry( @Nonnull RunMode runMode, @Nonnegative Long testRunId,
+                              String source, String sourceText, String name, String nameText,
+                              StackTraceWriter stackTraceWriter, Integer elapsed, String message,
+                              Map<String, String> systemProperties )
     {
+        this.runMode = runMode;
+        this.testRunId = testRunId;
         this.source = source;
         this.sourceText = sourceText;
         this.name = name;
@@ -90,35 +106,39 @@ public class SimpleReportEntry
         this.systemProperties = new ImmutableMap<>( systemProperties );
     }
 
-    public SimpleReportEntry( String source, String sourceText, String name, String nameText,
-                              StackTraceWriter stackTraceWriter, Integer elapsed )
+    public SimpleReportEntry( @Nonnull RunMode runMode, @Nonnegative Long testRunId,
+                               String source, String sourceText, String name, String nameText,
+                               StackTraceWriter stackTraceWriter, Integer elapsed )
     {
-        this( source, sourceText, name, nameText, stackTraceWriter, elapsed, Collections.<String, String>emptyMap() );
+        this( runMode, testRunId,
+            source, sourceText, name, nameText, stackTraceWriter, elapsed, Collections.<String, String>emptyMap() );
     }
 
-    public SimpleReportEntry( String source, String sourceText, String name, String nameText,
+    public SimpleReportEntry( @Nonnull RunMode runMode, @Nonnegative Long testRunId,
+                              String source, String sourceText, String name, String nameText,
                               StackTraceWriter stackTraceWriter, Integer elapsed, Map<String, String> systemProperties )
     {
-        this( source, sourceText, name, nameText,
-                stackTraceWriter, elapsed, safeGetMessage( stackTraceWriter ), systemProperties );
+        this( runMode, testRunId, source, sourceText, name, nameText,
+            stackTraceWriter, elapsed, safeGetMessage( stackTraceWriter ), systemProperties );
     }
 
-    public static SimpleReportEntry assumption( String source, String sourceText, String name, String nameText,
-                                                String message )
+    public static SimpleReportEntry assumption( RunMode runMode, Long testRunId, String source,
+                                                String sourceText, String name, String nameText, String message )
     {
-        return new SimpleReportEntry( source, sourceText, name, nameText, message );
+        return new SimpleReportEntry( runMode, testRunId, source, sourceText, name, nameText, message );
     }
 
-    public static SimpleReportEntry ignored( String source, String sourceText, String name, String nameText,
-                                             String message )
+    public static SimpleReportEntry ignored( RunMode runMode, Long testRunId, String source,
+                                             String sourceText, String name, String nameText, String message )
     {
-        return new SimpleReportEntry( source, sourceText, name, nameText, message );
+        return new SimpleReportEntry( runMode, testRunId, source, sourceText, name, nameText, message );
     }
 
-    public static SimpleReportEntry withException( String source, String sourceText, String name, String nameText,
+    public static SimpleReportEntry withException( RunMode runMode, Long testRunId, String source,
+                                                   String sourceText, String name, String nameText,
                                                    StackTraceWriter stackTraceWriter )
     {
-        return new SimpleReportEntry( source, sourceText, name, nameText, stackTraceWriter );
+        return new SimpleReportEntry( runMode, testRunId, source, sourceText, name, nameText, stackTraceWriter );
     }
 
     private static String safeGetMessage( StackTraceWriter stackTraceWriter )
@@ -185,9 +205,10 @@ public class SimpleReportEntry
     @Override
     public String toString()
     {
-        return "ReportEntry{" + "source='" + source + "', sourceText='" + sourceText
-                + "', name='" + name + "', nameText='" + nameText + "', stackTraceWriter='"
-                + stackTraceWriter + "', elapsed='" + elapsed + "', message='" + message + "'}";
+        return "ReportEntry{" + "runMode='" + runMode + "', testRunId='" + testRunId
+            + "', source='" + source + "', sourceText='" + sourceText
+            + "', name='" + name + "', nameText='" + nameText + "', stackTraceWriter='" + stackTraceWriter
+            + "', elapsed='" + elapsed + "', message='" + message + "'}";
     }
 
     @Override
@@ -209,7 +230,8 @@ public class SimpleReportEntry
         }
 
         SimpleReportEntry that = (SimpleReportEntry) o;
-        return isSourceEqual( that ) && isSourceTextEqual( that )
+        return isRunModeEqual( that ) && isTestRunIdEqual( that )
+                && isSourceEqual( that ) && isSourceTextEqual( that )
                 && isNameEqual( that ) && isNameTextEqual( that )
                 && isStackEqual( that )
                 && isElapsedTimeEqual( that )
@@ -220,7 +242,9 @@ public class SimpleReportEntry
     @Override
     public int hashCode()
     {
-        int result = Objects.hashCode( getSourceName() );
+        int result = Objects.hashCode( getRunMode() );
+        result = 31 * result + Objects.hashCode( getTestRunId() );
+        result = 31 * result + Objects.hashCode( getSourceName() );
         result = 31 * result + Objects.hashCode( getSourceText() );
         result = 31 * result + Objects.hashCode( getName() );
         result = 31 * result + Objects.hashCode( getNameText() );
@@ -244,9 +268,34 @@ public class SimpleReportEntry
     }
 
     @Override
+    @Nonnull
+    public final RunMode getRunMode()
+    {
+        return runMode;
+    }
+
+    @Override
+    @Nonnegative
+    @Nullable
+    public final Long getTestRunId()
+    {
+        return testRunId;
+    }
+
+    @Override
     public Map<String, String> getSystemProperties()
     {
         return systemProperties;
+    }
+
+    private boolean isRunModeEqual( SimpleReportEntry en )
+    {
+        return Objects.equals( getRunMode(), en.getRunMode() );
+    }
+
+    private boolean isTestRunIdEqual( SimpleReportEntry en )
+    {
+        return Objects.equals( getTestRunId(), en.getTestRunId() );
     }
 
     private boolean isElapsedTimeEqual( SimpleReportEntry en )

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/booter/ForkingRunListenerTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/booter/ForkingRunListenerTest.java
@@ -20,8 +20,10 @@ package org.apache.maven.surefire.api.booter;
  */
 
 import junit.framework.TestCase;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.mockito.ArgumentCaptor;
 
+import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -41,7 +43,8 @@ public class ForkingRunListenerTest
         MasterProcessChannelEncoder encoder = mock( MasterProcessChannelEncoder.class );
         ArgumentCaptor<String> argument1 = ArgumentCaptor.forClass( String.class );
         doNothing().when( encoder ).consoleInfoLog( anyString() );
-        ForkingRunListener forkingRunListener = new ForkingRunListener( encoder, true );
+        RunListenerContext ctx = new RunListenerContext( NORMAL_RUN );
+        ForkingRunListener forkingRunListener = new ForkingRunListener( ctx, encoder, true );
         forkingRunListener.info( new String( new byte[]{ (byte) 'A' } ) );
         forkingRunListener.info( new String( new byte[]{ } ) );
         verify( encoder, times( 2 ) ).consoleInfoLog( argument1.capture() );

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/SurefireReflectorTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/SurefireReflectorTest.java
@@ -20,12 +20,14 @@ package org.apache.maven.surefire.booter;
  */
 
 import junit.framework.TestCase;
+import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.surefire.api.booter.BaseProviderFactory;
 import org.apache.maven.surefire.api.provider.ProviderParameters;
 import org.apache.maven.surefire.api.provider.SurefireProvider;
+import org.apache.maven.surefire.api.report.AbstractRunListener;
+import org.apache.maven.surefire.api.report.ConsoleStream;
 import org.apache.maven.surefire.api.report.ReporterConfiguration;
 import org.apache.maven.surefire.api.report.ReporterFactory;
-import org.apache.maven.surefire.api.report.RunListener;
 import org.apache.maven.surefire.api.suite.RunResult;
 import org.apache.maven.surefire.api.testset.DirectoryScannerParameters;
 import org.apache.maven.surefire.api.testset.RunOrderParameters;
@@ -55,7 +57,19 @@ public class SurefireReflectorTest
         ReporterFactory factory = new ReporterFactory()
         {
             @Override
-            public RunListener createReporter()
+            public AbstractRunListener getRunListener()
+            {
+                return null;
+            }
+
+            @Override
+            public ConsoleLogger getConsoleLogger()
+            {
+                return null;
+            }
+
+            @Override
+            public ConsoleStream getConsoleStream()
             {
                 return null;
             }
@@ -255,7 +269,19 @@ public class SurefireReflectorTest
         ReporterFactory reporterFactory = new ReporterFactory()
         {
             @Override
-            public RunListener createReporter()
+            public AbstractRunListener getRunListener()
+            {
+                return null;
+            }
+
+            @Override
+            public ConsoleLogger getConsoleLogger()
+            {
+                return null;
+            }
+
+            @Override
+            public ConsoleStream getConsoleStream()
             {
                 return null;
             }
@@ -279,7 +305,19 @@ public class SurefireReflectorTest
         ReporterFactory reporterFactory = new ReporterFactory()
         {
             @Override
-            public RunListener createReporter()
+            public AbstractRunListener getRunListener()
+            {
+                return null;
+            }
+
+            @Override
+            public ConsoleLogger getConsoleLogger()
+            {
+                return null;
+            }
+
+            @Override
+            public ConsoleStream getConsoleStream()
             {
                 return null;
             }

--- a/surefire-providers/common-junit4/src/test/java/org/apache/maven/surefire/common/junit4/MockReporter.java
+++ b/surefire-providers/common-junit4/src/test/java/org/apache/maven/surefire/common/junit4/MockReporter.java
@@ -19,8 +19,9 @@ package org.apache.maven.surefire.common.junit4;
  * under the License.
  */
 
+import org.apache.maven.surefire.api.report.AbstractRunListener;
 import org.apache.maven.surefire.api.report.ReportEntry;
-import org.apache.maven.surefire.api.report.RunListener;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.apache.maven.surefire.api.report.RunMode;
 import org.apache.maven.surefire.api.report.TestSetReportEntry;
 
@@ -32,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Internal tests use only.
  */
 final class MockReporter
-    implements RunListener
+    extends AbstractRunListener
 {
     private final List<String> events = new ArrayList<>();
 
@@ -56,6 +57,7 @@ final class MockReporter
 
     MockReporter()
     {
+        super( new RunListenerContext( RunMode.NORMAL_RUN ) );
     }
 
     @Override

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -113,7 +113,7 @@ public class JUnitPlatformProvider
         final RunResult runResult;
         try
         {
-            RunListener runListener = reporterFactory.createReporter();
+            RunListener runListener = reporterFactory.getRunListener();
             startCapture( ( ConsoleOutputReceiver ) runListener );
             if ( forkTestSet instanceof TestsToRun )
             {

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -929,7 +929,7 @@ public class JUnitPlatformProviderTest
         when( runOrderCalculator.orderTestClasses( any() ) ).thenReturn( testsToRun );
 
         ReporterFactory reporterFactory = mock( ReporterFactory.class );
-        when( reporterFactory.createReporter() ).thenReturn( runListener );
+        when( reporterFactory.getRunListener() ).thenReturn( runListener );
 
         TestRequest testRequest = mock( TestRequest.class );
         when( testRequest.getTestListResolver() ).thenReturn( testListResolver );
@@ -1111,7 +1111,7 @@ public class JUnitPlatformProviderTest
         TestsToRun testsToRun = newTestsToRun( Sub1Tests.class, Sub2Tests.class );
 
         invokeProvider( jUnitPlatformProvider, testsToRun );
-        RunListener reporter = providerParameters.getReporterFactory().createReporter();
+        RunListener reporter = providerParameters.getReporterFactory().getRunListener();
 
         ArgumentCaptor<ReportEntry> reportEntryArgumentCaptor =
                         ArgumentCaptor.forClass( ReportEntry.class );

--- a/surefire-providers/surefire-junit3/src/main/java/org/apache/maven/surefire/junit/JUnit3Provider.java
+++ b/surefire-providers/surefire-junit3/src/main/java/org/apache/maven/surefire/junit/JUnit3Provider.java
@@ -97,7 +97,7 @@ public class JUnit3Provider
         RunResult runResult;
         try
         {
-            final RunListener reporter = reporterFactory.createReporter();
+            final RunListener reporter = reporterFactory.getRunListener();
             ConsoleOutputCapture.startCapture( (ConsoleOutputReceiver) reporter );
             Map<String, String> systemProperties = systemProps();
             String smClassName = System.getProperty( "surefire.security.manager" );

--- a/surefire-providers/surefire-junit3/src/main/java/org/apache/maven/surefire/junit/TestListenerInvocationHandler.java
+++ b/surefire-providers/surefire-junit3/src/main/java/org/apache/maven/surefire/junit/TestListenerInvocationHandler.java
@@ -52,17 +52,17 @@ public class TestListenerInvocationHandler
 
     private final Set<FailedTest> failedTestsSet = new HashSet<>();
 
-    private RunListener reporter;
+    private final RunListener reporter;
 
-    private static final Class[] EMPTY_CLASS_ARRAY = { };
+    private static final Class<?>[] EMPTY_CLASS_ARRAY = { };
 
     private static final Object[] EMPTY_STRING_ARRAY = { };
 
     private static class FailedTest
     {
-        private Object testThatFailed;
+        private final Object testThatFailed;
 
-        private Thread threadOnWhichTestFailed;
+        private final Thread threadOnWhichTestFailed;
 
         FailedTest( Object testThatFailed, Thread threadOnWhichTestFailed )
         {

--- a/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
+++ b/surefire-providers/surefire-junit4/src/main/java/org/apache/maven/surefire/junit4/JUnit4Provider.java
@@ -22,6 +22,7 @@ package org.apache.maven.surefire.junit4;
 import org.apache.maven.surefire.api.booter.Command;
 import org.apache.maven.surefire.api.provider.CommandChainReader;
 import org.apache.maven.surefire.api.provider.CommandListener;
+import org.apache.maven.surefire.api.report.AbstractRunListener;
 import org.apache.maven.surefire.common.junit4.JUnit4RunListener;
 import org.apache.maven.surefire.common.junit4.JUnit4TestChecker;
 import org.apache.maven.surefire.common.junit4.JUnitTestFailureListener;
@@ -121,7 +122,7 @@ public class JUnit4Provider
         RunResult runResult;
         try
         {
-            RunListener reporter = reporterFactory.createReporter();
+            AbstractRunListener reporter = reporterFactory.getRunListener();
 
             startCapture( (ConsoleOutputReceiver) reporter );
             // startCapture() called in prior to setTestsToRun()

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/ClassesParallelRunListener.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/ClassesParallelRunListener.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.maven.surefire.api.report.ConsoleStream;
 import org.apache.maven.surefire.api.report.ReporterFactory;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.apache.maven.surefire.api.testset.TestSetFailedException;
 import org.junit.runner.notification.RunListener.ThreadSafe;
 
@@ -33,11 +34,13 @@ import org.junit.runner.notification.RunListener.ThreadSafe;
 public class ClassesParallelRunListener
     extends ConcurrentRunListener
 {
-    public ClassesParallelRunListener( Map<String, TestSet> classMethodCounts, ReporterFactory reporterFactory,
+    public ClassesParallelRunListener( RunListenerContext ctx,
+                                       Map<String, TestSet> classMethodCounts,
+                                       ReporterFactory reporterFactory,
                                        ConsoleStream consoleStream )
         throws TestSetFailedException
     {
-        super( reporterFactory, consoleStream, false, classMethodCounts );
+        super( ctx, reporterFactory, consoleStream, false, classMethodCounts );
     }
 
     @Override

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreRunListener.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreRunListener.java
@@ -19,9 +19,9 @@ package org.apache.maven.surefire.junitcore;
  * under the License.
  */
 
+import org.apache.maven.surefire.api.report.AbstractRunListener;
 import org.apache.maven.surefire.common.junit4.JUnit4RunListener;
 import org.apache.maven.surefire.common.junit4.JUnit4StackTraceWriter;
-import org.apache.maven.surefire.api.report.RunListener;
 import org.apache.maven.surefire.api.report.StackTraceWriter;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
@@ -49,7 +49,7 @@ public class JUnitCoreRunListener
      * @param reporter          the report manager to log testing events to
      * @param classMethodCounts A map of methods
      */
-    public JUnitCoreRunListener( RunListener reporter, Map<String, TestSet> classMethodCounts )
+    public JUnitCoreRunListener( AbstractRunListener reporter, Map<String, TestSet> classMethodCounts )
     {
         super( reporter );
         this.classMethodCounts = classMethodCounts;
@@ -62,7 +62,6 @@ public class JUnitCoreRunListener
      */
     @Override
     public void testRunStarted( Description description )
-        throws Exception
     {
         fillTestCountMap( description );
         reporter.testSetStarting( null ); // Not entirely meaningful as we can see
@@ -70,7 +69,6 @@ public class JUnitCoreRunListener
 
     @Override
     public void testRunFinished( Result result )
-        throws Exception
     {
         try
         {

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/MethodsParallelRunListener.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/MethodsParallelRunListener.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.maven.surefire.api.report.ConsoleStream;
 import org.apache.maven.surefire.api.report.ReporterFactory;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.apache.maven.surefire.api.testset.TestSetFailedException;
 import org.junit.runner.notification.RunListener.ThreadSafe;
 
@@ -37,11 +38,13 @@ public class MethodsParallelRunListener
 
     private final Object lock = new Object();
 
-    public MethodsParallelRunListener( Map<String, TestSet> classMethodCounts, ReporterFactory reporterFactory,
+    public MethodsParallelRunListener( RunListenerContext ctx,
+                                       Map<String, TestSet> classMethodCounts,
+                                       ReporterFactory reporterFactory,
                                        boolean reportImmediately, ConsoleStream consoleStream )
         throws TestSetFailedException
     {
-        super( reporterFactory, consoleStream, reportImmediately, classMethodCounts );
+        super( ctx, reporterFactory, consoleStream, reportImmediately, classMethodCounts );
     }
 
     @Override

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/NonConcurrentRunListener.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/NonConcurrentRunListener.java
@@ -19,13 +19,13 @@ package org.apache.maven.surefire.junitcore;
  * under the License.
  */
 
+import org.apache.maven.surefire.api.report.AbstractRunListener;
+import org.apache.maven.surefire.api.report.RunMode;
 import org.apache.maven.surefire.api.util.internal.ClassMethod;
 import org.apache.maven.surefire.common.junit4.JUnit4RunListener;
 import org.apache.maven.surefire.api.report.ConsoleOutputReceiver;
-import org.apache.maven.surefire.api.report.RunListener;
 import org.apache.maven.surefire.api.report.SimpleReportEntry;
 import org.apache.maven.surefire.api.report.TestSetReportEntry;
-import org.apache.maven.surefire.api.testset.TestSetFailedException;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
@@ -49,8 +49,7 @@ public class NonConcurrentRunListener
 
     private Description lastFinishedDescription;
 
-    public NonConcurrentRunListener( RunListener reporter )
-        throws TestSetFailedException
+    public NonConcurrentRunListener( AbstractRunListener reporter )
     {
         super( reporter );
     }
@@ -65,13 +64,17 @@ public class NonConcurrentRunListener
     protected SimpleReportEntry createReportEntry( Description description )
     {
         ClassMethod classMethod = toClassMethod( description );
-        return new SimpleReportEntry( classMethod.getClazz(), null, classMethod.getMethod(), null );
+        RunMode runMode = reporter.getContext().getRunMode();
+        long testId = currentTestId();
+        return new SimpleReportEntry( runMode, testId, classMethod.getClazz(), null, classMethod.getMethod(), null );
     }
 
     private TestSetReportEntry createReportEntryForTestSet( Description description, Map<String, String> systemProps )
     {
         ClassMethod classMethod = toClassMethod( description );
-        return new SimpleReportEntry( classMethod.getClazz(), null, null, null, systemProps );
+        RunMode runMode = reporter.getContext().getRunMode();
+        long testId = currentTestId();
+        return new SimpleReportEntry( runMode, testId, classMethod.getClazz(), null, null, null, systemProps );
     }
 
     private TestSetReportEntry createTestSetReportEntryStarted( Description description )

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/ConcurrentRunListenerTest.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/ConcurrentRunListenerTest.java
@@ -24,10 +24,11 @@ import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
+import org.apache.maven.surefire.api.report.AbstractRunListener;
 import org.apache.maven.surefire.api.report.ConsoleStream;
-import org.apache.maven.surefire.api.report.DefaultDirectConsoleReporter;
 import org.apache.maven.surefire.api.report.ReporterFactory;
-import org.apache.maven.surefire.api.report.RunListener;
+import org.apache.maven.surefire.api.report.RunListenerContext;
+import org.apache.maven.surefire.api.report.RunMode;
 import org.apache.maven.surefire.report.RunStatistics;
 import org.apache.maven.surefire.api.testset.TestSetFailedException;
 
@@ -149,15 +150,17 @@ public class ConcurrentRunListenerTest
         DefaultReporterFactory reporterFactory = createReporterFactory();
         HashMap<String, TestSet> classMethodCounts = new HashMap<>();
         final ConsoleStream defaultConsoleReporter = new DefaultDirectConsoleReporter( System.out );
-        RunListener reporter =
-            new ClassesParallelRunListener( classMethodCounts, reporterFactory, defaultConsoleReporter );
+        RunListenerContext ctx = new RunListenerContext( RunMode.NORMAL_RUN );
+        AbstractRunListener reporter =
+            new ClassesParallelRunListener( ctx, classMethodCounts, reporterFactory, defaultConsoleReporter );
         JUnitCoreRunListener runListener = new JUnitCoreRunListener( reporter, classMethodCounts );
         RunStatistics result = runClasses( reporterFactory, runListener, classes );
         assertReporter( result, success, ignored, failure, "classes" );
         classMethodCounts.clear();
 
         reporterFactory = createReporterFactory();
-        reporter = new MethodsParallelRunListener( classMethodCounts, reporterFactory, true, defaultConsoleReporter );
+        reporter =
+            new MethodsParallelRunListener( ctx, classMethodCounts, reporterFactory, true, defaultConsoleReporter );
         runListener = new JUnitCoreRunListener( reporter, classMethodCounts );
         result = runClasses( reporterFactory, runListener, classes );
         assertReporter( result, success, ignored, failure, "methods" );
@@ -200,8 +203,9 @@ public class ConcurrentRunListenerTest
                                                                          Map<String, TestSet> testSetMap )
         throws TestSetFailedException
     {
+        RunListenerContext ctx = new RunListenerContext( RunMode.NORMAL_RUN );
         return new JUnitCoreRunListener(
-            new ClassesParallelRunListener( testSetMap, reporterFactory,
+            new ClassesParallelRunListener( ctx, testSetMap, reporterFactory,
                                                   new DefaultDirectConsoleReporter( System.out ) ), testSetMap );
     }
 

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/DefaultDirectConsoleReporter.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/DefaultDirectConsoleReporter.java
@@ -1,4 +1,4 @@
-package org.apache.maven.surefire.api.report;
+package org.apache.maven.surefire.junitcore;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -18,6 +18,8 @@ package org.apache.maven.surefire.api.report;
  * specific language governing permissions and limitations
  * under the License.
  */
+
+import org.apache.maven.surefire.api.report.ConsoleStream;
 
 import java.io.PrintStream;
 

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
@@ -26,9 +26,9 @@ import org.apache.maven.plugin.surefire.extensions.SurefireStatelessTestsetInfoR
 import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
 import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
 import org.apache.maven.surefire.api.report.ConsoleOutputReceiver;
-import org.apache.maven.surefire.api.report.DefaultDirectConsoleReporter;
 import org.apache.maven.surefire.api.report.ReporterFactory;
 import org.apache.maven.surefire.api.report.RunListener;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.apache.maven.surefire.api.testset.TestSetFailedException;
 import org.junit.runner.Computer;
 import org.junit.runner.JUnitCore;
@@ -38,8 +38,9 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
 
-import static org.apache.maven.surefire.junitcore.ConcurrentRunListener.createInstance;
 import static org.apache.maven.surefire.api.report.ConsoleOutputCapture.startCapture;
+import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
+import static org.apache.maven.surefire.junitcore.ConcurrentRunListener.createInstance;
 
 /**
  * @author Kristian Rosenvold
@@ -66,8 +67,8 @@ public class JUnitCoreTester
         try
         {
             final HashMap<String, TestSet> classMethodCounts = new HashMap<>();
-            RunListener reporter = createInstance( classMethodCounts, reporterManagerFactory, parallelClasses, false,
-                                                         new DefaultDirectConsoleReporter( System.out ) );
+            RunListener reporter = createInstance( new RunListenerContext( NORMAL_RUN ), classMethodCounts,
+                reporterManagerFactory, parallelClasses, false, new DefaultDirectConsoleReporter( System.out ) );
             startCapture( (ConsoleOutputReceiver) reporter );
 
             JUnitCoreRunListener runListener = new JUnitCoreRunListener( reporter, classMethodCounts );

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/MockReporter.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/MockReporter.java
@@ -22,8 +22,10 @@ package org.apache.maven.surefire.junitcore;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.maven.surefire.api.report.AbstractRunListener;
 import org.apache.maven.surefire.api.report.ReportEntry;
-import org.apache.maven.surefire.api.report.RunListener;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.apache.maven.surefire.api.report.TestSetReportEntry;
 import org.apache.maven.surefire.api.report.RunMode;
 
@@ -31,7 +33,7 @@ import org.apache.maven.surefire.api.report.RunMode;
  * Internal tests use only.
  */
 final class MockReporter
-    implements RunListener
+    extends AbstractRunListener
 {
     private final List<String> events = new ArrayList<>();
 
@@ -55,6 +57,7 @@ final class MockReporter
 
     MockReporter()
     {
+        super( new RunListenerContext( RunMode.NORMAL_RUN ) );
     }
 
     @Override

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/Surefire746Test.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/Surefire746Test.java
@@ -46,9 +46,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.maven.surefire.api.booter.BaseProviderFactory;
 import org.apache.maven.surefire.api.booter.ProviderParameterNames;
+import org.apache.maven.surefire.api.report.RunListenerContext;
 import org.apache.maven.surefire.common.junit4.JUnit4RunListener;
 import org.apache.maven.surefire.common.junit4.Notifier;
-import org.apache.maven.surefire.api.report.DefaultDirectConsoleReporter;
 import org.apache.maven.surefire.api.report.ReporterConfiguration;
 import org.apache.maven.surefire.api.report.ReporterFactory;
 import org.apache.maven.surefire.api.report.RunListener;
@@ -66,6 +66,7 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.InitializationError;
 
 import static junit.framework.Assert.assertEquals;
+import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 
 /**
  * {@code
@@ -120,8 +121,8 @@ public class Surefire746Test
 
         final Map<String, TestSet> testSetMap = new ConcurrentHashMap<>();
 
-        RunListener listener = ConcurrentRunListener.createInstance( testSetMap, reporterFactory, false, false,
-                new DefaultDirectConsoleReporter( System.out ) );
+        RunListener listener = ConcurrentRunListener.createInstance( new RunListenerContext( NORMAL_RUN ),
+            testSetMap, reporterFactory, false, false, new DefaultDirectConsoleReporter( System.out ) );
 
         TestsToRun testsToRun = new TestsToRun( Collections.<Class<?>>singleton( TestClassTest.class ) );
 
@@ -137,7 +138,8 @@ public class Surefire746Test
             exception.expect( TestSetFailedException.class );
             JUnit4RunListener dummy = new JUnit4RunListener( new MockReporter() );
             new JUnitCoreWrapper( new Notifier( dummy, 0 ), jUnitCoreParameters,
-                    new DefaultDirectConsoleReporter( System.out ) ).execute( testsToRun, customRunListeners, null );
+                    new DefaultDirectConsoleReporter( System.out ) )
+                .execute( testsToRun, customRunListeners, null );
         }
         finally
         {

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilderTest.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilderTest.java
@@ -21,7 +21,7 @@ package org.apache.maven.surefire.junitcore.pc;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.maven.surefire.api.report.ConsoleStream;
-import org.apache.maven.surefire.api.report.DefaultDirectConsoleReporter;
+import org.apache.maven.surefire.junitcore.DefaultDirectConsoleReporter;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerUtilTest.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerUtilTest.java
@@ -21,7 +21,7 @@ package org.apache.maven.surefire.junitcore.pc;
 
 import org.apache.maven.surefire.junitcore.JUnitCoreParameters;
 import org.apache.maven.surefire.api.report.ConsoleStream;
-import org.apache.maven.surefire.api.report.DefaultDirectConsoleReporter;
+import org.apache.maven.surefire.junitcore.DefaultDirectConsoleReporter;
 import org.apache.maven.surefire.api.testset.TestSetFailedException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/pc/SchedulingStrategiesTest.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/pc/SchedulingStrategiesTest.java
@@ -20,7 +20,7 @@ package org.apache.maven.surefire.junitcore.pc;
  */
 
 import org.apache.maven.surefire.api.report.ConsoleStream;
-import org.apache.maven.surefire.api.report.DefaultDirectConsoleReporter;
+import org.apache.maven.surefire.junitcore.DefaultDirectConsoleReporter;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;

--- a/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/TestNGProvider.java
+++ b/surefire-providers/surefire-testng/src/main/java/org/apache/maven/surefire/testng/TestNGProvider.java
@@ -98,7 +98,7 @@ public class TestNGProvider
         }
 
         final ReporterFactory reporterFactory = providerParameters.getReporterFactory();
-        final RunListener reporter = reporterFactory.createReporter();
+        final RunListener reporter = reporterFactory.getRunListener();
         /*
          * {@link org.apache.maven.surefire.api.report.ConsoleOutputCapture#startCapture(ConsoleOutputReceiver)}
          * called in prior to initializing variable {@link #testsToRun}


### PR DESCRIPTION
See the Jira issue https://issues.apache.org/jira/browse/SUREFIRE-1860