### PR TITLE
Fix documentation: integration tests are in surefire-its now

### DIFF
--- a/maven-surefire-plugin/src/site/apt/developing.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/developing.apt.vm
@@ -44,11 +44,11 @@ Developer Center
   When reporting an issue, it is immensely useful to create a small sample project
   that demonstrates the problem. Surefire already contains a large number of such
   projects, and they can be found at
-  {{surefire-integration-tests/src/test/resources/}}.
+  {{surefire-its/src/test/resources/}}.
   Typically you can check out one of the pre-existing projects and run it like this:
 
 +---+
-  cd surefire-integration-tests/src/test/resources/failsafe-buildfail
+  cd surefire-its/src/test/resources/failsafe-buildfail
   mvn -Dsurefire.version=2.12 verify
 +---+
 
@@ -96,10 +96,10 @@ mvn -e -X install | grep Forking
 
   There are
   numerous other integration tests that all operate on small sample projects in
-  <<<surefire-integration-tests/src/test/resources>>>.
+  <<<surefire-its/src/test/resources>>>.
 
   Example integration tests are <<<Surefire141PluggableProvidersIT>>> and the corresponding
-  <<<surefire-integration-tests/src/test/resources/surefire-141-pluggableproviders>>>.
+  <<<surefire-its/src/test/resources/surefire-141-pluggableproviders>>>.
 
 * Essential Source Code Reading List
 


### PR DESCRIPTION
The folder `surefire-integration-tests` has been renamed to `surefire-its`. This should corrected in the documentation.

Since this is like a typo, I did not create a ticket.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).
To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)