### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,8 @@
               <arg>-Xdoclint:all</arg>
             </compilerArgs>
             <encoding>UTF-8</encoding>
+          	<useIncrementalCompilation>true</useIncrementalCompilation>
+
           </configuration>
         </plugin>
         <!-- NOTE: animal sniffer does not check test classes: https://jira.codehaus.org/browse/MANIMALSNIFFER-40 -->


### PR DESCRIPTION

Maven can recompile only the classes that were affected by a change. This feature is the default. We can activate it by setting `<useIncrementalCompilation>true</useIncrementalCompilation>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
