### PR TITLE
[SUREFIRE-1926] Console logs should be synchronized

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/NativeStdErrStreamConsumer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/NativeStdErrStreamConsumer.java
@@ -19,13 +19,12 @@ package org.apache.maven.plugin.surefire.booterclient.output;
  * under the License.
  */
 
-import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.surefire.extensions.EventHandler;
 
 import javax.annotation.Nonnull;
 
 /**
- * The error logger for the error stream of the forked JMV,
+ * The standard error logger for the error stream of the forked JMV,
  * see {@link org.apache.maven.plugin.surefire.booterclient.ForkStarter}.
  *
  * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
@@ -35,16 +34,19 @@ import javax.annotation.Nonnull;
 public final class NativeStdErrStreamConsumer
     implements EventHandler<String>
 {
-    private final ConsoleLogger logger;
+    private final Object errStreamLock;
 
-    public NativeStdErrStreamConsumer( ConsoleLogger logger )
+    public NativeStdErrStreamConsumer( Object errStreamLock )
     {
-        this.logger = logger;
+        this.errStreamLock = errStreamLock;
     }
 
     @Override
-    public void handleEvent( @Nonnull String line )
+    public void handleEvent( @Nonnull String message )
     {
-        logger.error( line );
+        synchronized ( errStreamLock )
+        {
+            System.err.println( message );
+        }
     }
 }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/NativeStdOutStreamConsumer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/NativeStdOutStreamConsumer.java
@@ -19,13 +19,12 @@ package org.apache.maven.plugin.surefire.booterclient.output;
  * under the License.
  */
 
-import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.surefire.extensions.EventHandler;
 
 import javax.annotation.Nonnull;
 
 /**
- * The output/INFO logger for the output stream of the forked JMV,
+ * The standard output logger for the output stream of the forked JMV,
  * see org.apache.maven.plugin.surefire.extensions.SurefireForkChannel.
  *
  * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
@@ -34,16 +33,19 @@ import javax.annotation.Nonnull;
 public final class NativeStdOutStreamConsumer
     implements EventHandler<String>
 {
-    private final ConsoleLogger logger;
+    private final Object outStreamLock;
 
-    public NativeStdOutStreamConsumer( ConsoleLogger logger )
+    public NativeStdOutStreamConsumer( Object outStreamLock )
     {
-        this.logger = logger;
+        this.outStreamLock = outStreamLock;
     }
 
     @Override
-    public void handleEvent( @Nonnull String event )
+    public void handleEvent( @Nonnull String message )
     {
-        logger.info( event );
+        synchronized ( outStreamLock )
+        {
+            System.out.println( message );
+        }
     }
 }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireForkChannel.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireForkChannel.java
@@ -143,7 +143,7 @@ final class SurefireForkChannel extends ForkChannel
     {
         ForkNodeArguments args = getArguments();
         out = new LineConsumerThread( "fork-" + args.getForkChannelId() + "-out-thread", stdOut,
-            new NativeStdOutStreamConsumer( args.getConsoleLogger() ), countdown );
+            new NativeStdOutStreamConsumer( args.getConsoleLock() ), countdown );
         out.start();
 
         eventBindings = new EventBindings( eventHandler, countdown );

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/log/PluginConsoleLogger.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/log/PluginConsoleLogger.java
@@ -25,6 +25,10 @@ import org.codehaus.plexus.logging.Logger;
 /**
  * Wrapper logger of miscellaneous implementations of {@link Logger}.
  *
+ * This instance is synchronized. The logger operations are mutually exclusive to standard out, standard err and console
+ * err/warn/info/debug logger operations, see {@link org.apache.maven.plugin.surefire.report.DefaultReporterFactory},
+ * {@link org.apache.maven.plugin.surefire.report.TestSetRunListener}.
+ *
  * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
  * @since 2.20
  * @see ConsoleLogger
@@ -46,12 +50,12 @@ public final class PluginConsoleLogger
     }
 
     @Override
-    public void debug( String message )
+    public synchronized void debug( String message )
     {
         plexusLogger.debug( message );
     }
 
-    public void debug( CharSequence content, Throwable error )
+    public synchronized void debug( CharSequence content, Throwable error )
     {
         plexusLogger.debug( content == null ? "" : content.toString(), error );
     }
@@ -63,7 +67,7 @@ public final class PluginConsoleLogger
     }
 
     @Override
-    public void info( String message )
+    public synchronized void info( String message )
     {
         plexusLogger.info( message );
     }
@@ -75,12 +79,12 @@ public final class PluginConsoleLogger
     }
 
     @Override
-    public void warning( String message )
+    public synchronized void warning( String message )
     {
         plexusLogger.warn( message );
     }
 
-    public void warning( CharSequence content, Throwable error )
+    public synchronized void warning( CharSequence content, Throwable error )
     {
         plexusLogger.warn( content == null ? "" : content.toString(), error );
     }
@@ -92,19 +96,19 @@ public final class PluginConsoleLogger
     }
 
     @Override
-    public void error( String message )
+    public synchronized void error( String message )
     {
         plexusLogger.error( message );
     }
 
     @Override
-    public void error( String message, Throwable t )
+    public synchronized void error( String message, Throwable t )
     {
         plexusLogger.error( message, t );
     }
 
     @Override
-    public void error( Throwable t )
+    public synchronized void error( Throwable t )
     {
         plexusLogger.error( "", t );
     }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
@@ -65,7 +65,7 @@ import static org.apache.maven.surefire.api.util.internal.ObjectUtils.useNonNull
  * @author Kristian Rosenvold
  */
 public class DefaultReporterFactory
