### PR TITLE
Support junit-platform-runner and junit-platform-suite-engine in plugin dependencies

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -2385,7 +2385,8 @@ public abstract class AbstractSurefireMojo
 
     private Artifact getJUnit5Artifact()
     {
-        if ( getProjectArtifactMap().get( "org.junit.platform:junit-platform-runner" ) != null )
+        if ( getProjectArtifactMap().containsKey( "org.junit.platform:junit-platform-runner" )
+            || getPluginArtifactMap().containsKey( "org.junit.platform:junit-platform-runner" ) )
         {
             return null;
         }
@@ -2393,7 +2394,7 @@ public abstract class AbstractSurefireMojo
         Artifact artifact = getPluginArtifactMap().get( "org.junit.platform:junit-platform-engine" );
         if ( artifact == null )
         {
-            return getProjectArtifactMap().get( "org.junit.platform:junit-platform-commons" );
+            artifact = getProjectArtifactMap().get( "org.junit.platform:junit-platform-commons" );
         }
 
         return artifact;

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -775,6 +775,54 @@ public class AbstractSurefireMojoTest
     }
 
     @Test
+    public void shouldNotBeJunit5ArtifactInPluginDeps() throws Exception
+    {
+        Artifact testClasspathJupiter = new DefaultArtifact( "org.junit.jupiter", "junit-jupiter-engine",
+            createFromVersion( "5.4.0" ), null, "jar", null, mock( ArtifactHandler.class ) );
+
+        Artifact testClasspathPlatformEng = new DefaultArtifact( "org.junit.platform", "junit-platform-engine",
+            createFromVersion( "1.4.0" ), null, "jar", null, mock( ArtifactHandler.class ) );
+
+        Artifact testClasspathCommons = new DefaultArtifact( "org.junit.platform", "junit-platform-commons",
+            createFromVersion( "1.4.0" ), null, "jar", null, mock( ArtifactHandler.class ) );
+
+        setProjectDepedenciesToMojo( testClasspathJupiter, testClasspathPlatformEng, testClasspathCommons );
+
+        Artifact pluginDep1 = new DefaultArtifact( "org.junit.platform", "junit-platform-runner",
+            createFromVersion( "1.4.0" ), null, "jar", null, mock( ArtifactHandler.class ) );
+
+        Artifact pluginDep2 = new DefaultArtifact( "org.junit.platform", "junit-platform-commons",
+            createFromVersion( "1.4.0" ), null, "jar", null, mock( ArtifactHandler.class ) );
+
+        addPluginDependencies( pluginDep1, pluginDep2 );
+
+        Artifact junitPlatformArtifact = invokeMethod( mojo, "getJUnit5Artifact" );
+        assertThat( junitPlatformArtifact ).isNull();
+    }
+
+    @Test
+    public void shouldNotBeJunit5ArtifactInProjectDeps() throws Exception
+    {
+        Artifact testClasspathJupiter = new DefaultArtifact( "org.junit.jupiter", "junit-jupiter-engine",
+            createFromVersion( "5.4.0" ), null, "jar", null, mock( ArtifactHandler.class ) );
+
+        Artifact testClasspathPlatformEng = new DefaultArtifact( "org.junit.platform", "junit-platform-engine",
+            createFromVersion( "1.4.0" ), null, "jar", null, mock( ArtifactHandler.class ) );
+
+        Artifact testClasspathCommons = new DefaultArtifact( "org.junit.platform", "junit-platform-commons",
+            createFromVersion( "1.4.0" ), null, "jar", null, mock( ArtifactHandler.class ) );
+
+        Artifact testClasspathRunner = new DefaultArtifact( "org.junit.platform", "junit-platform-runner",
+            createFromVersion( "1.4.0" ), null, "jar", null, mock( ArtifactHandler.class ) );
+
+        setProjectDepedenciesToMojo( testClasspathJupiter, testClasspathPlatformEng, testClasspathCommons,
+            testClasspathRunner );
+
+        Artifact junitPlatformArtifact = invokeMethod( mojo, "getJUnit5Artifact" );
+        assertThat( junitPlatformArtifact ).isNull();
+    }
+
+    @Test
     public void shouldSmartlyResolveJUnit5ProviderWithJUnit4() throws Exception
     {
         MavenProject mavenProject = new MavenProject();

--- a/maven-surefire-plugin/src/site/apt/examples/junit-platform.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/junit-platform.apt.vm
@@ -411,6 +411,53 @@ Using JUnit 5 Platform
 </dependencies>
 +---+
 
+** JUnit5 Suite
+
+  For more information see this
+  {{{https://github.com/apache/maven-surefire/tree/master/surefire-its/src/test/resources/junit5-suite}example}}.
+
++---+
+<dependencies>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.8.0</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite-api</artifactId>
+        <version>1.8.0</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <includes>
+                    <include>JUnit5Tests</include>
+                </includes>
+            </configuration>
+            <dependencies>
+                <dependency>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-engine</artifactId>
+                    <version>5.8.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-suite-engine</artifactId>
+                    <version>1.8.2</version>
+                </dependency>
+            </dependencies>
+        </plugin>
+    </plugins>
+</build>
++---+
+
 * Provider Selection
 
    If nothing is configured, Surefire detects which JUnit version to use by the following algorithm:

--- a/maven-surefire-plugin/src/site/apt/examples/junit-platform.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/junit-platform.apt.vm
@@ -420,14 +420,14 @@ Using JUnit 5 Platform
 <dependencies>
     <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>5.8.0</version>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.8.2</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-suite-api</artifactId>
-        <version>1.8.0</version>
+        <artifactId>junit-platform-suite-engine</artifactId>
+        <version>1.8.2</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
@@ -441,18 +441,6 @@ Using JUnit 5 Platform
                     <include>JUnit5Tests</include>
                 </includes>
             </configuration>
-            <dependencies>
-                <dependency>
-                    <groupId>org.junit.jupiter</groupId>
-                    <artifactId>junit-jupiter-engine</artifactId>
-                    <version>5.8.2</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.junit.platform</groupId>
-                    <artifactId>junit-platform-suite-engine</artifactId>
-                    <version>1.8.2</version>
-                </dependency>
-            </dependencies>
         </plugin>
     </plugins>
 </build>

--- a/maven-surefire-plugin/src/site/apt/examples/junit-platform.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/junit-platform.apt.vm
@@ -414,7 +414,8 @@ Using JUnit 5 Platform
 ** JUnit5 Suite
 
   For more information see this
-  {{{https://github.com/apache/maven-surefire/tree/master/surefire-its/src/test/resources/junit5-suite}example}}.
+  {{{https://github.com/apache/maven-surefire/tree/master/surefire-its/src/test/resources/junit5-suite}example}}
+  and the {{{https://junit.org/junit5/docs/current/user-guide/#junit-platform-suite-engine}tutorial}}.
 
 +---+
 <dependencies>

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
@@ -77,13 +77,14 @@ public class JUnitPlatformEnginesIT extends SurefireJUnit4IntegrationTestCase
     {
         ArrayList<Object[]> args = new ArrayList<>();
         args.add( new Object[] {"1.0.3", "5.0.3", "1.0.0", "1.0.0"} );
-        args.add( new Object[] {"1.1.1", "5.1.1", "1.0.0", "1.0.0"} );
-        args.add( new Object[] {"1.2.0", "5.2.0", "1.1.0", "1.0.0"} );
+        //args.add( new Object[] {"1.1.1", "5.1.1", "1.0.0", "1.0.0"} );
+        //args.add( new Object[] {"1.2.0", "5.2.0", "1.1.0", "1.0.0"} );
         args.add( new Object[] {"1.3.2", "5.3.2", "1.1.1", "1.0.0"} );
-        args.add( new Object[] {"1.4.2", "5.4.2", "1.1.1", "1.0.0"} );
-        args.add( new Object[] {"1.5.2", "5.5.2", "1.2.0", "1.1.0"} );
+        //args.add( new Object[] {"1.4.2", "5.4.2", "1.1.1", "1.0.0"} );
+        //args.add( new Object[] {"1.5.2", "5.5.2", "1.2.0", "1.1.0"} );
         args.add( new Object[] {"1.6.2", "5.6.2", "1.2.0", "1.1.0"} );
-        //args.add( new Object[] { "1.6.0-SNAPSHOT", "5.6.0-SNAPSHOT", "1.2.0", "1.1.0" } );
+        //args.add( new Object[] {"1.7.2", "5.7.2", "1.2.0", "1.1.0"} );
+        args.add( new Object[] {"1.8.2", "5.8.2", "1.2.0", "1.1.2"} );
         return args;
     }
 

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
@@ -77,13 +77,8 @@ public class JUnitPlatformEnginesIT extends SurefireJUnit4IntegrationTestCase
     {
         ArrayList<Object[]> args = new ArrayList<>();
         args.add( new Object[] {"1.0.3", "5.0.3", "1.0.0", "1.0.0"} );
-        //args.add( new Object[] {"1.1.1", "5.1.1", "1.0.0", "1.0.0"} );
-        //args.add( new Object[] {"1.2.0", "5.2.0", "1.1.0", "1.0.0"} );
         args.add( new Object[] {"1.3.2", "5.3.2", "1.1.1", "1.0.0"} );
-        //args.add( new Object[] {"1.4.2", "5.4.2", "1.1.1", "1.0.0"} );
-        //args.add( new Object[] {"1.5.2", "5.5.2", "1.2.0", "1.1.0"} );
         args.add( new Object[] {"1.6.2", "5.6.2", "1.2.0", "1.1.0"} );
-        //args.add( new Object[] {"1.7.2", "5.7.2", "1.2.0", "1.1.0"} );
         args.add( new Object[] {"1.8.2", "5.8.2", "1.2.0", "1.1.2"} );
         return args;
     }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1787JUnit5IT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1787JUnit5IT.java
@@ -129,4 +129,15 @@ public class Surefire1787JUnit5IT extends SurefireJUnit4IntegrationTestCase
             .verifyTextInLog( "Running pkg.JUnit5Tests" )
             .verifyTextInLog( "Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider" );
     }
+
+    @Test
+    public void junit5Suite()
+    {
+        unpack( "junit5-suite" )
+            .executeTest()
+            .verifyErrorFree( 1 )
+            .verifyTextInLog( "Running pkg.JUnit5Test" )
+            .verifyTextInLog(
+                "Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider" );
+    }
 }

--- a/surefire-its/src/test/resources/junit5-runner/pom.xml
+++ b/surefire-its/src/test/resources/junit5-runner/pom.xml
@@ -37,13 +37,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.2</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
-            <version>1.6.2</version>
+            <version>1.8.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/surefire-its/src/test/resources/junit5-suite/pom.xml
+++ b/surefire-its/src/test/resources/junit5-suite/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>junit5-suite</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+    <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.8.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite-api</artifactId>
+      <version>1.8.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${surefire.version}</version>
+          <configuration>
+            <includes>
+              <include>JUnit5Tests</include>
+            </includes>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.junit.jupiter</groupId>
+              <artifactId>junit-jupiter-engine</artifactId>
+              <version>5.8.2</version>
+            </dependency>
+            <dependency>
+              <groupId>org.junit.platform</groupId>
+              <artifactId>junit-platform-suite-engine</artifactId>
+              <version>1.8.2</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/surefire-its/src/test/resources/junit5-suite/src/test/java/pkg/JUnit5Tests.java
+++ b/surefire-its/src/test/resources/junit5-suite/src/test/java/pkg/JUnit5Tests.java
@@ -1,0 +1,29 @@
+package pkg;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({pkg.domain.AxTest.class})
+public class JUnit5Tests
+{
+}

--- a/surefire-its/src/test/resources/junit5-suite/src/test/java/pkg/domain/AxTest.java
+++ b/surefire-its/src/test/resources/junit5-suite/src/test/java/pkg/domain/AxTest.java
@@ -1,0 +1,30 @@
+package pkg.domain;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+public class AxTest
+{
+    @Test
+    void test()
+    {
+    }
+}

--- a/surefire-its/src/test/resources/junit5-suite/src/test/java/pkg/domain/BxTest.java
+++ b/surefire-its/src/test/resources/junit5-suite/src/test/java/pkg/domain/BxTest.java
@@ -1,0 +1,30 @@
+package pkg.domain;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+public class BxTest
+{
+    @Test
+    void test()
+    {
+    }
+}


### PR DESCRIPTION
The plugin does not have a real problem with the class path as we expected in the Jira issue SUREFIRE-2000.
I found this PR as an improvement where the `junit-platform-runner` can be in the plugin dependencies. The previous implementation expected `junit-platform-runner` only in the project dependencies. Additionally, we added `junit-platform-suite-engine` as a successor of `junit-platform-runner` in the documentation and IT.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
