### PR TITLE
[SUREFIRE-2091] don't require install to run ITs

### DIFF
--- a/maven-failsafe-plugin/pom.xml
+++ b/maven-failsafe-plugin/pom.xml
@@ -52,6 +52,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit3</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${project.version}</version>
@@ -230,43 +236,36 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
+                        <configuration>
+                            <projectsDirectory>src/it</projectsDirectory>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                            <goals>
+                                <goal>verify</goal>
+                            </goals>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <skipInstallation>${skipTests}</skipInstallation>
+                            <skipInvocation>${skipTests}</skipInvocation>
+                            <showErrors>false</showErrors>
+                            <properties>
+                                <integration-test-port>${failsafe-integration-test-port}</integration-test-port>
+                                <integration-test-stop-port>${failsafe-integration-test-stop-port}</integration-test-stop-port>
+                            </properties>
+                            <debug>true</debug>
+                        </configuration>
                         <executions>
-                            <execution>
-                                <id>pre-its</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>install</goal>
-                                </goals>
-                                <configuration>
-                                    <skipInstallation>${skipTests}</skipInstallation>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>integration-test</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <projectsDirectory>src/it</projectsDirectory>
-                                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-                                    <goals>
-                                        <goal>verify</goal>
-                                        <goal>-nsu</goal>
-                                    </goals>
-                                    <pomIncludes>
-                                        <pomInclude>*/pom.xml</pomInclude>
-                                    </pomIncludes>
-                                    <postBuildHookScript>verify</postBuildHookScript>
-                                    <settingsFile>src/it/settings.xml</settingsFile>
-                                    <skipInvocation>${skipTests}</skipInvocation>
-                                    <showErrors>true</showErrors>
-                                    <properties>
-                                        <integration-test-port>${failsafe-integration-test-port}</integration-test-port>
-                                        <integration-test-stop-port>${failsafe-integration-test-stop-port}</integration-test-stop-port>
-                                    </properties>
-                                    <debug>true</debug>
-                                </configuration>
-                            </execution>
+                          <execution>
+                            <id>integration-test</id>
+                            <goals>
+                              <goal>install</goal>
+                              <goal>integration-test</goal>
+                              <goal>verify</goal>
+                            </goals>
+                          </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/maven-failsafe-plugin/src/it/settings.xml
+++ b/maven-failsafe-plugin/src/it/settings.xml
@@ -18,5 +18,36 @@
   ~ under the License.
   -->
 <settings>
-    <localRepository>@localRepositoryUrl@</localRepository>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -390,13 +390,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <artifactId>maven-release-plugin</artifactId>
-          <configuration>
-            <preparationGoals>clean install</preparationGoals>
-            <commitByProject>false</commitByProject>
-          </configuration>
-        </plugin>
-        <plugin>
           <artifactId>maven-plugin-plugin</artifactId>
           <executions>
             <execution>


### PR DESCRIPTION
first commit fixes maven-failsafe-plugin ITs that run invoker

surefire its that invoke Maven by hand still need to have an equivalent fix