### PR TITLE
[SUREFIRE-2016] The MOJO parameter testSourceDirectory is used only in the TestNG HTML, and it should be optional. Javadoc and documentation should be fixed.

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -281,10 +281,11 @@ public abstract class AbstractSurefireMojo
 
     /**
      * The test source directory containing test class sources.
+     * Important <b>only</b> for TestNG HTML reports.
      *
      * @since 2.2
      */
-    @Parameter( defaultValue = "${project.build.testSourceDirectory}", required = true )
+    @Parameter( defaultValue = "${project.build.testSourceDirectory}" )
     private File testSourceDirectory;
 
     /**

--- a/maven-surefire-plugin/src/site/apt/examples/inclusion-exclusion.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/inclusion-exclusion.apt.vm
@@ -211,10 +211,10 @@ Inclusions and Exclusions of Tests
 
 * Tests from dependencies
 
-  By default, ${thisPlugin} will only scan for test classes to execute in the configured <<<testSourceDirectory>>>. To
-  have the plugin scan dependencies to find test classes to execute, use the <<<dependenciesToScan>>> configuration.
-  Dependencies can be specified using the <<<groupId[:artifactId[:type[:classifier][:version]]]>>> format, and must already
-  be <<<dependency>>> elements in scope.
+  In order to scan dependencies by the ${thisPlugin} plugin and find the test classes to execute in the dependencies,
+  use the MOJO parameter <<<dependenciesToScan>>> and configure it as necessary.
+  Dependencies can be specified using the <<<groupId[:artifactId[:type[:classifier][:version]]]>>> format, and must
+  already be <<<dependency>>> elements in scope.
   
   <Note:> Support for version, type and classifier was introduced in version <<<3.0.0-M4>>>. When using earlier versions,
   ${thisPlugin} will fail with an <<<IllegalArgumentException>>> if more than groupId and artifactId are specified.


### PR DESCRIPTION
The MOJO param `testSourceDirectory` is currently required.
It is maybe a history. But now this parameter has no real meaning. One of our users in SUREFIRE-2013 was confused with that and he thought that this param is used for some test filters. Not true because it is used only in the TestNG HTML reports and nowhere else.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
