### PR TITLE
[SUREFIRE-1994] Upgrade javacc-maven-plugin, add setup instructions for Eclipse

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,25 @@ Build the Surefire project using **Maven 3.2.5+** and **JDK 1.8+**.
   ```
   mvn install site site:stage -P reporting,run-its
   ```
-  
+
+* To set up the project in [Eclipse IDE](https://www.eclipse.org/), please follow these steps:
+
+  * Build module `surefire-shared-utils` with profile `ide-development` and install it into the local maven repository using this Maven command:
+    ```
+    mvn install -P ide-development -f surefire-shared-utils/pom.xml
+    ```
+  * Build module `surefire-grouper` in order to generate and compile sources into `target/generated-sources/javacc` using this Maven command:
+    ```
+    mvn compile -f surefire-grouper/pom.xml
+    ```
+  * In Eclipse, select _File > Import ... > Maven Project_
+
+     * Select all projects (poms) except `surefire-shared-utils`,
+       enter profile `ide-development` in _Advanced -> Profiles_
+     * Check module `surefire-grouper` has source folder `target/generated-sources/javacc`.
+       If not, add it manually in the module's project properties
+
+* Setup for development in [IntelliJ IDEA](https://www.jetbrains.com/idea/) should work out of the box.
 
 ### Deploying web site
 

--- a/surefire-grouper/pom.xml
+++ b/surefire-grouper/pom.xml
@@ -35,9 +35,9 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>org.javacc.plugin</groupId>
         <artifactId>javacc-maven-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.0.3</version>
         <executions>
           <execution>
             <id>javacc</id>
@@ -46,6 +46,13 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>net.java.dev.javacc</groupId>
+            <artifactId>javacc</artifactId>
+            <version>7.0.10</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
This PR addresses the issue in [SUREFIRE-1994] to upgrade/configure `javacc-maven-plugin`.

✅ Each commit in the pull request should have a meaningful subject line and body.
✅ Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`
✅ Run `mvn clean install` to make sure basic checks pass.
(I use `mvn clean verify` usually which is the same but does not put artifacts into the local repo.)

✅ I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
