### PR TITLE
[SUREFIRE-1993] Discover providing modules from dependencies

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -2055,6 +2055,7 @@ public abstract class AbstractSurefireMojo
         {
             providerRequirements = new ProviderRequirements( true, true, false );
             ResolvePathsRequest<String> req = ResolvePathsRequest.ofStrings( testClasspath.getClassPath() )
+                    .setIncludeAllProviders( true )
                     .setJdkHome( javaHome )
                     .setModuleDescriptor( javaModuleDescriptor );
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
@@ -61,6 +61,7 @@ import static java.util.Collections.singletonMap;
 import static org.apache.maven.artifact.versioning.VersionRange.createFromVersion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Index.atIndex;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -151,6 +152,7 @@ public class AbstractSurefireMojoJava7PlusTest
         mockStatic( ResolvePathsRequest.class );
         when( ResolvePathsRequest.ofStrings( eq( testClasspath.toClasspath().getClassPath() ) ) ).thenReturn( req );
         when( req.setJdkHome( anyString() ) ).thenReturn( req );
+        when( req.setIncludeAllProviders( anyBoolean() ) ).thenReturn( req );
         when( req.setModuleDescriptor( eq( descriptor ) ) ).thenReturn( req );
 
         when( descriptor.name() ).thenReturn( "abc" );

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1993JpmsProvidingModulesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1993JpmsProvidingModulesIT.java
@@ -1,0 +1,57 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaVersion;
+
+/**
+ * Verify that Surefire adds Maven dependencies to the Module Path if they <code>provide</code> a service that is
+ * <code>use</code> 'd by another JPMS module that is already on the Module Path.
+ *
+ * @author mthmulders
+ */
+public class Surefire1993JpmsProvidingModulesIT
+    extends SurefireJUnit4IntegrationTestCase
+{
+    @Before
+    public void setUp()
+    {
+        assumeJavaVersion( 9 );
+    }
+
+    @Test
+    public void verify() throws VerificationException
+    {
+        SurefireLauncher launcher = unpack( "surefire-1993-jpms-providing-modules" );
+
+        launcher.debugLogging()
+                .executeVerify();
+
+        launcher.getSubProjectValidator( "application" )
+                .verifyErrorFreeLog()
+                .assertIntegrationTestSuiteResults( 1, 0, 0, 0 );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one
+~ or more contributor license agreements.  See the NOTICE file
+~ distributed with this work for additional information
+~ regarding copyright ownership.  The ASF licenses this file
+~ to you under the Apache License, Version 2.0 (the
+~ "License"); you may not use this file except in compliance
+~ with the License.  You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing,
+~ software distributed under the License is distributed on an
+~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~ KIND, either express or implied.  See the License for the
+~ specific language governing permissions and limitations
+~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.plugins.surefire</groupId>
+        <artifactId>surefire-1993-jpms-providing-modules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.apache.plugins.failsafe.its</groupId>
+    <artifactId>application</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.plugins.failsafe.its</groupId>
+            <artifactId>studentservice</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.plugins.failsafe.its</groupId>
+            <artifactId>studentservice-provider</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <forkMode>once</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/src/main/java/module-info.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module application {
+    requires studentservice;
+
+    uses org.apache.failsafe.its.serviceloader.api.service.StudentService;
+}

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/src/main/java/org/apache/failsafe/its/serviceloader/application/StudentServiceLoader.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/src/main/java/org/apache/failsafe/its/serviceloader/application/StudentServiceLoader.java
@@ -1,0 +1,46 @@
+package org.apache.failsafe.its.serviceloader.application;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.failsafe.its.serviceloader.api.service.StudentService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+
+public class StudentServiceLoader {
+
+    public StudentService getStudentService(){
+        Optional<StudentService> studentService = ServiceLoader.load( StudentService.class ).findFirst();
+        return studentService.orElseThrow(() -> {
+            throw new RuntimeException( "Could not find StudentService implementation" );
+        } );
+    }
+
+    public List<StudentService> getStudentServices(){
+        ServiceLoader<StudentService> loader = ServiceLoader.load( StudentService.class );
+        List<StudentService> studentServices = new ArrayList<>();
+        for ( StudentService studentService : loader ) {
+            studentServices.add(studentService);
+        }
+        return studentServices;
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/src/main/java/org/apache/failsafe/its/serviceloader/application/TrainingApplication.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/src/main/java/org/apache/failsafe/its/serviceloader/application/TrainingApplication.java
@@ -1,0 +1,45 @@
+package org.apache.failsafe.its.serviceloader.application;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.failsafe.its.serviceloader.api.model.Student;
+import org.apache.failsafe.its.serviceloader.api.service.StudentService;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TrainingApplication {
+
+    private StudentService studentService;
+    private List<String> modules;
+
+    public TrainingApplication() {
+        String modulePath = System.getProperty( "jdk.module.path", "" );
+        System.out.printf( "Java Module Path:%n%s%n%n", modulePath.replace( ":", System.lineSeparator() ) );
+        this.modules = Arrays.asList( modulePath.split( ":" ) );
+        this.studentService = new StudentServiceLoader().getStudentService();
+    }
+
+    public List<String> getModules() {
+        return this.modules;
+    }
+
+}
+

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/src/test/java/org/apache/failsafe/its/serviceloader/application/TrainingApplicationIT.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/application/src/test/java/org/apache/failsafe/its/serviceloader/application/TrainingApplicationIT.java
@@ -1,0 +1,38 @@
+package org.apache.failsafe.its.serviceloader.application;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.failsafe.its.serviceloader.api.model.Student;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TrainingApplicationIT {
+
+    private TrainingApplication trainingApplication = new TrainingApplication();
+
+    @Test
+    public void testModules() {
+        List<String> modules = trainingApplication.getModules();
+        assertThat( modules ).isNotEmpty();
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one
+~ or more contributor license agreements.  See the NOTICE file
+~ distributed with this work for additional information
+~ regarding copyright ownership.  The ASF licenses this file
+~ to you under the Apache License, Version 2.0 (the
+~ "License"); you may not use this file except in compliance
+~ with the License.  You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing,
+~ software distributed under the License is distributed on an
+~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~ KIND, either express or implied.  See the License for the
+~ specific language governing permissions and limitations
+~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.surefire</groupId>
+        <artifactId>it-parent</artifactId>
+        <version>1.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-1993-jpms-providing-modules</artifactId>
+
+    <version>1.0-SNAPSHOT</version>
+    <name>Discover providing JPMS modules</name>
+    <packaging>pom</packaging>
+
+    <contributors>
+        <contributor>
+            <name>Maarten Mulders (mthmulders)</name>
+            <url>https://github.com/mthmulders</url>
+        </contributor>
+        <contributor>
+            <name>Joris Nienkemper</name>
+            <url>https://github.com/JorisNienkemper</url>
+        </contributor>
+    </contributors>
+
+    <properties>
+        <maven.compiler.release>${java.specification.version}</maven.compiler.release>
+    </properties>
+
+    <modules>
+        <module>studentservice</module>
+        <module>studentservice-provider</module>
+        <module>application</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.21.0</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+
+</project>

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice-provider/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice-provider/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one
+~ or more contributor license agreements.  See the NOTICE file
+~ distributed with this work for additional information
+~ regarding copyright ownership.  The ASF licenses this file
+~ to you under the Apache License, Version 2.0 (the
+~ "License"); you may not use this file except in compliance
+~ with the License.  You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing,
+~ software distributed under the License is distributed on an
+~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~ KIND, either express or implied.  See the License for the
+~ specific language governing permissions and limitations
+~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.plugins.surefire</groupId>
+        <artifactId>surefire-1993-jpms-providing-modules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.apache.plugins.failsafe.its</groupId>
+    <artifactId>studentservice-provider</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.plugins.failsafe.its</groupId>
+            <artifactId>studentservice</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice-provider/src/main/java/module-info.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice-provider/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module studentserviceprovider {
+    requires studentservice;
+
+    provides org.apache.failsafe.its.serviceloader.api.service.StudentService
+            with org.apache.failsafe.its.serviceloader.provider.service.StudentServiceImpl;
+}

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice-provider/src/main/java/org/apache/failsafe/its/serviceloader/provider/internal/InternalStudentService.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice-provider/src/main/java/org/apache/failsafe/its/serviceloader/provider/internal/InternalStudentService.java
@@ -1,0 +1,40 @@
+package org.apache.failsafe.its.serviceloader.provider.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.failsafe.its.serviceloader.api.model.Student;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class InternalStudentService {
+
+    public int retrieveStudentDept(String name) {
+        // Mimic retrieving from database
+        return name.length();
+    }
+
+    public List<Student> retrieveStudents() {
+        // Mimic retrieving from database
+        Student anne = new Student( "Anne" );
+        Student peter = new Student( "Peter" );
+        return Arrays.asList( anne, peter );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice-provider/src/main/java/org/apache/failsafe/its/serviceloader/provider/service/StudentServiceImpl.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice-provider/src/main/java/org/apache/failsafe/its/serviceloader/provider/service/StudentServiceImpl.java
@@ -1,0 +1,52 @@
+package org.apache.failsafe.its.serviceloader.provider.service;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.failsafe.its.serviceloader.provider.internal.InternalStudentService;
+import org.apache.failsafe.its.serviceloader.api.model.Student;
+import org.apache.failsafe.its.serviceloader.api.service.StudentService;
+
+import java.util.List;
+
+public class StudentServiceImpl implements StudentService {
+
+    private InternalStudentService internalStudentService = new InternalStudentService();
+
+    @Override
+    public String retrieveStudentName(int number) {
+        return "Susan " + number;
+    }
+
+    @Override
+    public List<Student> retrieveStudents() {
+        return internalStudentService.retrieveStudents();
+    }
+
+    @Override
+    public int retrieveTotalStudentDept() {
+        List<Student> studentList = internalStudentService.retrieveStudents();
+        int totalDept = 0;
+        for (Student student : studentList) {
+            int studentDept = internalStudentService.retrieveStudentDept(student.getName());
+            totalDept += studentDept;
+        }
+        return totalDept;
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Licensed to the Apache Software Foundation (ASF) under one
+~ or more contributor license agreements.  See the NOTICE file
+~ distributed with this work for additional information
+~ regarding copyright ownership.  The ASF licenses this file
+~ to you under the Apache License, Version 2.0 (the
+~ "License"); you may not use this file except in compliance
+~ with the License.  You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing,
+~ software distributed under the License is distributed on an
+~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~ KIND, either express or implied.  See the License for the
+~ specific language governing permissions and limitations
+~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.maven.plugins.surefire</groupId>
+        <artifactId>surefire-1993-jpms-providing-modules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.apache.plugins.failsafe.its</groupId>
+    <artifactId>studentservice</artifactId>
+</project>

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice/src/main/java/module-info.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module studentservice {
+    exports org.apache.failsafe.its.serviceloader.api.model;
+    exports org.apache.failsafe.its.serviceloader.api.service;
+}

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice/src/main/java/org/apache/failsafe/its/serviceloader/api/model/Student.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice/src/main/java/org/apache/failsafe/its/serviceloader/api/model/Student.java
@@ -1,0 +1,39 @@
+package org.apache.failsafe.its.serviceloader.api.model;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Student {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public Student(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "Student{" +
+                "name='" + name + '\'' +
+                '}';
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice/src/main/java/org/apache/failsafe/its/serviceloader/api/service/StudentService.java
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/studentservice/src/main/java/org/apache/failsafe/its/serviceloader/api/service/StudentService.java
@@ -1,0 +1,32 @@
+package org.apache.failsafe.its.serviceloader.api.service;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.failsafe.its.serviceloader.api.model.Student;
+
+import java.util.List;
+
+public interface StudentService {
+    public List<Student> retrieveStudents();
+
+    public String retrieveStudentName( int number );
+
+    public int retrieveTotalStudentDept();
+}


### PR DESCRIPTION
The `includeAllProviders` flag that we flip to "true" here lets Plexus Java detect all JPMS modules that "provide" a service that any module we already depend on "uses". This fixes [SUREFIRE-1993](https://issues.apache.org/jira/browse/SUREFIRE-1993)

 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
