### PR TITLE
Enabling Surefire to run test classes and test methods in any order specified by a runOrder

### DIFF
--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/RunOrder.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/RunOrder.java
@@ -44,6 +44,8 @@ public class RunOrder
 
     public static final RunOrder FAILEDFIRST = new RunOrder( "failedfirst" );
 
+    public static final RunOrder TESTORDER = new RunOrder( "testorder" );
+
     public static final RunOrder[] DEFAULT = new RunOrder[]{ FILESYSTEM };
 
     /**
@@ -108,7 +110,8 @@ public class RunOrder
 
     private static RunOrder[] values()
     {
-        return new RunOrder[]{ ALPHABETICAL, FILESYSTEM, HOURLY, RANDOM, REVERSE_ALPHABETICAL, BALANCED, FAILEDFIRST };
+        return new RunOrder[]{ ALPHABETICAL, FILESYSTEM, HOURLY, RANDOM, REVERSE_ALPHABETICAL, BALANCED, FAILEDFIRST,
+                               TESTORDER };
     }
 
     public static String asString( RunOrder[] runOrder )

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/RunOrderCalculator.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/RunOrderCalculator.java
@@ -19,10 +19,14 @@ package org.apache.maven.surefire.api.util;
  * under the License.
  */
 
+import java.util.Comparator;
+
 /**
  * @author Kristian Rosenvold
  */
 public interface RunOrderCalculator
 {
     TestsToRun orderTestClasses( TestsToRun scannedClasses );
+
+    Comparator<String> comparatorForTestMethods();
 }

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/testset/TestListResolverTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/testset/TestListResolverTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.addAll;
@@ -501,5 +502,69 @@ public class TestListResolverTest
             resolved.add( new ResolvedTest( CLASS, pattern, false ) );
         }
         return resolved;
