### PR TITLE
[SUREFIRE-2036] Fix JUnit 5 with configured provider

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1181,7 +1181,7 @@ public abstract class AbstractSurefireMojo
     {
         Artifact junitDepArtifact = getJunitDepArtifact();
         return providerDetector.resolve( new DynamicProviderInfo( null ),
-            new JUnitPlatformProviderInfo( getJUnit5Artifact(), testClasspath ),
+            new JUnitPlatformProviderInfo( getJUnitPlatformRunnerArtifact(), getJUnit5Artifact(), testClasspath ),
             new TestNgProviderInfo( getTestNgArtifact() ),
             new JUnitCoreProviderInfo( getJunitArtifact(), junitDepArtifact ),
             new JUnit4ProviderInfo( getJunitArtifact(), junitDepArtifact ),
@@ -2413,13 +2413,13 @@ public abstract class AbstractSurefireMojo
         return getProjectArtifactMap().get( "junit:junit-dep" );
     }
 
+    private Artifact getJUnitPlatformRunnerArtifact()
+    {
+        return getProjectArtifactMap().get( "org.junit.platform:junit-platform-runner" );
+    }
+
     private Artifact getJUnit5Artifact()
     {
-        if ( getProjectArtifactMap().get( "org.junit.platform:junit-platform-runner" ) != null )
-        {
-            return null;
-        }
-
         Artifact artifact = getPluginArtifactMap().get( "org.junit.platform:junit-platform-engine" );
         if ( artifact == null )
         {
@@ -3252,11 +3252,14 @@ public abstract class AbstractSurefireMojo
         private static final String PROVIDER_DEP_GID = "org.junit.platform";
         private static final String PROVIDER_DEP_AID = "junit-platform-launcher";
 
+        private final Artifact junitPlatformRunnerArtifact;
         private final Artifact junitPlatformArtifact;
         private final TestClassPath testClasspath;
 
-        JUnitPlatformProviderInfo( Artifact junitPlatformArtifact, @Nonnull TestClassPath testClasspath )
+        JUnitPlatformProviderInfo( Artifact junitPlatformRunnerArtifact, Artifact junitPlatformArtifact,
+                                   @Nonnull TestClassPath testClasspath )
         {
+            this.junitPlatformRunnerArtifact = junitPlatformRunnerArtifact;
             this.junitPlatformArtifact = junitPlatformArtifact;
             this.testClasspath = testClasspath;
         }
@@ -3271,7 +3274,7 @@ public abstract class AbstractSurefireMojo
         @Override
         public boolean isApplicable()
         {
-            return junitPlatformArtifact != null;
+            return junitPlatformRunnerArtifact == null && junitPlatformArtifact != null;
         }
 
         @Override

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
@@ -531,7 +531,7 @@ public class AbstractSurefireMojoJava7PlusTest
 
         ProviderInfo newJUnitPlatformProviderInfo()
         {
-            return new JUnitPlatformProviderInfo( null, null );
+            return new JUnitPlatformProviderInfo( null, null, null );
         }
 
         @Override

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -2004,7 +2004,7 @@ public class AbstractSurefireMojoTest
         private JUnitPlatformProviderInfo createJUnitPlatformProviderInfo( Artifact junitPlatformArtifact,
                                                                            TestClassPath testClasspathWrapper )
         {
-            return new JUnitPlatformProviderInfo( junitPlatformArtifact, testClasspathWrapper );
+            return new JUnitPlatformProviderInfo( null, junitPlatformArtifact, testClasspathWrapper );
         }
 
         void setProjectTestArtifacts( List<Artifact> projectTestArtifacts )

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire2036IT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire2036IT.java
@@ -1,0 +1,41 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
+
+/**
+ * Integration Tests for SUREFIRE-2036
+ */
+@SuppressWarnings( "checkstyle:magicnumber" )
+public class Surefire2036IT extends SurefireJUnit4IntegrationTestCase
+{
+    @Test
+    public void selectJUnit5UsingConfiguredProviderWithPlatformRunner()
+    {
+        unpack( "surefire-2036" )
+            .executeTest()
+            .verifyErrorFree( 1 )
+            .verifyTextInLog( "Running pkg.JUnit5Test" )
+            .verifyTextInLog(
+                "Using configured provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider" );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2036/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2036/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>surefire-2036</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+        <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+            <version>1.6.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+              <version>${surefire.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${surefire.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-2036/src/test/java/pkg/JUnit4Test.java
+++ b/surefire-its/src/test/resources/surefire-2036/src/test/java/pkg/JUnit4Test.java
@@ -1,0 +1,10 @@
+package pkg;
+
+import org.junit.Test;
+
+public class JUnit4Test {
+    @Test
+    public void test() {
+
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2036/src/test/java/pkg/JUnit5Test.java
+++ b/surefire-its/src/test/resources/surefire-2036/src/test/java/pkg/JUnit5Test.java
@@ -1,0 +1,10 @@
+package pkg;
+
+import org.junit.jupiter.api.Test;
+
+class JUnit5Test {
+    @Test
+    public void test() {
+
+    }
+}


### PR DESCRIPTION
Modified getJUnit5Artifact() to care _only_ about JUnit 5 artifacts
Added getJUnitPlatformRunnerArtifact() to care about the JUnit Platform Runner artifact
JUnitPlatformProviderInfo is enabled by default based on a combination of above

Avoids NullPointerException when explicitly configured provider needs to know the available JUnit5 artifact

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