-    implements ReporterFactory
+    implements ReporterFactory, ReportsMerger
 {
     private final Collection<TestSetRunListener> listeners = new ConcurrentLinkedQueue<>();
     private final StartupReportConfiguration reportConfiguration;
@@ -107,11 +107,13 @@ public class DefaultReporterFactory
                                     createStatisticsReporter(),
                                     reportConfiguration.isTrimStackTrace(),
                                     PLAIN.equals( reportConfiguration.getReportFormat() ),
-                                    reportConfiguration.isBriefOrPlainFormat() );
+                                    reportConfiguration.isBriefOrPlainFormat(),
+                                    consoleLogger );
         addListener( testSetRunListener );
         return testSetRunListener;
     }
 
+    @Override
     public File getReportsDirectory()
     {
         return reportConfiguration.getReportsDirectory();
@@ -151,6 +153,7 @@ public class DefaultReporterFactory
         return useNonNull( statisticsReporter, NullStatisticsReporter.INSTANCE );
     }
 
+    @Override
     public void mergeFromOtherFactories( Collection<DefaultReporterFactory> factories )
     {
         for ( DefaultReporterFactory factory : factories )
@@ -176,6 +179,7 @@ public class DefaultReporterFactory
         return globalStats.getRunResult();
     }
 
+    @Override
     public void runStarting()
     {
         if ( reportConfiguration.isPrintSummary() )

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ReportsMerger.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ReportsMerger.java
@@ -1,0 +1,36 @@
+package org.apache.maven.plugin.surefire.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.api.suite.RunResult;
+
+import java.io.File;
+import java.util.Collection;
+
+/**
+ * This interface is used to merge reports in {@link org.apache.maven.plugin.surefire.booterclient.ForkStarter}.
+ */
+public interface ReportsMerger
+{
+    void runStarting();
+    void mergeFromOtherFactories( Collection<DefaultReporterFactory> factories );
+    File getReportsDirectory();
+    RunResult close();
+}

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
@@ -28,6 +28,9 @@ import org.apache.maven.plugin.surefire.booterclient.lazytestprovider.TestLessIn
 import org.apache.maven.plugin.surefire.booterclient.lazytestprovider.TestProvidingInputStream;
 import org.apache.maven.plugin.surefire.booterclient.output.ForkClient;
 import org.apache.maven.plugin.surefire.extensions.LegacyForkNodeFactory;
+import org.apache.maven.plugin.surefire.extensions.SurefireConsoleOutputReporter;
+import org.apache.maven.plugin.surefire.extensions.SurefireStatelessReporter;
+import org.apache.maven.plugin.surefire.extensions.SurefireStatelessTestsetInfoReporter;
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.plugin.surefire.report.DefaultReporterFactory;
 import org.apache.maven.surefire.booter.AbstractPathConfiguration;
@@ -155,15 +158,21 @@ public class ForkStarterTest
         when( forkConfiguration.createCommandLine( eq( startupConfiguration ), eq( 1 ), eq( tmp ) ) )
             .thenReturn( cli );
 
+        SurefireStatelessTestsetInfoReporter statelessTestsetInfoReporter = new SurefireStatelessTestsetInfoReporter();
+        SurefireConsoleOutputReporter outputReporter = new SurefireConsoleOutputReporter();
+        SurefireStatelessReporter xmlReporter = new SurefireStatelessReporter( true, "3" );
+
         StartupReportConfiguration startupReportConfiguration = new StartupReportConfiguration( true, true, null,
-            false, tmp, true, "", null, false, 0, null, null, true, null, null, null );
+            false, tmp, true, "", null, false, 0, null, null, true,
+            xmlReporter, outputReporter, statelessTestsetInfoReporter );
 
         ConsoleLogger logger = mock( ConsoleLogger.class );
 
         ForkStarter forkStarter = new ForkStarter( providerConfiguration, startupConfiguration, forkConfiguration,
             0, startupReportConfiguration, logger );
 
