### PR TITLE
Replace unsupported <tt> tags in Javadoc comments

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
@@ -150,7 +150,7 @@ public class VerifyMojo
 
     /**
      * The character encoding scheme to be applied.
-     * Deprecated since 2.20.1 and used encoding UTF-8 in <tt>failsafe-summary.xml</tt>.
+     * Deprecated since 2.20.1 and used encoding UTF-8 in <code>failsafe-summary.xml</code>.
      *
      * @deprecated since of 2.20.1
      */

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -848,7 +848,7 @@ public abstract class AbstractSurefireMojo
 
     /**
      * Calls {@link #getSuiteXmlFiles()} as {@link List list}.
-     * Never returns <tt>null</tt>.
+     * Never returns <code>null</code>.
      *
      * @return list of TestNG suite XML files provided by MOJO
      */

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReportEntry.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReportEntry.java
@@ -76,7 +76,8 @@ public interface ReportEntry
     Integer getElapsed();
 
     /**
-     * Returns same value as {@link #getElapsed()} and fallbacks to {@code fallback} for <tt>null</tt> elapsed timed.
+     * Returns same value as {@link #getElapsed()} and fallbacks to {@code fallback} for <code>null</code> elapsed
+     * timed.
      *
      * @param fallback usually 0
      * @return elapsed time if {@link #getElapsed()} is not null; otherwise returns {@code fallback}

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/AbstractPathConfiguration.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/AbstractPathConfiguration.java
@@ -65,14 +65,14 @@ public abstract class AbstractPathConfiguration
     /**
      * Must be exclusive with {@link #isClassPathConfig()}.
      *
-     * @return {@code true} if <tt>this</tt> is {@link ModularClasspathConfiguration}.
+     * @return {@code true} if <code>this</code> is {@link ModularClasspathConfiguration}.
      */
     public abstract boolean isModularPathConfig();
 
     /**
      * Must be exclusive with {@link #isModularPathConfig()}.
      *
-     * @return {@code true} if <tt>this</tt> is {@link ClasspathConfiguration}.
+     * @return {@code true} if <code>this</code> is {@link ClasspathConfiguration}.
      */
     public abstract boolean isClassPathConfig();
 

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/SystemUtils.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/SystemUtils.java
@@ -77,13 +77,13 @@ public final class SystemUtils
     }
 
     /**
-     * If {@code jvmExecutable} is <tt>/jdk/bin/java</tt> (since jdk9) or <tt>/jdk/jre/bin/java</tt> (prior to jdk9)
-     * then the absolute path to JDK home is returned <tt>/jdk</tt>.
+     * If {@code jvmExecutable} is <code>/jdk/bin/java</code> (since jdk9) or <code>/jdk/jre/bin/java</code>
+     * (prior to jdk9) then the absolute path to JDK home is returned <code>/jdk</code>.
      * <br>
      * Null is returned if {@code jvmExecutable} is incorrect.
      *
      * @param jvmExecutable    /jdk/bin/java* or /jdk/jre/bin/java*
-     * @return path to jdk directory; or <tt>null</tt> if wrong path or directory layout of JDK installation.
+     * @return path to jdk directory; or <code>null</code> if wrong path or directory layout of JDK installation.
      */
     public static File toJdkHomeFromJvmExec( String jvmExecutable )
     {
@@ -102,9 +102,9 @@ public final class SystemUtils
     }
 
     /**
-     * If system property <tt>java.home</tt> is <tt>/jdk</tt> (since jdk9) or <tt>/jdk/jre</tt> (prior to jdk9) then
-     * the absolute path to
-     * JDK home is returned <tt>/jdk</tt>.
+     * If system property <code>java.home</code> is <code>/jdk</code> (since jdk9) or <code>/jdk/jre</code>
+     * (prior to jdk9) then the absolute path to
+     * JDK home is returned <code>/jdk</code>.
      *
      * @return path to JDK
      */
