### PR TITLE
[SUREFIRE-2065] Test Reports Inconsistencies with Parameterized and junit4

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/TestFile.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/TestFile.java
@@ -154,6 +154,25 @@ public class TestFile
         return assertContainsText( containsString( text ) );
     }
 
+    public TestFile assertNotContainsText( Matcher<String> matcher )
+    {
+        final List<String> list = surefireVerifier.loadFile( file, encoding );
+        for ( String line : list )
+        {
+            if ( matcher.matches( line ) )
+            {
+                Assert.fail( "Did not find expected message in log" );
+                return null;
+            }
+        }
+        return this;
+    }
+
+    public TestFile assertNotContainsText( String text )
+    {
+        return assertNotContainsText( containsString( text ) );
+    }
+
     public URI toURI()
     {
         return file.toURI();

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire2065IT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire2065IT.java
@@ -1,0 +1,103 @@
+package org.apache.maven.surefire.its.jiras;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Integration Tests for SUREFIRE-2065
+ */
+@SuppressWarnings( "checkstyle:magicnumber" )
+public class Surefire2065IT extends SurefireJUnit4IntegrationTestCase
+{
+    @Test
+    public void shouldNotDetectFlakyTestsWhenCombiningJunit4And5Tests() throws VerificationException
+    {
+        OutputValidator validator = unpack( "surefire-2065-common" )
+            .mavenTestFailureIgnore( true )
+            .executeTest()
+            .assertTestSuiteResults( 8, 0, 4, 0, 0 );
+
+        assertJunit4( validator );
+        assertJunit5( validator );
+    }
+
+    @Test
+    public void shouldNotDetectFlakyTestsWhenRunningOnlyJunit4() throws VerificationException
+    {
+        OutputValidator validator = unpack( "surefire-2065-junit4" )
+            .mavenTestFailureIgnore( true )
+            .executeTest()
+            .assertTestSuiteResults( 4, 0, 2, 0, 0 );
+
+        assertJunit4( validator );
+    }
+
+    @Test
+    public void shouldNotDetectFlakyTestsWhenRunningOnlyJunit5() throws VerificationException
+    {
+        OutputValidator validator = unpack( "surefire-2065-junit5" )
+            .mavenTestFailureIgnore( true )
+            .executeTest()
+            .assertTestSuiteResults( 4, 0, 2, 0, 0 );
+
+        assertJunit5( validator );
+    }
+
+    private static void assertJunit4( OutputValidator validator )
+    {
+        validator.getSurefireReportsFile( "TEST-pkg.junit4.ParameterizedTest.xml", UTF_8 )
+            .assertContainsText( Matchers.matchesPattern( "^ *<testcase name=\"notFlaky\\[0]\".*/>$" ) )
+            .assertContainsText( Matchers.matchesPattern( "^ *<testcase name=\"notFlaky\\[1]\".*[^/]>$" ) )
+            .assertContainsText( "<failure message=" )
+            .assertContainsText( "<rerunFailure message=" )
+            .assertNotContainsText( "<flakyFailure message=" );
+
+        validator.getSurefireReportsFile( "TEST-pkg.junit4.ParameterizedWithDisplayNameTest.xml", UTF_8 )
+            .assertContainsText( Matchers.matchesPattern( "^ *<testcase name=\"notFlaky\\[value=0]\".*/>$" ) )
+            .assertContainsText( Matchers.matchesPattern( "^ *<testcase name=\"notFlaky\\[value=1]\".*[^/]>$" ) )
+            .assertContainsText( "<failure message=" )
+            .assertContainsText( "<rerunFailure message=" )
+            .assertNotContainsText( "<flakyFailure message=" );
+    }
+
+    private static void assertJunit5( OutputValidator validator )
+    {
+        validator.getSurefireReportsFile( "TEST-pkg.junit5.ParameterizedTest.xml", UTF_8 )
+            .assertContainsText( Matchers.matchesPattern( "^ *<testcase name=\"notFlaky\\(int\\)\\[1]\".*/>$" ) )
+            .assertContainsText( Matchers.matchesPattern( "^ *<testcase name=\"notFlaky\\(int\\)\\[2]\".*[^/]>$" ) )
+            .assertContainsText( "<failure message=" )
+            .assertContainsText( "<rerunFailure message=" )
+            .assertNotContainsText( "<flakyFailure message=" );
+
+        validator.getSurefireReportsFile( "TEST-pkg.junit5.ParameterizedWithDisplayNameTest.xml", UTF_8 )
+            .assertContainsText( Matchers.matchesPattern( "^ *<testcase name=\"notFlaky\\(int\\)\\[1]\".*/>$" ) )
+            .assertContainsText( Matchers.matchesPattern( "^ *<testcase name=\"notFlaky\\(int\\)\\[2]\".*[^/]>$" ) )
+            .assertContainsText( "<failure message=" )
+            .assertContainsText( "<rerunFailure message=" )
+            .assertNotContainsText( "<flakyFailure message=" );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2065-common/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2065-common/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>surefire-2065-common</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+    <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+    <junit4.version>4.12</junit4.version>
+    <junit5.version>5.3.2</junit5.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit4.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <rerunFailingTestsCount>1</rerunFailingTestsCount>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-2065-common/src/test/java/pkg/junit4/ParameterizedTest.java
+++ b/surefire-its/src/test/resources/surefire-2065-common/src/test/java/pkg/junit4/ParameterizedTest.java
@@ -1,0 +1,29 @@
+package pkg.junit4;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ParameterizedTest
+{
+    @Parameterized.Parameters
+    public static List<Integer> parameters() throws Exception
+    {
+        return Arrays.asList( 0, 1 );
+    }
+
+    @Parameterized.Parameter(0)
+    public int expected;
+
+    @Test
+    public void notFlaky()
+    {
+        assertEquals( expected, 0 );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2065-common/src/test/java/pkg/junit4/ParameterizedWithDisplayNameTest.java
+++ b/surefire-its/src/test/resources/surefire-2065-common/src/test/java/pkg/junit4/ParameterizedWithDisplayNameTest.java
@@ -1,0 +1,31 @@
+package pkg.junit4;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ParameterizedWithDisplayNameTest
+{
+    private static int count = 0;
+
+    @Parameterized.Parameters(name = "value={0}")
+    public static List<Integer> parameters() throws Exception
+    {
+        return Arrays.asList( 0, 1 );
+    }
+
+    @Parameterized.Parameter(0)
+    public int expected;
+
+    @Test
+    public void notFlaky()
+    {
+        assertEquals( expected, 0 );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2065-common/src/test/java/pkg/junit5/ParameterizedTest.java
+++ b/surefire-its/src/test/resources/surefire-2065-common/src/test/java/pkg/junit5/ParameterizedTest.java
@@ -1,0 +1,30 @@
+package pkg.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class ParameterizedTest
+{
+    static class ParameterSource implements ArgumentsProvider
+    {
+        @Override
+        public Stream<? extends Arguments> provideArguments( ExtensionContext context ) throws Exception
+        {
+            return Arrays.asList(0, 1).stream().map( Arguments::of );
+        }
+    }
+
+    @org.junit.jupiter.params.ParameterizedTest
+    @ArgumentsSource(value = ParameterSource.class)
+    public void notFlaky(int expected)
+    {
+        assertEquals( expected, 0 );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2065-common/src/test/java/pkg/junit5/ParameterizedWithDisplayNameTest.java
+++ b/surefire-its/src/test/resources/surefire-2065-common/src/test/java/pkg/junit5/ParameterizedWithDisplayNameTest.java
@@ -1,0 +1,30 @@
+package pkg.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class ParameterizedWithDisplayNameTest
+{
+    static class ParameterSource implements ArgumentsProvider
+    {
+        @Override
+        public Stream<? extends Arguments> provideArguments( ExtensionContext context ) throws Exception
+        {
+            return Arrays.asList(0, 1).stream().map( Arguments::of );
+        }
+    }
+
+    @org.junit.jupiter.params.ParameterizedTest(name = "value={0}")
+    @ArgumentsSource(value = ParameterSource.class)
+    public void notFlaky(int expected)
+    {
+        assertEquals( expected, 0 );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2065-junit4/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2065-junit4/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>surefire-2065-junit4</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+    <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+    <junit4.version>4.12</junit4.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit4.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <rerunFailingTestsCount>1</rerunFailingTestsCount>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-2065-junit4/src/test/java/pkg/junit4/ParameterizedTest.java
+++ b/surefire-its/src/test/resources/surefire-2065-junit4/src/test/java/pkg/junit4/ParameterizedTest.java
@@ -1,0 +1,29 @@
+package pkg.junit4;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ParameterizedTest
+{
+    @Parameterized.Parameters
+    public static List<Integer> parameters() throws Exception
+    {
+        return Arrays.asList( 0, 1 );
+    }
+
+    @Parameterized.Parameter(0)
+    public int expected;
+
+    @Test
+    public void notFlaky()
+    {
+        assertEquals( expected, 0 );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2065-junit4/src/test/java/pkg/junit4/ParameterizedWithDisplayNameTest.java
+++ b/surefire-its/src/test/resources/surefire-2065-junit4/src/test/java/pkg/junit4/ParameterizedWithDisplayNameTest.java
@@ -1,0 +1,31 @@
+package pkg.junit4;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ParameterizedWithDisplayNameTest
+{
+    private static int count = 0;
+
+    @Parameterized.Parameters(name = "value={0}")
+    public static List<Integer> parameters() throws Exception
+    {
+        return Arrays.asList( 0, 1 );
+    }
+
+    @Parameterized.Parameter(0)
+    public int expected;
+
+    @Test
+    public void notFlaky()
+    {
+        assertEquals( expected, 0 );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2065-junit5/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2065-junit5/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>surefire-2065-junit5</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+    <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+    <junit5.version>5.3.2</junit5.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <rerunFailingTestsCount>1</rerunFailingTestsCount>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-2065-junit5/src/test/java/pkg/junit5/ParameterizedTest.java
+++ b/surefire-its/src/test/resources/surefire-2065-junit5/src/test/java/pkg/junit5/ParameterizedTest.java
@@ -1,0 +1,30 @@
+package pkg.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class ParameterizedTest
+{
+    static class ParameterSource implements ArgumentsProvider
+    {
+        @Override
+        public Stream<? extends Arguments> provideArguments( ExtensionContext context ) throws Exception
+        {
+            return Arrays.asList(0, 1).stream().map( Arguments::of );
+        }
+    }
+
+    @org.junit.jupiter.params.ParameterizedTest
+    @ArgumentsSource(value = ParameterSource.class)
+    public void notFlaky(int expected)
+    {
+        assertEquals( expected, 0 );
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2065-junit5/src/test/java/pkg/junit5/ParameterizedWithDisplayNameTest.java
+++ b/surefire-its/src/test/resources/surefire-2065-junit5/src/test/java/pkg/junit5/ParameterizedWithDisplayNameTest.java
@@ -1,0 +1,30 @@
+package pkg.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class ParameterizedWithDisplayNameTest
+{
+    static class ParameterSource implements ArgumentsProvider
+    {
+        @Override
+        public Stream<? extends Arguments> provideArguments( ExtensionContext context ) throws Exception
+        {
+            return Arrays.asList(0, 1).stream().map( Arguments::of );
+        }
+    }
+
+    @org.junit.jupiter.params.ParameterizedTest(name = "value={0}")
+    @ArgumentsSource(value = ParameterSource.class)
+    public void notFlaky(int expected)
+    {
+        assertEquals( expected, 0 );
+    }
+}

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.apache.maven.surefire.api.report.OutputReportEntry;
@@ -58,8 +57,6 @@ import org.junit.platform.launcher.TestPlan;
 final class RunListenerAdapter
     implements TestExecutionListener, TestOutputReceiver<OutputReportEntry>, RunModeSetter
 {
-    private static final Pattern COMMA_PATTERN = Pattern.compile( "," );
-
     private final ClassMethodIndexer classMethodIndexer = new ClassMethodIndexer();
     private final ConcurrentMap<TestIdentifier, Long> testStartTime = new ConcurrentHashMap<>();
     private final ConcurrentMap<TestIdentifier, TestExecutionResult> failures = new ConcurrentHashMap<>();
@@ -144,7 +141,7 @@ final class RunListenerAdapter
                     break;
                 case FAILED:
                     String reason = safeGetMessage( testExecutionResult.getThrowable().orElse( null ) );
-                    SimpleReportEntry reportEntry = createReportEntry( testIdentifier, testExecutionResult, 
+                    SimpleReportEntry reportEntry = createReportEntry( testIdentifier, testExecutionResult,
                             reason, elapsed );
                     if ( isAssertionError )
                     {
@@ -300,7 +297,9 @@ final class RunListenerAdapter
             MethodSource methodSource = testSource.map( MethodSource.class::cast ).get();
             String realClassName = methodSource.getClassName();
 
-            String[] source = testPlan.getParent( testIdentifier )
+            String[] source = collectAllTestIdentifiersInHierarchy( testIdentifier )
+                    .filter( i -> i.getSource().map( ClassSource.class::isInstance ).orElse( false ) )
+                    .findFirst()
                     .map( this::toClassMethodName )
                     .map( s -> new String[] { s[0], s[1] } )
                     .orElse( new String[] { realClassName, realClassName } );
@@ -314,28 +313,26 @@ final class RunListenerAdapter
             boolean needsSpaceSeparator = isNotBlank( parentDisplay ) && !display.startsWith( "[" );
             String methodDisplay = parentDisplay + ( needsSpaceSeparator ? " " : "" ) + display;
 
-            String simpleClassNames = COMMA_PATTERN.splitAsStream( methodSource.getMethodParameterTypes() )
-                    .map( s -> s.substring( 1 + s.lastIndexOf( '.' ) ) )
-                    .collect( joining( "," ) );
-
-            boolean hasParams = isNotBlank( methodSource.getMethodParameterTypes() );
-            String methodName = methodSource.getMethodName();
+            // SUREFIRE-2065 (see tables below)
             String description = testIdentifier.getLegacyReportingName();
-            String methodSign = hasParams ? methodName + '(' + simpleClassNames + ')' : methodName;
-            boolean equalDescriptions = methodDisplay.equals( description );
-            boolean hasLegacyDescription = description.startsWith( methodName + '(' );
-            boolean hasDisplayName = !equalDescriptions || !hasLegacyDescription;
-            String methodDesc = equalDescriptions || !hasParams ? methodSign : description;
-            String methodDisp = hasDisplayName ? methodDisplay : methodDesc;
 
-            // The behavior of methods getLegacyReportingName() and getDisplayName().
-            //     test      ||  legacy  |  display
+            // For better handling of parameterized junit4, use of LegacyReportingName as description
+            // fits better since display and legacy are same for parameterized junit4
+            //     junit4    ||  legacy  |  display
+            // ==============||==========|==========
+            //     normal    ||     m    |     m
+            //     param     ||   m[0]   |   m[0]
+            //  param+displ  || m[displ] | m[displ]
+
+            // For junit5 legacy / display behaves as below
+            //     junit5    ||  legacy  |  display
             // ==============||==========|==========
             //    normal     ||    m()   |    m()
-            //  normal+displ ||   displ  |  displ
-            // parameterized ||  m()[1]  |  displ
+            //  normal+displ ||    m()   |   displ
+            //     param     ||  m()[1]  | [1] <param>
+            //  param+displ  ||  m()[1]  |   displ
 
-            return new String[] {source[0], source[1], methodDesc, methodDisp};
+            return new String[] {source[0], source[1], description, methodDisplay};
         }
         else if ( testSource.filter( ClassSource.class::isInstance ).isPresent() )
         {

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -448,7 +448,7 @@ public class JUnitPlatformProviderTest
 
         assertEquals( DisplayNameTest.class.getName(), reportEntries.get( 0 ).getSourceName() );
         assertEquals( "<< ✨ >>", reportEntries.get( 0 ).getSourceText() );
-        assertEquals( "test1", reportEntries.get( 0 ).getName() );
+        assertEquals( "test1()", reportEntries.get( 0 ).getName() );
         assertEquals( "73$71 ✔", reportEntries.get( 0 ).getNameText() );
     }
 
@@ -480,7 +480,7 @@ public class JUnitPlatformProviderTest
 
         assertEquals( TestClass8.class.getName(), reportEntries.get( 0 ).getSourceName() );
         assertNull( reportEntries.get( 0 ).getSourceText() );
-        assertEquals( "testParameterizedTestCases", reportEntries.get( 0 ).getName() );
+        assertEquals( "testParameterizedTestCases()", reportEntries.get( 0 ).getName() );
         assertNull( reportEntries.get( 0 ).getNameText() );
 
         TestExecutionSummary summary = executionListener.summaries.get( 0 );
@@ -519,7 +519,7 @@ public class JUnitPlatformProviderTest
 
         assertEquals( TestClass9.class.getName(), reportEntries.get( 0 ).getSourceName() );
         assertNull( reportEntries.get( 0 ).getSourceText() );
-        assertEquals( "testParameterizedTestCases", reportEntries.get( 0 ).getName() );
+        assertEquals( "testParameterizedTestCases()", reportEntries.get( 0 ).getName() );
         assertNull( reportEntries.get( 0 ).getNameText() );
 
         TestExecutionSummary summary = executionListener.summaries.get( 0 );

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -111,7 +111,7 @@ public class RunListenerAdapterTest
         verify( listener ).testStarting( entryCaptor.capture() );
 
         ReportEntry entry = entryCaptor.getValue();
-        assertEquals( MY_TEST_METHOD_NAME, entry.getName() );
+        assertEquals( MY_TEST_METHOD_NAME.concat( "()" ), entry.getName() );
         assertEquals( MyTestClass.class.getName(), entry.getSourceName() );
         assertNull( entry.getStackTraceWriter() );
     }
@@ -161,7 +161,7 @@ public class RunListenerAdapterTest
 
         adapter.executionStarted( TestIdentifier.from( child ) );
         verify( listener ).testStarting( new SimpleReportEntry( NORMAL_RUN, 0x0000000100000001L, className, null,
-            MY_TEST_METHOD_NAME, null ) );
+            MY_TEST_METHOD_NAME.concat( "()" ), null ) );
         verifyNoMoreInteractions( listener );
 
         adapter.executionFinished( TestIdentifier.from( child ), successful() );
@@ -176,7 +176,7 @@ public class RunListenerAdapterTest
         assertThat( report.getValue().getSourceText() )
                 .isNull();
         assertThat( report.getValue().getName() )
-                .isEqualTo( MY_TEST_METHOD_NAME );
+                .isEqualTo( MY_TEST_METHOD_NAME.concat( "()" ) );
         assertThat( report.getValue().getNameText() )
                 .isNull();
         assertThat( report.getValue().getElapsed() )
@@ -526,7 +526,7 @@ public class RunListenerAdapterTest
 
         ReportEntry entry = entryCaptor.getValue();
         assertEquals( MyTestClass.class.getTypeName(), entry.getSourceName() );
-        assertEquals( MY_TEST_METHOD_NAME, entry.getName() );
+        assertEquals( MY_TEST_METHOD_NAME.concat( "()" ), entry.getName() );
         assertNotNull( entry.getStackTraceWriter() );
         assertNotNull( entry.getStackTraceWriter().getThrowable() );
         assertThat( entry.getStackTraceWriter().getThrowable().getTarget() )
@@ -800,10 +800,24 @@ public class RunListenerAdapterTest
 
     static class TestMethodTestDescriptorWithDisplayName extends AbstractTestDescriptor
     {
+        private final String legacyName;
+
         private TestMethodTestDescriptorWithDisplayName( UniqueId uniqueId,
                                                          Class<?> testClass, Method testMethod, String displayName )
         {
-            super( uniqueId, displayName, MethodSource.from( testClass, testMethod ) );
+            this( uniqueId, displayName, MethodSource.from( testClass, testMethod ) );
+        }
+
+        private TestMethodTestDescriptorWithDisplayName( UniqueId uniqueId, String displayName, MethodSource source )
+        {
+            super( uniqueId, displayName, source );
+            legacyName = source.getMethodName() + (source.getMethodParameterTypes().isEmpty() ? "" : "(" + source.getMethodParameterTypes() + ")");
+        }
+
+        @Override
+        public String getLegacyReportingName()
+        {
+            return legacyName;
         }
 
         @Override


### PR DESCRIPTION
-- This PR resumes [516](https://github.com/apache/maven-surefire/pull/516) - while re-doing some changes had to do this on a separate branch instead for cleaner approach

Changing the run listener to use the nameText value (for parameterized scenarios) to prevent invalid flake test reports (see https://github.com/chalmagr/surefire-flaky-report)

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