-        DefaultReporterFactory reporterFactory = new DefaultReporterFactory( startupReportConfiguration, logger, 1 );
+        DefaultReporterFactory reporterFactory =
+            new DefaultReporterFactory( startupReportConfiguration, logger, 1 );
 
         e.expect( SurefireBooterForkException.class );
         e.expectMessage( containsString( "Process Exit Code: 1" ) );
@@ -214,15 +223,21 @@ public class ForkStarterTest
         when( forkConfiguration.createCommandLine( eq( startupConfiguration ), eq( 1 ), eq( tmp ) ) )
             .thenReturn( cli );
 
+        SurefireStatelessTestsetInfoReporter statelessTestsetInfoReporter = new SurefireStatelessTestsetInfoReporter();
+        SurefireConsoleOutputReporter outputReporter = new SurefireConsoleOutputReporter();
+        SurefireStatelessReporter xmlReporter = new SurefireStatelessReporter( true, "3" );
+
         StartupReportConfiguration startupReportConfiguration = new StartupReportConfiguration( true, true, null,
-            false, tmp, true, "", null, false, 0, null, null, true, null, null, null );
+            false, tmp, true, "", null, false, 0, null, null, true,
+            xmlReporter, outputReporter, statelessTestsetInfoReporter );
 
         ConsoleLogger logger = mock( ConsoleLogger.class );
 
         ForkStarter forkStarter = new ForkStarter( providerConfiguration, startupConfiguration, forkConfiguration,
             0, startupReportConfiguration, logger );
 
-        DefaultReporterFactory reporterFactory = new DefaultReporterFactory( startupReportConfiguration, logger, 1 );
+        DefaultReporterFactory reporterFactory =
+            new DefaultReporterFactory( startupReportConfiguration, logger, 1 );
 
         Class<?>[] types = {Object.class, PropertiesWrapper.class, ForkClient.class, SurefireProperties.class,
             int.class, AbstractCommandReader.class, ForkNodeFactory.class, boolean.class};

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkingRunListenerTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkingRunListenerTest.java
@@ -371,6 +371,13 @@ public class ForkingRunListenerTest
             return logger;
         }
 
+        @Nonnull
+        @Override
+        public Object getConsoleLock()
+        {
+            return logger;
+        }
+
         boolean isCalled()
         {
             return !dumpStreamText.isEmpty() || !logWarningAtEnd.isEmpty();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClientTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClientTest.java
@@ -1880,6 +1880,13 @@ public class ForkClientTest
             return logger;
         }
 
