### PR TITLE
Tests runorder

### DIFF
--- a/surefire-providers/surefire-junit4/src/test/java/org/apache/maven/surefire/junit4/JUnit4ProviderOrderingTest.java
+++ b/surefire-providers/surefire-junit4/src/test/java/org/apache/maven/surefire/junit4/JUnit4ProviderOrderingTest.java
@@ -1,0 +1,143 @@
+package org.apache.maven.surefire.junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.api.booter.BaseProviderFactory;
+import org.apache.maven.surefire.api.report.ReporterFactory;
+import org.apache.maven.surefire.api.report.TestOutputReportEntry;
+import org.apache.maven.surefire.api.report.TestReportListener;
+import org.apache.maven.surefire.api.suite.RunResult;
+import org.apache.maven.surefire.api.testset.RunOrderParameters;
+import org.apache.maven.surefire.api.testset.TestListResolver;
+import org.apache.maven.surefire.api.testset.TestRequest;
+import org.apache.maven.surefire.api.testset.TestSetFailedException;
+import org.apache.maven.surefire.api.util.TestsToRun;
+import org.junit.Test;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * @author Aslak Hellesøy
+ */
+public class JUnit4ProviderOrderingTest
+{
+    /**
+     */
+    public static class TestX
+    {
+        @Test
+        public void testA()
+        {
+        }
+
+        @Test
+        public void testB()
+        {
+        }
+
+        @Test
+        public void testC()
+        {
+        }
+    }
+
+    /**
+     */
+    public static class TestY
+    {
+        @Test
+        public void testD()
+        {
+        }
+
+        @Test
+        public void testE()
+        {
+        }
+
+        @Test
+        public void testF()
+        {
+        }
+
+    }
+
+    @Test
+    public void testShouldOrderWithinSingleTestClass() throws TestSetFailedException
+    {
+        assertTestOrder(
+            TestX.class.getName() + "#testC",
+            TestX.class.getName() + "#testA",
+            TestX.class.getName() + "#testB"
+        );
+    }
+
+    private void assertTestOrder( String... tests ) throws TestSetFailedException
+    {
+        List<String> testOrder = asList( tests );
+        BaseProviderFactory providerParameters = new BaseProviderFactory( true );
+        providerParameters.setProviderProperties( new HashMap<>() );
+        providerParameters.setClassLoaders( getClass().getClassLoader() );
+        TestListResolver requestedTests = new TestListResolver( String.join( ",", testOrder ) );
+        TestRequest testRequest = new TestRequest( null, null, requestedTests );
+        providerParameters.setTestRequest( testRequest );
+        providerParameters.setRunOrderParameters( RunOrderParameters.alphabetical() );
+
+        MockReporter testReportListener = new MockReporter();
+        providerParameters.setReporterFactory( new StubReporterFactory( testReportListener ) );
+        JUnit4Provider provider = new JUnit4Provider( providerParameters );
+        TestsToRun testsToRun = new TestsToRun( new HashSet<>( asList( TestX.class, TestY.class ) ) );
+        provider.invoke( testsToRun );
+
+        List<String> actualOrder = testReportListener.getReports().stream()
+            .map( r -> String.format( "%s#%s", r.getSourceName(), r.getName() ) )
+            .collect( Collectors.toList() );
+
+        assertThat( actualOrder, is( testOrder ) );
+    }
+
+    private static class StubReporterFactory implements ReporterFactory
+    {
+        private final TestReportListener<TestOutputReportEntry> testReportListener;
+
+        private StubReporterFactory( TestReportListener<TestOutputReportEntry> testReportListener )
+        {
+            this.testReportListener = testReportListener;
+        }
+
+        @Override
+        public TestReportListener<TestOutputReportEntry> createTestReportListener()
+        {
+            return testReportListener;
+        }
+
+        @Override
+        public RunResult close()
+        {
+            return null;
+        }
+    }
+}

--- a/surefire-providers/surefire-junit4/src/test/java/org/apache/maven/surefire/junit4/JUnit4ProviderOrderingTest.java
+++ b/surefire-providers/surefire-junit4/src/test/java/org/apache/maven/surefire/junit4/JUnit4ProviderOrderingTest.java
@@ -29,6 +29,7 @@ import org.apache.maven.surefire.api.testset.TestListResolver;
 import org.apache.maven.surefire.api.testset.TestRequest;
 import org.apache.maven.surefire.api.testset.TestSetFailedException;
 import org.apache.maven.surefire.api.util.TestsToRun;
+import org.junit.Ignore;
 import org.junit.Test;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -92,6 +93,20 @@ public class JUnit4ProviderOrderingTest
             TestX.class.getName() + "#testC",
             TestX.class.getName() + "#testA",
             TestX.class.getName() + "#testB"
