### PR TITLE
[SUREFIRE-1909] -  Support JUnit 5 reflection access by changing add-exports to add-opens

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ModularClasspathForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ModularClasspathForkConfiguration.java
@@ -183,7 +183,7 @@ public class ModularClasspathForkConfiguration
 
                 for ( String pkg : packages )
                 {
-                    args.append( "--add-exports" )
+                    args.append( "--add-opens" )
                             .append( NL )
                             .append( moduleName )
                             .append( '/' )

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ModularClasspathForkConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ModularClasspathForkConfigurationTest.java
@@ -116,7 +116,7 @@ public class ModularClasspathForkConfigurationTest
                 .isEqualTo( "abc=\"" + replace( patchFile.getPath(), "\\", "\\\\" ) + "\"" );
 
         assertThat( argsFileLines.get( 6 ) )
-                .isEqualTo( "--add-exports" );
+                .isEqualTo( "--add-opens" );
 
         assertThat( argsFileLines.get( 7 ) )
                 .isEqualTo( "abc/org.apache.abc=ALL-UNNAMED" );

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/Junit5ModulePathIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/Junit5ModulePathIT.java
@@ -1,0 +1,69 @@
+package org.apache.maven.surefire.its;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+
+import org.apache.maven.surefire.its.fixture.AbstractJava9PlusIT;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class Junit5ModulePathIT
+        extends AbstractJava9PlusIT
+{
+    private String suffix;
+
+    @Test
+    public void testModulePath()
+            throws IOException
+    {
+        assumeJava9()
+                .debugLogging()
+                .executeTest()
+                .verifyErrorFreeLog()
+                .assertTestSuiteResults( 2 );
+    }
+
+    @Test
+    public void testModulePathWithSpaces()
+            throws IOException
+    {
+        suffix = " with spaces";
+        assumeJava9()
+                .debugLogging()
+                .executeTest()
+                .verifyErrorFreeLog()
+                .assertTestSuiteResults( 2 );
+    }
+
+    @Override
+    protected String getProjectDirectoryName()
+    {
+        return "junit5-modulepath";
+    }
+
+    @Override
+    protected String getSuffix()
+    {
+        return suffix;
+    }
+}

--- a/surefire-its/src/test/resources/junit5-modulepath/pom.xml
+++ b/surefire-its/src/test/resources/junit5-modulepath/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>foo</groupId>
+    <artifactId>app</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <name>app</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>${java.specification.version}</maven.compiler.release>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.9.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/surefire-its/src/test/resources/junit5-modulepath/src/main/java/com/app/Main.java
+++ b/surefire-its/src/test/resources/junit5-modulepath/src/main/java/com/app/Main.java
@@ -1,0 +1,31 @@
+package com.app;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.joda.time.DateTime;
+
+public class Main
+{
+    public static void main( String... args )
+    {
+        DateTime dt = new DateTime();
+        System.out.println( dt );
+    }
+}

--- a/surefire-its/src/test/resources/junit5-modulepath/src/main/java/module-info.java
+++ b/surefire-its/src/test/resources/junit5-modulepath/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+module com.app {
+    requires joda.time;
+}

--- a/surefire-its/src/test/resources/junit5-modulepath/src/test/java/com/app/AppTest.java
+++ b/surefire-its/src/test/resources/junit5-modulepath/src/test/java/com/app/AppTest.java
@@ -1,0 +1,37 @@
+package com.app;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+public class AppTest
+{
+    @Test
+    void testNoop()
+            throws Exception
+    {
+    }
+
+    @Test
+    void testMain()
+    {
+        Main.main();
+    }
+}


### PR DESCRIPTION
This PR fixes : https://issues.apache.org/jira/browse/SUREFIRE-1909

We decided to go with the drop in replacement of `--add-exports` with `--add-opens`, as suggested in the issue.

To add to the background of this issue, a previous PR has been created, introducing the option to use either `add-exports` or `add-opens`, the PR is still accessible here : https://github.com/apache/maven-surefire/pull/461

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
