### PR TITLE
[SUREFIRE-1266] Skip junit dependency check if module has no tests to run

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -924,7 +924,7 @@ public abstract class AbstractSurefireMojo
         setupStuff();
         Platform platform = PLATFORM.withJdkExecAttributesForTests( getEffectiveJvm() );
 
-        if ( verifyParameters() && !hasExecutedBefore() )
+        if ( verifyParameters( false ) && !hasExecutedBefore() )
         {
             DefaultScanResult scan = scanForTestClasses();
             if ( !hasSuiteXmlFiles() && scan.isEmpty() )
@@ -944,6 +944,7 @@ public abstract class AbstractSurefireMojo
                         return;
                 }
             }
+            verifyParameters( true );
             logReportsDirectory();
             executeAfterPreconditionsChecked( scan, platform );
         }
@@ -1101,7 +1102,7 @@ public abstract class AbstractSurefireMojo
         }
     }
 
-    boolean verifyParameters()
+    boolean verifyParameters( boolean pluginActive )
         throws MojoFailureException, MojoExecutionException
     {
         setProperties( new SurefireProperties( getProperties() ) );
@@ -1138,7 +1139,10 @@ public abstract class AbstractSurefireMojo
             ensureParallelRunningCompatibility();
             ensureThreadCountWithPerThread();
             warnIfUselessUseSystemClassLoaderParameter();
-            warnIfDefunctGroupsCombinations();
+            if ( pluginActive )
+            {
+                warnIfDefunctGroupsCombinations();
+            }
             warnIfRerunClashes();
             warnIfWrongShutdownValue();
             warnIfNotApplicableSkipAfterFailureCount();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -2022,7 +2022,7 @@ public class AbstractSurefireMojoTest
 
         e.expect( MojoFailureException.class );
         e.expectMessage( "Unexpected value 'fake' in the configuration parameter 'enableProcessChecker'." );
-        mojo.verifyParameters();
+        mojo.verifyParameters( true );
     }
 
     private void setProjectDepedenciesToMojo( Artifact... deps )


### PR DESCRIPTION
Don't require users to add junit dependencies on all projects when using
groups in surefire/failsafe at the reactor-level

This is a proposal on how to achieve this effect, as described in the issue. Please guide me if you have expectations on how to structure this check in a better way (such as a separate method instead of a boolean?)

I have prepared a demo test-case project at https://github.com/CMoH/surefire1266-sample to illustrate the situation and the fix. I can add it to the `surefire-it` folder if you find it worthwhile - maybe in a form more suitable for that purpose. The current incarnation is intended to depict the situation I am faced with, the one that motivated this contribution.