@@ -114,10 +114,10 @@ public final class SystemUtils
     }
 
     /**
-     * If {@code jreHome} is <tt>/jdk</tt> (since jdk9) or <tt>/jdk/jre</tt> (prior to jdk9) then
-     * the absolute path to JDK home is returned <tt>/jdk</tt>.
+     * If {@code jreHome} is <code>/jdk</code> (since jdk9) or <code>/jdk/jre</code> (prior to jdk9) then
+     * the absolute path to JDK home is returned <code>/jdk</code>.
      * <br>
-     * JRE home directory {@code jreHome} must be taken from system property <tt>java.home</tt>.
+     * JRE home directory {@code jreHome} must be taken from system property <code>java.home</code>.
      *
      * @param jreHome    path to /jdk or /jdk/jre
      * @return path to JDK

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire621TestCountingJunit3InParallelIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire621TestCountingJunit3InParallelIT.java
@@ -26,7 +26,7 @@ import org.junit.Test;
  * SUREFIRE-621 Asserts proper test counts when running junit 3 tests in parallel<br>
  * SUREFIRE-1264 Some tests can be lost when running in parallel with parameterized tests<br>
  * <br>
- * Removed decision making with JUnit3 in {@code TestSet} class during Jira activity of <tt>SUREFIRE-1264</tt>
+ * Removed decision making with JUnit3 in {@code TestSet} class during Jira activity of <code>SUREFIRE-1264</code>
  * which results in one hot spot where the test class is determined (see JUnitCoreRunListener#fillTestCountMap()).
  *
  * @author Kristian Rosenvold

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilder.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ParallelComputerBuilder.java
@@ -148,9 +148,9 @@ public final class ParallelComputerBuilder
 
     /**
      * @param totalPoolSize Pool size where suites, classes and methods are executed in parallel.
-     *                      If the <tt>totalPoolSize</tt> is {@link Integer#MAX_VALUE}, the pool capacity is not
+     *                      If the <code>totalPoolSize</code> is {@link Integer#MAX_VALUE}, the pool capacity is not
      *                      limited.
-     * @throws IllegalArgumentException If <tt>totalPoolSize</tt> is &lt; 1.
+     * @throws IllegalArgumentException If <code>totalPoolSize</code> is &lt; 1.
      */
     ParallelComputerBuilder useOnePool( int totalPoolSize )
     {

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/Scheduler.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/Scheduler.java
@@ -92,7 +92,7 @@ public class Scheduler
      * @param description description of current runner
      * @param strategy    scheduling strategy with a shared thread pool
      * @param concurrency determines maximum concurrent children scheduled a time via {@link #schedule(Runnable)}
-     * @throws NullPointerException if null <tt>strategy</tt>
+     * @throws NullPointerException if null <code>strategy</code>
      */
     public Scheduler( ConsoleStream logger, Description description, SchedulingStrategy strategy, int concurrency )
     {
@@ -100,19 +100,19 @@ public class Scheduler
     }
 
     /**
-     * New instances should be used by schedulers with limited concurrency by <tt>balancer</tt>
+     * New instances should be used by schedulers with limited concurrency by <code>balancer</code>
      * against other groups of schedulers. The schedulers share one pool.
      * <br>
      * Unlike in {@link #Scheduler(ConsoleStream, org.junit.runner.Description, SchedulingStrategy, int)} which was
-     * limiting the <tt>concurrency</tt> of children of a runner where this scheduler was set, {@code this}
-     * <tt>balancer</tt> is limiting the concurrency of all children in runners having schedulers created by this
+     * limiting the <code>concurrency</code> of children of a runner where this scheduler was set, {@code this}
+     * <code>balancer</code> is limiting the concurrency of all children in runners having schedulers created by this
      * constructor.
      *
      * @param logger current logger implementation
      * @param description description of current runner
      * @param strategy    scheduling strategy which may share threads with other strategy
      * @param balancer    determines maximum concurrent children scheduled a time via {@link #schedule(Runnable)}
-     * @throws NullPointerException if null <tt>strategy</tt> or <tt>balancer</tt>
+     * @throws NullPointerException if null <code>strategy</code> or <code>balancer</code>
      */
     public Scheduler( ConsoleStream logger, Description description, SchedulingStrategy strategy, Balancer balancer )
     {
@@ -133,7 +133,7 @@ public class Scheduler
      * @param masterScheduler scheduler sharing own threads with this slave
      * @param strategy        scheduling strategy for this scheduler
      * @param balancer        determines maximum concurrent children scheduled a time via {@link #schedule(Runnable)}
-     * @throws NullPointerException if null <tt>masterScheduler</tt>, <tt>strategy</tt> or <tt>balancer</tt>
+     * @throws NullPointerException if null <code>masterScheduler</code>, <code>strategy</code> or <code>balancer</code>
      */
     public Scheduler( ConsoleStream logger, Description description, Scheduler masterScheduler,
                       SchedulingStrategy strategy, Balancer balancer )
@@ -191,7 +191,7 @@ public class Scheduler
 
     /**
      * @param slave a slave scheduler to register
-     * @return {@code true} if successfully registered the <tt>slave</tt>.
+     * @return {@code true} if successfully registered the <code>slave</code>.
      */
     private boolean register( Scheduler slave )
     {
@@ -237,7 +237,7 @@ public class Scheduler
      * of descriptions of those tasks which have started prior to this call.
      * <br>
      * This scheduler and other registered schedulers will stop, see {@link #register(Scheduler)}.
-     * If <tt>shutdownNow</tt> is set, waiting methods will be interrupted via {@link Thread#interrupt}.
+     * If <code>shutdownNow</code> is set, waiting methods will be interrupted via {@link Thread#interrupt}.
      *
      * @param stopNow if {@code true} interrupts waiting test methods
      * @return collection of descriptions started before shutting down

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/SchedulingStrategies.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/SchedulingStrategies.java
@@ -66,7 +66,7 @@ public class SchedulingStrategies
     }
 
     /**
-     * The <tt>threadPool</tt> passed to this strategy can be shared in other strategies.
+     * The <code>threadPool</code> passed to this strategy can be shared in other strategies.
      * <br>
      * The call {@link SchedulingStrategy#finished()} is waiting until own tasks have finished.
      * New tasks will not be scheduled by this call in this strategy. This strategy is not
@@ -76,7 +76,7 @@ public class SchedulingStrategies
      * @param logger current error logger
      * @param threadPool thread pool possibly shared with other strategies
      * @return parallel strategy with shared thread pool
-     * @throws NullPointerException if <tt>threadPool</tt> is null
+     * @throws NullPointerException if <code>threadPool</code> is null
      */
     public static SchedulingStrategy createParallelSharedStrategy( ConsoleStream logger, ExecutorService threadPool )
     {

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/SchedulingStrategy.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/SchedulingStrategy.java
@@ -54,9 +54,9 @@ public abstract class SchedulingStrategy
      * Schedules tasks if {@link #canSchedule()}.
      *
      * @param task runnable to schedule in a thread pool or invoke
-     * @throws java.util.concurrent.RejectedExecutionException if <tt>task</tt>
+     * @throws java.util.concurrent.RejectedExecutionException if <code>task</code>
      *                                    cannot be scheduled for execution
-     * @throws NullPointerException       if <tt>task</tt> is <tt>null</tt>
+     * @throws NullPointerException       if <code>task</code> is <code>null</code>
      * @see org.junit.runners.model.RunnerScheduler#schedule(Runnable)
      * @see java.util.concurrent.Executor#execute(Runnable)
      */

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ThreadResourcesBalancer.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/pc/ThreadResourcesBalancer.java
@@ -34,7 +34,7 @@ final class ThreadResourcesBalancer
     private final int numPermits;
 
     /**
-     * <tt>fair</tt> set to false.
+     * <code>fair</code> set to false.
      *
      * @param numPermits number of permits to acquire when maintaining concurrency on tests.
      *                   Must be &gt;0 and &lt; {@link Integer#MAX_VALUE}.
@@ -49,7 +49,7 @@ final class ThreadResourcesBalancer
      * @param numPermits number of permits to acquire when maintaining concurrency on tests.
      *                   Must be &gt;0 and &lt; {@link Integer#MAX_VALUE}.
      * @param fair       {@code true} guarantees the waiting schedulers to wake up in order they acquired a permit
-     * @throws IllegalArgumentException if <tt>numPermits</tt> is not positive number
+     * @throws IllegalArgumentException if <code>numPermits</code> is not positive number
      */
     ThreadResourcesBalancer( int numPermits, boolean fair )
     {


### PR DESCRIPTION
When building Surefire with Java 17 (`OpenJDK 64-Bit Server VM Temurin-17+35`) and Maven 3.6.3, the Javadoc generation process fails with the following error:
```
[ERROR] /home/mike/Workspace/maven-surefire/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReportEntry.java:[79,89] error: tag not supported in HTML5: tt
```
The problem seems not to appear when building the project with Java 11 (`OpenJDK 64-Bit Server VM AdoptOpenJDK`).

As the `<tt>` tag [seems to be deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt), it should probably be replaced with an HTML 5-compatible alternative like `<code>`. This PR introduces such a change.

From the semantical point of view, not every introduced `<code>` usage represents the actual code. In case it's not desirable to use it like this everywhere, we may consider replacing some of the occurrences with a different tag like `<pre>`.