+        @Nonnull
+        @Override
+        public Object getConsoleLock()
+        {
+            return logger;
+        }
+
         boolean isCalled()
         {
             return !dumpStreamText.isEmpty() || !logWarningAtEnd.isEmpty();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/E2ETest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/E2ETest.java
@@ -431,6 +431,13 @@ public class E2ETest
             return logger;
         }
 
+        @Nonnull
+        @Override
+        public Object getConsoleLock()
+        {
+            return logger;
+        }
+
         @Override
         public File getEventStreamBinaryFile()
         {

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/EventConsumerThreadTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/EventConsumerThreadTest.java
@@ -229,6 +229,13 @@ public class EventConsumerThreadTest
             return null;
         }
 
+        @Nonnull
+        @Override
+        public Object getConsoleLock()
+        {
+            return new Object();
+        }
+
         @Override
         public File getEventStreamBinaryFile()
         {

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/ForkedProcessEventNotifierTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/ForkedProcessEventNotifierTest.java
@@ -1304,6 +1304,13 @@ public class ForkedProcessEventNotifierTest
             return logger;
         }
 
+        @Nonnull
+        @Override
+        public Object getConsoleLock()
+        {
+            return logger;
+        }
+
         boolean isCalled()
         {
             return !dumpStreamText.isEmpty() || !logWarningAtEnd.isEmpty();

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/extensions/ForkChannelTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/extensions/ForkChannelTest.java
@@ -118,6 +118,13 @@ public class ForkChannelTest
             {
                 return reporter;
             }
+
+            @Nonnull
+            @Override
+            public Object getConsoleLock()
+            {
+                return reporter;
+            }
         };
 
         ForkNodeFactory factory = new SurefireForkNodeFactory();

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/stream/EventDecoderTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/stream/EventDecoderTest.java
@@ -769,6 +769,13 @@ public class EventDecoderTest
             return null;
         }
 
+        @Nonnull
+        @Override
+        public Object getConsoleLock()
+        {
+            return new Object();
+        }
+
         @Override
         public File getEventStreamBinaryFile()
         {

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/fork/ForkNodeArguments.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/fork/ForkNodeArguments.java
@@ -55,6 +55,9 @@ public interface ForkNodeArguments
     @Nonnull
     ConsoleLogger getConsoleLogger();
 
+    @Nonnull
+    Object getConsoleLock();
+
     File getEventStreamBinaryFile();
 
     File getCommandStreamBinaryFile();

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoderTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoderTest.java
@@ -636,6 +636,13 @@ public class AbstractStreamDecoderTest
             return null;
         }
 
+        @Nonnull
+        @Override
+        public Object getConsoleLock()
+        {
+            return new Object();
+        }
+
         @Override
         public File getEventStreamBinaryFile()
         {

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedNodeArg.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedNodeArg.java
@@ -83,10 +83,17 @@ public final class ForkedNodeArg implements ForkNodeArguments
         return logger;
     }
 
+    @Nonnull
+    @Override
+    public Object getConsoleLock()
+    {
+        return logger;
+    }
+
     @Override
     public File getEventStreamBinaryFile()
     {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/CommandChannelDecoderTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/CommandChannelDecoderTest.java
@@ -400,6 +400,13 @@ public class CommandChannelDecoderTest
             return logger;
         }
 
+        @Nonnull
+        @Override
+        public Object getConsoleLock()
+        {
+            return logger;
+        }
+
         boolean isCalled()
         {
             return !dumpStreamText.isEmpty() || !logWarningAtEnd.isEmpty();


### PR DESCRIPTION
The point is to get logger operations in semi-sequential order across multiple threads.
The messages will not be mixed up, especially out and err.
`PluginConsoleLogger` is synchronized. This instance is only one and it is passed to `DefaultReporterFactory` and `TestSetRunListener` as a monitor object.