### PR TITLE
[SUREFIRE-1914] Take displayName of container into account for XML reporting of @ParameterizedTest

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
@@ -410,13 +410,13 @@ public class JUnitPlatformEnginesIT extends SurefireJUnit4IntegrationTestCase
         validator.getSurefireReportsFile( "TEST-junitplatformenginejupiter.BasicJupiterTest.xml", UTF_8 )
                 .assertContainsText( "<testcase name=\"test(TestInfo)\" "
                         + "classname=\"junitplatformenginejupiter.BasicJupiterTest\"" )
-                .assertContainsText( "<testcase name=\"0 + 1 = 1\" "
+                .assertContainsText( "<testcase name=\"add(int, int, int) 0 + 1 = 1\" "
                         + "classname=\"junitplatformenginejupiter.BasicJupiterTest\"" )
-                .assertContainsText( "<testcase name=\"1 + 2 = 3\" "
+                .assertContainsText( "<testcase name=\"add(int, int, int) 1 + 2 = 3\" "
                         + "classname=\"junitplatformenginejupiter.BasicJupiterTest\"" )
-                .assertContainsText( "<testcase name=\"49 + 51 = 100\" "
+                .assertContainsText( "<testcase name=\"add(int, int, int) 49 + 51 = 100\" "
                         + "classname=\"junitplatformenginejupiter.BasicJupiterTest\"" )
-                .assertContainsText( "<testcase name=\"1 + 100 = 101\" "
+                .assertContainsText( "<testcase name=\"add(int, int, int) 1 + 100 = 101\" "
                         + "classname=\"junitplatformenginejupiter.BasicJupiterTest\"" );
     }
 

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1914XmlReportingParameterizedTestIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1914XmlReportingParameterizedTestIT.java
@@ -1,0 +1,126 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.googlecode.junittoolbox.ParallelParameterized;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaVersion;
+
+/**
+ *
+ */
+@RunWith( ParallelParameterized.class )
+@SuppressWarnings( "checkstyle:magicnumber" )
+public class Surefire1914XmlReportingParameterizedTestIT extends SurefireJUnit4IntegrationTestCase
+{
+    @Parameter
+    @SuppressWarnings( "checkstyle:visibilitymodifier" )
+    public String platform;
+
+    @Parameter( 1 )
+    @SuppressWarnings( "checkstyle:visibilitymodifier" )
+    public String jupiter;
+
+    @Parameter( 2 )
+    @SuppressWarnings( "checkstyle:visibilitymodifier" )
+    public String opentest;
+
+    @Parameter( 3 )
+    @SuppressWarnings( "checkstyle:visibilitymodifier" )
+    public String apiguardian;
+
+    @Parameters( name = "{0}" )
+    public static Iterable<Object[]> artifactVersions()
+    {
+        List<Object[]> args = new ArrayList<>();
+        args.add( new Object[] {"1.0.3", "5.0.3", "1.0.0", "1.0.0"} );
+        args.add( new Object[] {"1.1.1", "5.1.1", "1.0.0", "1.0.0"} );
+        args.add( new Object[] {"1.2.0", "5.2.0", "1.1.0", "1.0.0"} );
+        args.add( new Object[] {"1.3.2", "5.3.2", "1.1.1", "1.0.0"} );
+        args.add( new Object[] {"1.4.2", "5.4.2", "1.1.1", "1.0.0"} );
+        args.add( new Object[] {"1.5.2", "5.5.2", "1.2.0", "1.1.0"} );
+        args.add( new Object[] {"1.6.2", "5.6.2", "1.2.0", "1.1.0"} );
+        args.add( new Object[] {"1.7.1", "5.7.1", "1.2.0", "1.1.0" } );
+        return args;
+    }
+
+    @Before
+    public void setUp()
+    {
+        assumeJavaVersion( 1.8d );
+    }
+
+    @Test
+    public void testXmlReportWithParameterizedTestMethodsAndPhrasedNamingActive()
+    {
+        OutputValidator validator = unpack( "surefire-1914-xml-reporting-parameterizedtest", "-" + jupiter )
+                .sysProp( "junit5.version", jupiter )
+                .executeTest()
+                .verifyErrorFree( 16 );
+
+        validator.getSurefireReportsFile( "TEST-jira1914.ParameterizedDisplayNameTest.xml", UTF_8 )
+                .assertContainsText( "testcase name=\"theDisplayNameOfTestMethod1[1] a\" "
+                        + "classname=\"theDisplayNameOfTheClass\"" )
+                .assertContainsText( "testcase name=\"theDisplayNameOfTestMethod1[2] b\" "
+                        + "classname=\"theDisplayNameOfTheClass\"" )
+                .assertContainsText( "testcase name=\"theDisplayNameOfTestMethod1[3] c\" "
+                        + "classname=\"theDisplayNameOfTheClass\"" )
+                .assertContainsText( "testcase name=\"theDisplayNameOfTestMethod2 with param a\" "
+                        + "classname=\"theDisplayNameOfTheClass\"" )
+                .assertContainsText( "testcase name=\"theDisplayNameOfTestMethod2 with param b\" "
+                        + "classname=\"theDisplayNameOfTheClass\"" )
+                .assertContainsText( "testcase name=\"theDisplayNameOfTestMethod2 with param c\" "
+                        + "classname=\"theDisplayNameOfTheClass\"" );
+
+        validator.getSurefireReportsFile( "TEST-jira1914.ParameterizedJupiterTest.xml", UTF_8 )
+                .assertContainsText( "<testcase name=\"add(int, int, int) 0 + 1 = 1\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" )
+                .assertContainsText( "<testcase name=\"add(int, int, int) 1 + 2 = 3\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" )
+                .assertContainsText( "<testcase name=\"add(int, int, int) 49 + 51 = 100\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" )
+                .assertContainsText( "<testcase name=\"add(int, int, int) 1 + 100 = 101\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" )
+                .assertContainsText( "<testcase name=\"square(int, int)[1] 1, 1\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" )
+                .assertContainsText( "<testcase name=\"square(int, int)[2] 2, 4\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" )
+                .assertContainsText( "<testcase name=\"square(int, int)[3] 3, 9\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" )
+                .assertContainsText( "<testcase name=\"cube(int, int)[1] 1, 1\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" )
+                .assertContainsText( "<testcase name=\"cube(int, int)[2] 2, 8\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" )
+                .assertContainsText( "<testcase name=\"cube(int, int)[3] 3, 27\" "
+                        + "classname=\"jira1914.ParameterizedJupiterTest\"" );
+    }
+
+}

--- a/surefire-its/src/test/resources/surefire-1914-xml-reporting-parameterizedtest/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1914-xml-reporting-parameterizedtest/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-1914-xml-reporting-parameterizedtest</artifactId>
+    <version>1.0</version>
+    <name>Test for: JUnit5Xml30StatelessReporter and Parameterized (SUREFIRE-1914)</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <!--
+        Declare "junit-jupiter-engine" dependency because the
+        Jupiter Engine is needed at test runtime. Artifacts
+        needed for test compilation, like "junit-jupiter-api",
+        are pulled-in via transitive dependency resolution.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <forkCount>1.0C</forkCount>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                        <disable>false</disable>
+                        <version>3.0</version>
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                        <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                        <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                        <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                    </statelessTestsetReporter>
+                    <consoleOutputReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+                        <disable>false</disable>
+                        <encoding>UTF-8</encoding>
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+                        <disable>false</disable>
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                        <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
+                        <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+                    </statelessTestsetInfoReporter>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-1914-xml-reporting-parameterizedtest/src/test/java/jira1914/ParameterizedDisplayNameTest.java
+++ b/surefire-its/src/test/resources/surefire-1914-xml-reporting-parameterizedtest/src/test/java/jira1914/ParameterizedDisplayNameTest.java
@@ -1,0 +1,45 @@
+package jira1914;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName( "theDisplayNameOfTheClass" )
+class ParameterizedDisplayNameTest
+{
+    @ParameterizedTest
+    @DisplayName( "theDisplayNameOfTestMethod1" )
+    @ValueSource(strings = {"a", "b", "c"})
+    void test1(String parameter)
+    {
+        // not relevant
+    }
+
+    @ParameterizedTest(name = "with param {0}")
+    @DisplayName( "theDisplayNameOfTestMethod2" )
+    @ValueSource(strings = {"a", "b", "c"})
+    void test2(String parameter)
+    {
+        // not relevant
+    }
+
+}

--- a/surefire-its/src/test/resources/surefire-1914-xml-reporting-parameterizedtest/src/test/java/jira1914/ParameterizedJupiterTest.java
+++ b/surefire-its/src/test/resources/surefire-1914-xml-reporting-parameterizedtest/src/test/java/jira1914/ParameterizedJupiterTest.java
@@ -1,0 +1,64 @@
+package jira1914;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ParameterizedJupiterTest
+{
+
+    @ParameterizedTest(name = "{0} + {1} = {2}")
+    @CsvSource({
+                    "0,    1,   1",
+                    "1,    2,   3",
+                    "49,  51, 100",
+                    "1,  100, 101"
+    })
+    void add(int first, int second, int expectedResult)
+    {
+        assertEquals(expectedResult, first + second, () -> first + " + " + second + " should equal " + expectedResult);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        " 1, 1",
+        " 2, 4",
+        " 3, 9"
+    })
+    void square(int number, int expectedResult)
+    {
+        assertEquals(expectedResult, number * number, () -> number + " * " + number + " should equal " + expectedResult);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1, 1",
+        "2, 8",
+        "3, 27"
+    })
+    void cube(int number, int expectedResult)
+    {
+        assertEquals(expectedResult, number * number * number, () -> number + " * " + number + " * " + number + " should equal " + expectedResult);
+    }
+
+}

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -554,22 +554,26 @@ public class JUnitPlatformProviderTest
         assertEquals( TestClass7.class.getName(), reportEntries.get( 0 ).getSourceName() );
         assertNull( reportEntries.get( 0 ).getSourceText() );
         assertEquals( "testParameterizedTestCases(String, boolean)[1]", reportEntries.get( 0 ).getName() );
-        assertEquals( "[1] Always pass, true", reportEntries.get( 0 ).getNameText() );
+        assertEquals( "testParameterizedTestCases(String, boolean)[1] Always pass, true",
+                       reportEntries.get( 0 ).getNameText() );
 
         assertEquals( TestClass7.class.getName(), reportEntries.get( 1 ).getSourceName() );
         assertNull( reportEntries.get( 1 ).getSourceText() );
         assertEquals( "testParameterizedTestCases(String, boolean)[2]", reportEntries.get( 1 ).getName() );
-        assertEquals( "[2] Always fail, false", reportEntries.get( 1 ).getNameText() );
+        assertEquals( "testParameterizedTestCases(String, boolean)[2] Always fail, false",
+                      reportEntries.get( 1 ).getNameText() );
 
         assertEquals( TestClass7.class.getName(), reportEntries.get( 2 ).getSourceName() );
         assertNull( reportEntries.get( 2 ).getSourceText() );
         assertEquals( "testParameterizedTestCases(String, boolean)[2]", reportEntries.get( 2 ).getName() );
-        assertEquals( "[2] Always fail, false", reportEntries.get( 2 ).getNameText() );
+        assertEquals( "testParameterizedTestCases(String, boolean)[2] Always fail, false",
+                      reportEntries.get( 2 ).getNameText() );
 
         assertEquals( TestClass7.class.getName(), reportEntries.get( 3 ).getSourceName() );
         assertNull( reportEntries.get( 3 ).getSourceText() );
         assertEquals( "testParameterizedTestCases(String, boolean)[2]", reportEntries.get( 3 ).getName() );
-        assertEquals( "[2] Always fail, false", reportEntries.get( 3 ).getNameText() );
+        assertEquals( "testParameterizedTestCases(String, boolean)[2] Always fail, false",
+                      reportEntries.get( 3 ).getNameText() );
 
         TestExecutionSummary summary = executionListener.summaries.get( 0 );
         assertEquals( 2, summary.getTestsFoundCount() );


### PR DESCRIPTION
This is work in progress. It does the job, but may not be the best or most appropriate way to do it.

I'm not particularly happy with the !display.startsWith( "[" ) in the needsSpaceSeparator condition in particular.