### PR TITLE
[SUREFIRE-2076] BufferOverflowException when encoding message with null runMode

### DIFF
--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoder.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoder.java
@@ -181,11 +181,8 @@ public abstract class AbstractStreamEncoder<E extends Enum<E>>
         // one byte + one delimiter character ':' + <string> + one delimiter character ':'
         int lengthOfMetadata = 1 + getEncodedMagicNumber().length + 1 + 1 + 1 + opcodeLength + 1;
 
-        if ( runMode != null )
-        {
-            // one byte of length + one delimiter character ':' + <string> + one delimiter character ':'
-            lengthOfMetadata += 1 + 1 + runMode.getRunmode().length() + 1;
-        }
+        // one byte of length + one delimiter character ':' + <string> + one delimiter character ':'
+        lengthOfMetadata += 1 + 1 + ( runMode == null ? 0 : runMode.getRunmodeBinary().length ) + 1;
 
         if ( encoder != null )
         {

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoderTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoderTest.java
@@ -134,45 +134,45 @@ public class AbstractStreamEncoderTest
             NORMAL_RUN, encoder, 0, 1, "s" ) )
             .isEqualTo( 88 );
 
-        // :maven-surefire-event:16:console-info-log:5:UTF-8:0003:sss:
+        // :maven-surefire-event:16:console-info-log:0::5:UTF-8:0001:s:
         assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_CONSOLE_INFO.getOpcodeBinary().length,
-            null, encoder, 0, 0, "s" ) )
-            .isEqualTo( 58 );
-
-        // :maven-surefire-event:17:console-debug-log:5:UTF-8:0003:sss:
-        assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_CONSOLE_DEBUG.getOpcodeBinary().length,
-            null, encoder, 0, 0, "s" ) )
-            .isEqualTo( 59 );
-
-        // :maven-surefire-event:19:console-warning-log:5:UTF-8:0003:sss:
-        assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_CONSOLE_WARNING.getOpcodeBinary().length,
             null, encoder, 0, 0, "s" ) )
             .isEqualTo( 61 );
 
-        // :maven-surefire-event:17:console-error-log:5:UTF-8:0003:sss:
+        // :maven-surefire-event:17:console-debug-log:0::5:UTF-8:0001:s:
+        assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_CONSOLE_DEBUG.getOpcodeBinary().length,
+            null, encoder, 0, 0, "s" ) )
+            .isEqualTo( 62 );
+
+        // :maven-surefire-event:19:console-warning-log:0::5:UTF-8:0001:s:
+        assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_CONSOLE_WARNING.getOpcodeBinary().length,
+            null, encoder, 0, 0, "s" ) )
+            .isEqualTo( 64 );
+
+        // :maven-surefire-event:17:console-error-log:0::5:UTF-8:0001:s:
         assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_CONSOLE_ERROR.getOpcodeBinary().length,
             null, encoder, 0, 0, "s" ) )
-            .isEqualTo( 59 );
+            .isEqualTo( 62 );
 
-        // :maven-surefire-event:3:bye:
+        // :maven-surefire-event:3:bye:0::
         assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_BYE.getOpcodeBinary().length,
             null, null, 0, 0 ) )
-            .isEqualTo( 28 );
+            .isEqualTo( 31 );
 
-        // :maven-surefire-event:17:stop-on-next-test:
+        // :maven-surefire-event:17:stop-on-next-test:0::
         assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_STOP_ON_NEXT_TEST.getOpcodeBinary().length,
             null, null, 0, 0 ) )
-            .isEqualTo( 42 );
+            .isEqualTo( 45 );
 
-        // :maven-surefire-event:9:next-test:
+        // :maven-surefire-event:9:next-test:0::
         assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_NEXT_TEST.getOpcodeBinary().length,
             null, null, 0, 0 ) )
-            .isEqualTo( 34 );
+            .isEqualTo( 37 );
 
-        // :maven-surefire-event:14:jvm-exit-error:
+        // :maven-surefire-event:14:jvm-exit-error:0::
         assertThat( streamEncoder.estimateBufferLength( BOOTERCODE_JVM_EXIT_ERROR.getOpcodeBinary().length,
             null, null, 0, 0 ) )
