### PR TITLE
[site] fixing typo in the junit.apt.vm file

### DIFF
--- a/maven-surefire-plugin/src/site/apt/examples/junit.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/junit.apt.vm
@@ -292,7 +292,7 @@ else
       }
 
       @Test
-      @Category(com.cmycompany.FastTests.class)
+      @Category(com.mycompany.FastTests.class)
       public void testSlow() {
         System.out.println("fast");
       }


### PR DESCRIPTION
* examples of <groups> fixed