### PR TITLE
How about turning off the default build reports generation feature

### DIFF
--- a/surefire-its/src/test/resources/reporters/pom.xml
+++ b/surefire-its/src/test/resources/reporters/pom.xml
@@ -24,7 +24,7 @@
            <artifactId>maven-surefire-plugin</artifactId>
            <version>${surefire.version}</version>
            <configuration>
-             <disableXmlReport>false</disableXmlReport>
+             <disableXmlReport>true</disableXmlReport>
              <forkMode>${forkMode}</forkMode>
              <printSummary>${printSummary}</printSummary>
              <useFile>true</useFile>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
