### PR TITLE
[SUREFIRE-2058] Corrupted STDOUT by directly writing to native stream in forked JVM 1 with UTF-8 console logging

### DIFF
--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoder.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoder.java
@@ -326,11 +326,8 @@ public abstract class AbstractStreamDecoder<M, MT extends Enum<MT>, ST extends E
             }
             while ( isLastChunk && bytesToDecode > 0 && output.hasRemaining() );
 
-            if ( isLastChunk || !output.hasRemaining() )
-            {
-                strings.add( ( (Buffer) output ).flip().toString() );
-                ( (Buffer) output ).clear();
-            }
+            strings.add( ( (Buffer) output ).flip().toString() );
+            ( (Buffer) output ).clear();
         }
 
         memento.getDecoder().reset();

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoderTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoderTest.java
@@ -29,7 +29,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.CharsetDecoder;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +50,7 @@ import static java.nio.charset.CodingErrorAction.REPLACE;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.apache.maven.surefire.api.booter.Constants.DEFAULT_STREAM_ENCODING;
 import static org.apache.maven.surefire.api.booter.ForkedProcessEventType.BOOTERCODE_STDOUT;
@@ -196,8 +196,7 @@ public class AbstractStreamDecoderTest
     {
         Channel channel = new Channel( new byte[] {0x01, 0x02, 0x03, 0x04, ':'}, 1 );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
 
@@ -210,8 +209,7 @@ public class AbstractStreamDecoderTest
     {
         Channel channel = new Channel( new byte[] {(byte) 0xff, 0x01, 0x02, 0x03, 0x04, ':'}, 1 );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         assertThat( thread.readInteger( memento ) )
@@ -223,8 +221,7 @@ public class AbstractStreamDecoderTest
     {
         Channel channel = new Channel( new byte[] {(byte) 0x00, ':'}, 1 );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         assertThat( thread.readInteger( memento ) )
@@ -237,8 +234,7 @@ public class AbstractStreamDecoderTest
         Channel channel = new Channel( PATTERN1.getBytes(), PATTERN1.length() );
         channel.read( ByteBuffer.allocate( 100 ) );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         invokeMethod( thread, "readString", memento, 10 );
@@ -249,8 +245,7 @@ public class AbstractStreamDecoderTest
     {
         Channel channel = new Channel( PATTERN1.getBytes(), PATTERN1.length() );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         String s = invokeMethod( thread, "readString", memento, 10 );
@@ -271,8 +266,7 @@ public class AbstractStreamDecoderTest
 
         Channel channel = new Channel( s.toString().getBytes( UTF_8 ), s.length() );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
 
@@ -296,8 +290,7 @@ public class AbstractStreamDecoderTest
 
         Channel channel = new Channel( s.toString().getBytes( UTF_8 ), s.length() );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
 
@@ -319,8 +312,7 @@ public class AbstractStreamDecoderTest
 
         Channel channel = new Channel( s.toString().getBytes( UTF_8 ), s.length() );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         // whatever position will be compacted to 0
@@ -341,8 +333,7 @@ public class AbstractStreamDecoderTest
         Channel channel = new Channel( s.toString().getBytes( UTF_8 ), s.length() );
         channel.read( ByteBuffer.allocate( 997 ) );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         assertThat( (String) invokeMethod( thread, "readString", memento, PATTERN1.length() ) )
@@ -362,8 +353,7 @@ public class AbstractStreamDecoderTest
         Channel channel = new Channel( s.toString().getBytes( UTF_8 ), s.length() );
         channel.read( ByteBuffer.allocate( 1997 ) );
 
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         // whatever position will be compacted to 0
@@ -391,8 +381,7 @@ public class AbstractStreamDecoderTest
         }
 
         Channel channel = new Channel( input, 64 * 1024 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
         Memento memento = thread.new Memento();
         String decodedOutput = invokeMethod( thread, "readString", memento, input.length );
 
@@ -466,8 +455,7 @@ public class AbstractStreamDecoderTest
     {
         byte[] stream = ":xxxxx-xxxxxxxx-xxxxx:\u000E:xxx".getBytes( UTF_8 );
         Channel channel = new Channel( stream, 1 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         memento.setCharset( UTF_8 );
@@ -479,8 +467,7 @@ public class AbstractStreamDecoderTest
     {
         byte[] stream = "\u0000\u0000\u0000\u0000::".getBytes( UTF_8 );
         Channel channel = new Channel( stream, 1 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         memento.setCharset( UTF_8 );
@@ -494,8 +481,7 @@ public class AbstractStreamDecoderTest
     {
         byte[] stream = "\u0000\u0000\u0000\u0001:\u0000:".getBytes( UTF_8 );
         Channel channel = new Channel( stream, 1 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         memento.setCharset( UTF_8 );
@@ -509,8 +495,7 @@ public class AbstractStreamDecoderTest
     {
         byte[] stream = "\u0000\u0000\u0000\u0001:A:".getBytes( UTF_8 );
         Channel channel = new Channel( stream, 1 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         memento.setCharset( UTF_8 );
@@ -524,8 +509,7 @@ public class AbstractStreamDecoderTest
     {
         byte[] stream = "\u0000\u0000\u0000\u0003:ABC:".getBytes( UTF_8 );
         Channel channel = new Channel( stream, 1 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         memento.setCharset( UTF_8 );
@@ -539,8 +523,7 @@ public class AbstractStreamDecoderTest
     {
         byte[] stream = "\u0005:UTF-8:".getBytes( US_ASCII );
         Channel channel = new Channel( stream, 1 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         memento.setCharset( UTF_8 );
@@ -555,8 +538,7 @@ public class AbstractStreamDecoderTest
     {
         byte[] stream = ( (char) 10 + ":ISO_8859_1:" ).getBytes( US_ASCII );
         Channel channel = new Channel( stream, 1 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         memento.setCharset( UTF_8 );
@@ -571,10 +553,9 @@ public class AbstractStreamDecoderTest
     {
         byte[] stream = {};
         Channel channel = new Channel( stream, 1 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
-        Memento memento = thread.new Memento();
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
+        Memento memento = thread.new Memento();
         memento.setCharset( ISO_8859_1 );
         assertThat( memento.getDecoder().charset() ).isEqualTo( ISO_8859_1 );
 
@@ -591,8 +572,7 @@ public class AbstractStreamDecoderTest
     {
         byte[] stream = ( (char) 8 + ":ISO_8859:" ).getBytes( US_ASCII );
         Channel channel = new Channel( stream, 1 );
-        Mock thread = new Mock( channel, new MockForkNodeArguments(),
-            Collections.<Segment, ForkedProcessEventType>emptyMap() );
+        Mock thread = new Mock( channel, new MockForkNodeArguments(), emptyMap() );
 
         Memento memento = thread.new Memento();
         memento.setCharset( UTF_8 );


### PR DESCRIPTION
Two cases are covered here:
* Test run swallowing some of the outputs and finishing with the following warning:
  ```
  [WARNING] Corrupted channel by directly writing to native stream in forked JVM 1. 
  ```
* Test run getting completely stuck

Both cases are caused by the same issue, output buffer overflow in [AbstractStreamDecoder#readString(Memento, int)](https://github.com/apache/maven-surefire/blob/master/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoder.java#L302), because output char buffer is not cleared if it's not completely full.

Added unit tests:
* AbstractStreamDecoderTest#shouldReadStringOverflowOnNewLine:
  Input buffer of 1026 bytes: 1023 x 1-byte + 1 x 2-bytes encoded character + new line (LF). 
  * In first iteration it decodes the first 1023 bytes from the input buffer without clearing the output buffer. 
  * In second iteration `decodeString` returns an overflow, but it still force reads the 2-byte encoded character from input to output. `readString` ends up with 1 remaining byte (LF) on input buffer causing channel to become corrupted.
* AbstractStreamDecoderTest#shouldReadStringOverflowOn4BytesEncodedSymbol:
  Input buffer of 1027 bytes: 1023 x 1 byte + 1 x 4-bytes encoded characters. 
  * In first iteration it decodes the first 1023 bytes from the input buffer without clearing the output buffer. 
  * In second iteration `decodeString` returns an overflow, without reading anything from input buffer. This is causing an infinite loop in `readString`, it never exits.

Tested locally with some private projects. In one of the project 1k corrupted channel messages on M6, 0 wtih these changes. Also tried just just printing out a ton of messages generated using RandomStringUtils#random.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