+        );
+    }
+
+    @Test
+    @Ignore( "this is currently not possible" )
+    public void testShouldOrderWithinInterleavedTestClasses() throws TestSetFailedException
+    {
+        assertTestOrder(
+            TestX.class.getName() + "#testC",
+            TestY.class.getName() + "#testE",
+            TestX.class.getName() + "#testA",
+            TestY.class.getName() + "#testD",
+            TestX.class.getName() + "#testB",
+            TestY.class.getName() + "#testF"
         );
     }
 

--- a/surefire-providers/surefire-junit4/src/test/java/org/apache/maven/surefire/junit4/JUnit4SuiteTest.java
+++ b/surefire-providers/surefire-junit4/src/test/java/org/apache/maven/surefire/junit4/JUnit4SuiteTest.java
@@ -22,6 +22,7 @@ package org.apache.maven.surefire.junit4;
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
 import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Adapt the JUnit4 tests which use only annotations to the JUnit3 test suite.
@@ -30,6 +31,9 @@ public class JUnit4SuiteTest extends TestCase
 {
     public static Test suite()
     {
-        return new JUnit4TestAdapter( JUnit4ProviderTest.class );
+        TestSuite testSuite = new TestSuite();
+        testSuite.addTest( new JUnit4TestAdapter( JUnit4ProviderTest.class ) );
+        testSuite.addTest( new JUnit4TestAdapter( JUnit4ProviderOrderingTest.class ) );
+        return testSuite;
     }
 }

--- a/surefire-providers/surefire-junit4/src/test/java/org/apache/maven/surefire/junit4/MockReporter.java
+++ b/surefire-providers/surefire-junit4/src/test/java/org/apache/maven/surefire/junit4/MockReporter.java
@@ -1,0 +1,147 @@
+package org.apache.maven.surefire.junit4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.TestOutputReportEntry;
+import org.apache.maven.surefire.api.report.TestReportListener;
+import org.apache.maven.surefire.api.report.TestSetReportEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Internal tests use only.
+ */
+final class MockReporter
+        implements TestReportListener<TestOutputReportEntry>
+{
+    private final List<ReportEntry> reports = new ArrayList<>();
+
+    @Override
+    public void testSetStarting( TestSetReportEntry report )
+    {
+    }
+
+    @Override
+    public void testSetCompleted( TestSetReportEntry report )
+    {
+    }
+
+    @Override
+    public void testStarting( ReportEntry report )
+    {
+        reports.add( report );
+    }
+
+    @Override
+    public void testSucceeded( ReportEntry report )
+    {
+    }
+
+    @Override
+    public void testSkipped( ReportEntry report )
+    {
+    }
+
+    @Override
+    public void testExecutionSkippedByUser()
+    {
+    }
+
+    @Override
+    public void testError( ReportEntry report )
+    {
+    }
+
+    @Override
+    public void testFailed( ReportEntry report )
+    {
+    }
+
+    @Override
+    public void testAssumptionFailure( ReportEntry report )
+    {
+    }
+
+    @Override
+    public void writeTestOutput( TestOutputReportEntry reportEntry )
+    {
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return false;
+    }
+
+    @Override
+    public void debug( String message )
+    {
+    }
+
+    @Override
+    public boolean isInfoEnabled()
+    {
+        return false;
+    }
+
+    @Override
+    public void info( String message )
+    {
+    }
+
+    @Override
+    public boolean isWarnEnabled()
+    {
+        return false;
+    }
+
+    @Override
+    public void warning( String message )
+    {
+    }
+
+    @Override
+    public boolean isErrorEnabled()
+    {
+        return false;
+    }
+
+    @Override
+    public void error( String message )
+    {
+    }
+
+    @Override
+    public void error( String message, Throwable t )
+    {
+    }
+
+    @Override
+    public void error( Throwable t )
+    {
+    }
+
+    public List<ReportEntry> getReports()
+    {
+        return reports;
+    }
+}


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

----

This is a proof of concept of an alternative implementation to #348 (currently only for JUnit 4).

I considered the suggestions by @Tibor17 to do serialization/deserialization of the run config, but from what I can tell this is already handled. I can access the `-Dtest=` value in `testResolver.getIncludedPatterns()`.

I've added two tests. The one that is ignored illustrates what I would like to achieve: Run test methods in a specific order without having to group the executions by class. Any suggestions how we might achieve that?

A bit of context - I'm working on a *test case prioritization* tool that may suggest ordering test methods in any order. I believe you're also working on something like this @winglam?
