### PR TITLE
Surefire shared utils, 

### DIFF
--- a/maven-surefire-common/pom.xml
+++ b/maven-surefire-common/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-shared-utils</artifactId>
-            <version>3.0.0-M4</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
   </contributors>
 
   <modules>
+    <module>surefire-shared-utils</module>
     <module>surefire-logger-api</module>
     <module>surefire-api</module>
     <module>surefire-extensions-api</module>
@@ -62,7 +63,6 @@
     <module>maven-failsafe-plugin</module>
     <module>maven-surefire-report-plugin</module>
     <module>surefire-its</module>
-    <module>surefire-shared-utils</module>
   </modules>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <javaVersion>8</javaVersion>
     <mavenVersion>3.2.5</mavenVersion>
     <!-- <shadedVersion>3.0.0-M2</shadedVersion> commented out due to https://issues.apache.org/jira/browse/MRELEASE-799 -->
-    <commonsLang3Version>3.8.1</commonsLang3Version>
+    <commonsLang3Version>3.12.0</commonsLang3Version>
     <commonsCompress>1.20</commonsCompress>
     <commonsIoVersion>2.6</commonsIoVersion>
     <doxiaVersion>1.11.1</doxiaVersion>

--- a/surefire-api/pom.xml
+++ b/surefire-api/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.maven.surefire</groupId>
       <artifactId>surefire-shared-utils</artifactId>
-      <version>3.0.0-M4</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/ObjectUtils.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/ObjectUtils.java
@@ -22,8 +22,11 @@ package org.apache.maven.surefire.api.util.internal;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
 
+import static org.apache.maven.surefire.shared.lang3.JavaVersion.JAVA_16;
+import static org.apache.maven.surefire.shared.lang3.JavaVersion.JAVA_RECENT;
+
 /**
- * Similar to Java 7 java.util.Objects.
+ * Similar to Java 7 java.util.Objects, and another utility methods.
  *
  * @author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
  * @since 2.20
@@ -43,5 +46,16 @@ public final class ObjectUtils
     public static Map<String, String> systemProps()
     {
         return ManagementFactory.getRuntimeMXBean().getSystemProperties();
+    }
+
+    /**
+     * The {@link SecurityManager} is deprecated since Java 17.
+     *
+     * @return <code>true</code> if Java Specification Version is less than
+     *         or equal to 16; <code>false</code> otherwise.
+     */
+    public static boolean isSecurityManagerSupported()
+    {
+        return JAVA_RECENT.atMost( JAVA_16 );
     }
 }

--- a/surefire-extensions-api/pom.xml
+++ b/surefire-extensions-api/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-shared-utils</artifactId>
-            <version>3.0.0-M4</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/surefire-providers/common-java5/pom.xml
+++ b/surefire-providers/common-java5/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.apache.maven.surefire</groupId>
       <artifactId>surefire-shared-utils</artifactId>
-      <version>3.0.0-M4</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/surefire-report-parser/pom.xml
+++ b/surefire-report-parser/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.maven.surefire</groupId>
       <artifactId>surefire-shared-utils</artifactId>
-      <version>3.0.0-M4</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>

--- a/surefire-shared-utils/pom.xml
+++ b/surefire-shared-utils/pom.xml
@@ -27,7 +27,7 @@
         <version>3.0.0-M6-SNAPSHOT</version>
     </parent>
 
-    <artifactId>surefire-shared-utils</artifactId>
+    <artifactId>surefire-shared-utils-project</artifactId>
     <name>Surefire Shared Utils</name>
     <description>Relocated Java packages of maven-shared-utils in Surefire</description>
 
@@ -94,6 +94,38 @@
                                     <shadedPattern>org.apache.maven.surefire.shared.compress</shadedPattern>
                                 </relocation>
                             </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-jar</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>target/${project.build.finalName}.jar</file>
+                            <artifactId>surefire-shared-utils</artifactId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>deploy-jar</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>target/${project.build.finalName}.jar</file>
+                            <artifactId>surefire-shared-utils</artifactId>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
We are aiming for an upgrade of the version of `org.apache.maven.surefire.shared.lang3.JavaVersion` which means that we have to install/deploy **current version** of `surefire-shared-utils`.
Then we are able to implement the method `isSecurityManagerSupported()` within the module `surefire-api` using the enum `JavaVersion`.