### PR TITLE
[SUREFIRE-2051] Propagate exceptions while resolving artifacts in `SurefireDependencyResolver`

### DIFF
--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -44,6 +44,7 @@ import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.DefaultResolutionErrorHandler;
 import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
@@ -157,6 +158,7 @@ public class AbstractSurefireMojoTest
         plugin.setVersion( mojoArtifact.getVersion() );
         when( pluginDescriptor.getPlugin() ).thenReturn( plugin );
         mojo.setPluginDescriptor( pluginDescriptor );
+        mojo.setResolutionErrorHandler( new DefaultResolutionErrorHandler() );
     }
 
     @Test


### PR DESCRIPTION
Surefire doesn't propagate the exception during artifact resolution, and then later, it fails with a `NullPointerException` when it needs to access the artifact (in `AbstractSurefireMojo.java#L4125` or `SurefireDependencyResolver.java#L203`). This makes harder to understand the underlying issue. This change uses `ResolutionErrorHandler` to propagate the actual issue.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)