### PR TITLE
[SUREFIRE-2055] Always show random seed

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -3114,9 +3114,12 @@ public abstract class AbstractSurefireMojo
 
     private void printDefaultSeedIfNecessary()
     {
-        if ( getRunOrderRandomSeed() == null && getRunOrder().equals( RunOrder.RANDOM.name() ) )
+        if ( getRunOrder().equals( RunOrder.RANDOM.name() ) )
         {
-            setRunOrderRandomSeed( System.nanoTime() );
+            if ( getRunOrderRandomSeed() == null )
+            {
+                setRunOrderRandomSeed( System.nanoTime() );
+            }
             getConsoleLogger().info(
                 "Tests will run in random order. To reproduce ordering use flag -D"
                     + getPluginName() + ".runOrder.random.seed=" + getRunOrderRandomSeed() );

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/DefaultRunOrderCalculator.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/DefaultRunOrderCalculator.java
@@ -55,7 +55,7 @@ public class DefaultRunOrderCalculator
         this.runOrder = runOrderParameters.getRunOrder();
         this.sortOrder = this.runOrder.length > 0 ? getSortOrderComparator( this.runOrder[0] ) : null;
         Long runOrderRandomSeed = runOrderParameters.getRunOrderRandomSeed();
-        random = runOrderRandomSeed == null ? null : new Random( runOrderRandomSeed );
+        random = new Random( runOrderRandomSeed == null ? System.nanoTime() : runOrderRandomSeed );
     }
 
     @Override

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/DefaultRunOrderCalculator.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/DefaultRunOrderCalculator.java
@@ -55,7 +55,7 @@ public class DefaultRunOrderCalculator
         this.runOrder = runOrderParameters.getRunOrder();
         this.sortOrder = this.runOrder.length > 0 ? getSortOrderComparator( this.runOrder[0] ) : null;
         Long runOrderRandomSeed = runOrderParameters.getRunOrderRandomSeed();
-        this.random = new Random( runOrderRandomSeed == null ? System.nanoTime() : runOrderRandomSeed );
+        random = runOrderRandomSeed == null ? null : new Random( runOrderRandomSeed );
     }
 
     @Override

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
@@ -97,7 +97,21 @@ public class RunOrderIT
             }
         }
     }
-    
+
+    @Test
+    public void testRandomJUnit4PrintSeedWithGivenSeed()
+    {
+        OutputValidator validator = executeWithRandomOrder( "junit4", 0L );
+        validator.verifyTextInLog( "To reproduce ordering use flag" );
+    }
+
+    @Test
+    public void testRandomJUnit4PrintSeedWithNoGivenSeed()
+    {
+        OutputValidator validator = executeWithRandomOrder( "junit4" );
+        validator.verifyTextInLog( "To reproduce ordering use flag" );
+    }
+
     @Test
     public void testReverseAlphabeticalJUnit4()
         throws Exception
@@ -183,6 +197,16 @@ public class RunOrderIT
             .activateProfile( profile )
             .forkMode( getForkMode() )
             .runOrder( runOrder )
+            .executeTest()
+            .verifyErrorFree( 3 );
+    }
+
+    private OutputValidator executeWithRandomOrder( String profile )
+    {
+        return unpack()
+            .activateProfile( profile )
+            .forkMode( getForkMode() )
+            .runOrder( "random" )
             .executeTest()
             .verifyErrorFree( 3 );
     }


### PR DESCRIPTION
Always show the random seed when using the random runOrder. This is so tests that fail because of their runOrder can be replayed without necessarily knowing the build command.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).