### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -21,6 +21,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: none
+
 jobs:
   build:
     name: Verify

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,6 +20,11 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
+
 jobs:
    update_release_draft:
+      permissions:
+        contents: none
       uses: apache/maven-gh-actions-shared/.github/workflows/release-drafter.yml@v2


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
