### PR TITLE
[SUREFIRE-1939] Fix NPE in SystemUtils.toJdkHomeFromJvmExec if java home has 2 components

### DIFF
--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/SystemUtils.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/SystemUtils.java
@@ -88,7 +88,7 @@ public final class SystemUtils
     public static File toJdkHomeFromJvmExec( String jvmExecutable )
     {
         File bin = new File( jvmExecutable ).getAbsoluteFile().getParentFile();
-        if ( "bin".equals( bin.getName() ) )
+        if ( bin != null && "bin".equals( bin.getName() ) )
         {
             File parent = bin.getParentFile();
             if ( "jre".equals( parent.getName() ) )

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/SystemUtilsTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/SystemUtilsTest.java
@@ -99,6 +99,15 @@ public class SystemUtilsTest
         }
 
         @Test
+        public void incorrectJdkPathShouldNotNPE()
+        {
+            File jre = new File( "/opt/jdk" );
+            File jdk = jre.getParentFile();
+            File incorrect = jdk.getParentFile();
+            assertThat( SystemUtils.isJava9AtLeast( incorrect.getAbsolutePath() ) ).isFalse();
+        }
+
+        @Test
         public void shouldHaveJavaPath()
         {
             String javaPath = System.getProperty( "java.home" ) + separator + "bin" + separator + "java";


### PR DESCRIPTION
Trivial fix for jira issue https://issues.apache.org/jira/browse/SUREFIRE-1939