-            .isEqualTo( 39 );
+            .isEqualTo( 42 );
     }
 
     @Test

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/EventChannelEncoder.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/EventChannelEncoder.java
@@ -214,7 +214,7 @@ public class EventChannelEncoder extends EventEncoder implements MasterProcessCh
         CharsetEncoder encoder = newCharsetEncoder();
         String stackTrace = t == null ? null : ConsoleLoggerUtils.toString( t );
         int bufferMaxLength = estimateBufferLength( BOOTERCODE_CONSOLE_ERROR.getOpcode().length(), null, encoder, 0, 0,
-            message, stackTrace );
+            message, null, stackTrace );
         ByteBuffer result = ByteBuffer.allocate( bufferMaxLength );
         encodeHeader( result, BOOTERCODE_CONSOLE_ERROR );
         encodeCharset( result );

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/EventChannelEncoderTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/EventChannelEncoderTest.java
@@ -1251,6 +1251,25 @@ public class EventChannelEncoderTest
             .isEqualTo( expected );
     }
 
+    @Test
+    public void testStdErrStreamEmptyMessageNullRunMode() throws IOException
+    {
+        Stream out = Stream.newStream();
+        WritableBufferedByteChannel channel = newBufferedChannel( out );
+        EventChannelEncoder encoder = new EventChannelEncoder( channel );
+
+        // This used to produce a BufferOverflowException; see SUREFIRE-2076.
+        encoder.testOutput( new TestOutputReportEntry( stdErr( "" ), null, 1L ) );
+        channel.close();
+
+        String expected = ":maven-surefire-event:\u000e:std-err-stream:"
+            + (char) 0 + "::" // One byte for length and 1+1 bytes for the 2 delimiters (0 bytes for null runMode)
+            + "\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001:"
+            + "\u0005:UTF-8:\u0000\u0000\u0000\u0000::";
+
+        assertThat( new String( out.toByteArray(), UTF_8 ) )
+            .isEqualTo( expected );
+    }
 
     @Test
     @SuppressWarnings( "checkstyle:innerassignment" )


### PR DESCRIPTION
Per @Tibor17's comment https://github.com/apache/maven-surefire/pull/518#issuecomment-1099706229 and https://github.com/apache/maven-surefire/pull/518#issuecomment-1108371215 
and after some dicsussion (see comment after https://github.com/apache/maven-surefire/pull/518#issuecomment-1099706229) pulled this into a separate issue.

Jira ticket: https://issues.apache.org/jira/browse/SUREFIRE-2076

[AbstractStreamEncoder#encodeHeader](https://github.com/apache/maven-surefire/blob/959c1e9cabb8d06c72f5ebd7eb6e56e9987eccf8/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoder.java#L86) stores runMode part in at least 3 bytes:
- 1 byte for length
- 1 byte delimiter
- runMode content in length-bytes
- 1 byte delimiter 

In case of null runMode the encoded part becomes `0::` (exactly 3 bytes length)

The issue is that [AbstractStreamEncoder#estimateBufferLength](https://github.com/apache/maven-surefire/blob/959c1e9cabb8d06c72f5ebd7eb6e56e9987eccf8/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamEncoder.java#L184) is not expecting/couting any bytes for runMode part in case of null runMode. This results in in BufferOverflowException becase the byte size of the entire message is underestimated.

Exception thrown:
```
java.nio.BufferOverflowException
	at java.nio.Buffer.nextPutIndex(Buffer.java:547)
	at java.nio.HeapByteBuffer.put(HeapByteBuffer.java:172)
	at org.apache.maven.surefire.api.stream.AbstractStreamEncoder.encodeString(AbstractStreamEncoder.java:127)
	at org.apache.maven.surefire.api.stream.AbstractStreamEncoder.encodeStringData(AbstractStreamEncoder.java:171)
	at org.apache.maven.surefire.api.stream.AbstractStreamEncoder.encode(AbstractStreamEncoder.java:157)
	at org.apache.maven.surefire.booter.spi.EventChannelEncoder.encodeMessage(EventChannelEncoder.java:398)
	at org.apache.maven.surefire.booter.spi.EventChannelEncoder.setOutErr(EventChannelEncoder.java:188)
	at org.apache.maven.surefire.booter.spi.EventChannelEncoder.testOutput(EventChannelEncoder.java:183)
	at org.apache.maven.surefire.api.booter.ForkingRunListener.writeTestOutput(ForkingRunListener.java:113)
	at org.apache.maven.surefire.api.booter.ForkingRunListener.writeTestOutput(ForkingRunListener.java:44)
	at org.apache.maven.surefire.common.junit4.JUnit4RunListener.writeTestOutput(JUnit4RunListener.java:235)
	at org.apache.maven.surefire.api.report.ConsoleOutputCapture$ForwardingPrintStream.println(ConsoleOutputCapture.java:144)
```


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
