### PR TITLE
[SUREFIRE-1992] - Do not abbreviate test error/failure messages to 78 characters

### DIFF
--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/LegacyPojoStackTraceWriter.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/LegacyPojoStackTraceWriter.java
@@ -21,6 +21,7 @@ package org.apache.maven.surefire.api.report;
 
 
 import org.apache.maven.surefire.api.util.internal.StringUtils;
+import static org.apache.maven.surefire.shared.utils.StringUtils.isNotEmpty;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -33,8 +34,6 @@ import java.io.StringWriter;
 public class LegacyPojoStackTraceWriter
     implements StackTraceWriter
 {
-    private static final int MAX_LINE_LENGTH = 77;
-
     private final Throwable t;
 
     private final String testClass;
@@ -81,19 +80,19 @@ public class LegacyPojoStackTraceWriter
         result.append( "#" );
         result.append( testMethod );
         SafeThrowable throwable = getThrowable();
-        if ( throwable.getTarget() instanceof AssertionError )
+        Throwable target = throwable.getTarget();
+        if ( target != null )
         {
-            result.append( " " );
-            result.append( getTruncatedMessage( throwable.getMessage(), MAX_LINE_LENGTH - result.length() ) );
-        }
-        else
-        {
-            Throwable target = throwable.getTarget();
-            if ( target != null )
+            if ( ! ( target instanceof AssertionError ) )
             {
-                result.append( " " );
-                result.append( target.getClass().getSimpleName() );
-                result.append( getTruncatedMessage( throwable.getMessage(), MAX_LINE_LENGTH - result.length() ) );
+                result.append( ' ' )
+                      .append( target.getClass().getSimpleName() );
+            }
+            final String msg = throwable.getMessage();
+            if ( isNotEmpty( msg ) )
+            {
+                result.append( ' ' )
+                      .append( msg );
             }
         }
         return result.toString();
@@ -119,28 +118,6 @@ public class LegacyPojoStackTraceWriter
         }
         return false;
     }
-
-    private static String getTruncatedMessage( String msg, int i )
-    {
-        if ( i < 0 )
-        {
-            return "";
-        }
-        if ( msg == null )
-        {
-            return "";
-        }
-        String substring = msg.substring( 0, Math.min( i, msg.length() ) );
-        if ( i < msg.length() )
-        {
-            return " " + substring + "...";
-        }
-        else
-        {
-            return " " + substring;
-        }
-    }
-
 
     @Override
     public String writeTrimmedTraceToString()

--- a/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/SmartStackTraceParser.java
+++ b/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/SmartStackTraceParser.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static java.lang.Math.min;
 import static java.util.Arrays.asList;
 import static java.util.Collections.reverse;
 import static org.apache.maven.surefire.shared.utils.StringUtils.chompLast;
@@ -37,8 +36,6 @@ import static org.apache.maven.surefire.shared.utils.StringUtils.isNotEmpty;
 @SuppressWarnings( "ThrowableResultOfMethodCallIgnored" )
 public class SmartStackTraceParser
 {
-    private static final int MAX_LINE_LENGTH = 77;
-
     private final SafeThrowable throwable;
 
     private final StackTraceElement[] stackTrace;
@@ -133,23 +130,19 @@ public class SmartStackTraceParser
         final String excClassName = excType.getName();
         final String msg = throwable.getMessage();
 
-        if ( target instanceof AssertionError
+        if ( ! ( target instanceof AssertionError
                 || "junit.framework.AssertionFailedError".equals( excClassName )
                 || "junit.framework.ComparisonFailure".equals( excClassName )
-                || excClassName.startsWith( "org.opentest4j." ) )
-        {
-            if ( isNotEmpty( msg ) )
-            {
-                result.append( ' ' )
-                    .append( msg );
-            }
-        }
-        else
+                || excClassName.startsWith( "org.opentest4j." ) ) )
         {
             result.append( rootIsInclass() ? " " : " » " )
-                    .append( toMinimalThrowableMiniMessage( excType ) );
+                  .append( toMinimalThrowableMiniMessage( excType ) );
+        }
 
-            result.append( truncateMessage( msg, MAX_LINE_LENGTH - result.length() ) );
+        if ( isNotEmpty( msg ) )
+        {
+            result.append( ' ' )
+                  .append( msg );
         }
         return result.toString();
     }
@@ -166,22 +159,6 @@ public class SmartStackTraceParser
             return chompLast( name, "Error" );
         }
         return name;
-    }
-
-    private static String truncateMessage( String msg, int i )
-    {
-        StringBuilder truncatedMessage = new StringBuilder();
-        if ( i >= 0 && msg != null )
-        {
-            truncatedMessage.append( ' ' )
-                    .append( msg, 0, min( i, msg.length() ) );
-
-            if ( i < msg.length() )
-            {
-                truncatedMessage.append( "..." );
-            }
-        }
-        return truncatedMessage.toString();
     }
 
     private boolean rootIsInclass()

--- a/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/ATestClass.java
+++ b/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/ATestClass.java
@@ -60,7 +60,7 @@ public class ATestClass
 
     public void aLongTestErrorMessage()
     {
-        throw new RuntimeException( "This message will be truncated, somewhere over the rainbow. "
+        throw new RuntimeException( "This message won't be truncated, somewhere over the rainbow. "
                                     + "Gangnam style, Gangnam style, Gangnam style, , Gangnam style, Gangnam style" );
     }
 

--- a/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/SmartStackTraceParserTest.java
+++ b/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/SmartStackTraceParserTest.java
@@ -136,7 +136,7 @@ public class SmartStackTraceParserTest
         }
     }
 
-    public void testLongMessageTruncation()
+    public void testLongMessageHandling()
     {
         ATestClass aTestClass = new ATestClass();
         try
@@ -148,7 +148,7 @@ public class SmartStackTraceParserTest
             SmartStackTraceParser smartStackTraceParser =
                     new SmartStackTraceParser( ATestClass.class.getName(), e, null );
             String res = smartStackTraceParser.getString();
-            assertEquals( "ATestClass.aLongTestErrorMessage:63 Runtime This message will be truncated, so...",
+            assertEquals( "ATestClass.aLongTestErrorMessage:63 Runtime " + e.getMessage(),
                     res );
         }
     }


### PR DESCRIPTION
Pull request for ticket [SUREFIRE-1992] which removes abbreviation of test error/failure messages to 78 characters in two classes that write test results to stdout/stderr.
The fix greatly improves usability of surefire when troubleshooting test failures.