+    }
+
+    public void testOrderComparatorTest()
+    {
+        List<String> orderParamList = new ArrayList<String>();
+        orderParamList.add( "TestClass1#testa2d" );
+        orderParamList.add( "TestClass1#testabc" );
+        orderParamList.add( "TestClass1#testa1b" );
+        orderParamList.add( "TestClass2#testa1b" );
+        orderParamList.add( "TestClass2#testaBc" );
+        TestListResolver tlr = new TestListResolver( orderParamList );
+        String className = "TestClass1";
+        String className2 = "TestClass2";
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa2d", "testa1b" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa2d", "testabc" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa1b", "testabc" ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa2d", "testaBc" ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa3d", "testa1b" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className2, "testa2d", "testa1b" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className2, className, "testaBc", "testa1b" ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className2, "testa3d", "testa1b" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className2, "testa2d", "testabc" ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa2d", "testa2d" ) == 0 );
+    }
+
+    public void testRegexMethodOrderComparator()
+    {
+        List<String> orderParamList = new ArrayList<String>();
+        orderParamList.add( "TestClass1#testa?c" );
+        orderParamList.add( "TestClass1#testa?b" );
+        orderParamList.add( "TestClass2#test?1*" );
+        orderParamList.add( "!TestClass1#testa4b" );
+        orderParamList.add( "!TestClass2#test11MyTest" );
+        TestListResolver tlr = new TestListResolver( orderParamList );
+        String className = "TestClass1";
+        String className2 = "TestClass2";
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testabc", "testa1b" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testaBc", "testa2b" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa1b", "testa3c" ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa1b", "testa4b" ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa4b", "testabc" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className2, "testa1b", "test1123" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className2, className, "testa1b", "testa1b" ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className2, className2, "testa1b", "test1123" ) == 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className2, className2, "test1123", "test11MyTest" ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className2, className2, "test11MyTest", "test456" ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, "testa1c", "testa1c" ) == 0 );
+    }
+
+    public void testRegexClassOrderComparator()
+    {
+        List<String> orderParamList = new ArrayList<String>();
+        orderParamList.add( "My2*Test.java" );
+        orderParamList.add( "???My1*Test" );
+        orderParamList.add( "!abcMy1PeaceTest" );
+        TestListResolver tlr = new TestListResolver( orderParamList );
+        String className = "My2ConnectTest";
+        String className2 = "456My1ConnectTest";
+        String className3 = "abcMy1PeaceTest";
+        assertTrue( ( int ) tlr.testOrderComparator( className, className2, null, null ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className2, className, null, null ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className3, className2, null, null ) < 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className3, null, null ) > 0 );
+        assertTrue( ( int ) tlr.testOrderComparator( className, className, null, null ) == 0 );
     }
 }

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/util/RunOrderCalculatorTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/util/RunOrderCalculatorTest.java
@@ -19,7 +19,10 @@ package org.apache.maven.surefire.api.util;
  * under the License.
  */
 
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.surefire.api.testset.RunOrderParameters;
@@ -58,5 +61,53 @@ public class RunOrderCalculatorTest
     static class B
     {
 
+    }
+
+    public void testOrderTestMethods()
+    {
+        RunOrderParameters runOrderParameters = new RunOrderParameters( "testorder" , null );
+        System.setProperty( "test", "TestClass#a2d,TestClass#aBc,TestClass#abc,TestClass#a1b" );
+        DefaultRunOrderCalculator runOrderCalculator = new DefaultRunOrderCalculator( runOrderParameters, 1 );
+        Comparator<String> testOrderRunOrderComparator = runOrderCalculator.comparatorForTestMethods();
+        String[] strArray = { "abc(TestClass)", "a1b(TestClass)", "a2d(TestClass)", "aBc(TestClass)" };
+        List<String> actual = Arrays.asList( strArray );
+        actual.sort( testOrderRunOrderComparator );
+        String[] strArray2 = { "a2d(TestClass)", "aBc(TestClass)", "abc(TestClass)", "a1b(TestClass)" };
+        List<String> expected = Arrays.asList( strArray2 );
+        assertEquals( actual, expected );
+    }
+
+    public void testOrderTestClassesAndMethods()
+    {
+        RunOrderParameters runOrderParameters = new RunOrderParameters( "testorder" , null );
+        System.setProperty( "test", "TestClass1#a2d,TestClass2#aBc,TestClass2#abc,TestClass2#a1b" );
+        DefaultRunOrderCalculator runOrderCalculator = new DefaultRunOrderCalculator( runOrderParameters, 1 );
+        Comparator<String> testOrderRunOrderComparator = runOrderCalculator.comparatorForTestMethods();
+        String[] strArray = { "abc(TestClass2)", "a1b(TestClass2)", "a2d(TestClass1)", "aBc(TestClass2)" };
+        List<String> actual = Arrays.asList( strArray );
+        actual.sort( testOrderRunOrderComparator );
+        String[] strArray2 = { "a2d(TestClass1)", "aBc(TestClass2)", "abc(TestClass2)", "a1b(TestClass2)" };
+        List<String> expected = Arrays.asList( strArray2 );
+        assertEquals( actual, expected );
+    }
+
+    public void testOrderTestRegexClassesAndMethods()
+    {
+        RunOrderParameters runOrderParameters = new RunOrderParameters( "testorder" , null );
+        System.setProperty( "test", "Amber*Test#a?c,My???Test#test*" );
+        DefaultRunOrderCalculator runOrderCalculator = new DefaultRunOrderCalculator( runOrderParameters, 1 );
+        Comparator<String> testOrderRunOrderComparator = runOrderCalculator.comparatorForTestMethods();
+        String[] strArray = { "abc(AmberGoodTest)", 
+                              "testabc(MyabcTest)", 
+                              "a2c(AmberBadTest)", 
+                              "testefg(MyefgTest)", 
+                              "aBc(AmberGoodTest)" };
+        List<String> actual = Arrays.asList( strArray );
+        actual.sort( testOrderRunOrderComparator );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 0 ) )[0].substring( 0, 5 ), "Amber" );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 1 ) )[0].substring( 0, 5 ), "Amber" );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 2 ) )[0].substring( 0, 5 ), "Amber" );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 3 ) )[0].substring( 0, 2 ), "My" );
+        assertEquals( runOrderCalculator.getClassAndMethod( actual.get( 4 ) )[0].substring( 0, 2 ), "My" );
     }
 }

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreProvider.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreProvider.java
@@ -145,7 +145,8 @@ public class JUnitCoreProvider
 
         try
         {
-            JUnitCoreWrapper core = new JUnitCoreWrapper( notifier, jUnitCoreParameters, consoleStream );
+            JUnitCoreWrapper core = new JUnitCoreWrapper( notifier, jUnitCoreParameters, consoleStream,
+                runOrderCalculator );
 
             if ( commandsReader != null )
             {
@@ -162,7 +163,8 @@ public class JUnitCoreProvider
             {
                 Notifier rerunNotifier = pureNotifier();
                 notifier.copyListenersTo( rerunNotifier );
-                JUnitCoreWrapper rerunCore = new JUnitCoreWrapper( rerunNotifier, jUnitCoreParameters, consoleStream );
+                JUnitCoreWrapper rerunCore = new JUnitCoreWrapper( rerunNotifier, jUnitCoreParameters, consoleStream,
+                    runOrderCalculator );
                 for ( int i = 0; i < rerunFailingTestsCount && !testFailureListener.getAllFailures().isEmpty(); i++ )
                 {
                     Set<Description> failures = generateFailingTestDescriptions( testFailureListener.getAllFailures() );

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/Surefire746Test.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/Surefire746Test.java
@@ -53,7 +53,9 @@ import org.apache.maven.surefire.api.report.ReporterConfiguration;
 import org.apache.maven.surefire.api.report.ReporterFactory;
 import org.apache.maven.surefire.api.report.RunListener;
 import org.apache.maven.surefire.api.suite.RunResult;
+import org.apache.maven.surefire.api.testset.RunOrderParameters;
 import org.apache.maven.surefire.api.testset.TestSetFailedException;
+import org.apache.maven.surefire.api.util.DefaultRunOrderCalculator;
 import org.apache.maven.surefire.api.util.TestsToRun;
 
 import org.junit.Rule;
@@ -137,7 +139,9 @@ public class Surefire746Test
             exception.expect( TestSetFailedException.class );
             JUnit4RunListener dummy = new JUnit4RunListener( new MockReporter() );
             new JUnitCoreWrapper( new Notifier( dummy, 0 ), jUnitCoreParameters,
-                    new DefaultDirectConsoleReporter( System.out ) ).execute( testsToRun, customRunListeners, null );
+                    new DefaultDirectConsoleReporter( System.out ),
+                    new DefaultRunOrderCalculator( RunOrderParameters.alphabetical(), 1 ) ).
+                        execute( testsToRun, customRunListeners, null );
         }
         finally
         {


### PR DESCRIPTION
The changes in this pull request enable Surefire to run test classes and test methods in any order specified by a newly added [\<runOrder\>](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder) (testorder). Namely, the changes include
- A new [\<runOrder\>](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder) called testorder that would make Surefire run test classes and test methods in the order specified by [\<test\>](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#test). Regex and include/exclude are supported as is the case for other runOrders
- Tests to TestListResolverTest and RunOrderCalculatorTest for the newly added features
 
The newly added testorder [\<runOrder\>](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder) is supported for all JUnit 3 and JUnit 4 tests. I will plan on supporting JUnit 5 tests after these changes are accepted.

**Simple (no regex) example using [Dubbo](https://github.com/apache/dubbo.git):**
```
mvn test -Dsurefire.runOrder=testorder \
-Dtest=org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest#testSticky2,\
org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest#testSticky1,\
org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest#testSticky3,\
org.apache.dubbo.rpc.protocol.dubbo.DubboProtocolTest#testNonSerializedParameter\
 -pl dubbo-rpc/dubbo-rpc-dubbo
```
 
Output from Maven should say that the test class `DubboLazyConnectTest` ran before `DubboProtocolTest`
 
The file `DubboLazyConnectTest.xml` (`dubbo-rpc/dubbo-rpc-dubbo/target/surefire-reports/TEST-org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest.xml`) should say 
```
<testcase name="testSticky2"...>
<testcase name="testSticky1"...>
<testcase name="testSticky3...>
```
 
**Regex example using [Dubbo](https://github.com/apache/dubbo.git):**
```
mvn test -Dsurefire.runOrder=testorder \
-Dtest=org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest*,\
org.apache.dubbo.rpc.protocol.dubbo.DubboProtocolTest#testDubboProtocol*\
 -pl dubbo-rpc/dubbo-rpc-dubbo
```
 
Output from Maven should say 
```
Tests run: 4 … in org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest
Tests run: 3 … in org.apache.dubbo.rpc.protocol.dubbo.DubboProtocolTest
```

The file `DubboProtocolTest.xml` (`dubbo-rpc/dubbo-rpc-dubbo/target/surefire-reports/TEST-org.apache.dubbo.rpc.protocol.dubbo.DubboProtocolTest.xml`) should say 
```
<testcase name=”testDubboProtocol”...>
<testcase name="testDubboProtocolWithMina"...>
<testcase name="testDubboProtocolMultiService”...>
```
 
**Include/Exclude example using [Dubbo](https://github.com/apache/dubbo.git):**
```
mvn test -Dsurefire.runOrder=testorder \
-Dtest=org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest#test*,\
!org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest#testSticky2\
 -pl dubbo-rpc/dubbo-rpc-dubbo
```

Output from Maven should say 
`Tests run: 3 … in org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest`

The file `DubboLazyConnectTest.xml` (`dubbo-rpc/dubbo-rpc-dubbo/target/surefire-reports/TEST-org.apache.dubbo.rpc.protocol.dubbo.DubboLazyConnectTest.xml`) should say 
```
<testcase name="testSticky1"...>
<testcase name="testSticky3"...>
<testcase name="testSticky4...>
```