### PR TITLE
[SUREFIRE-2101] - Fixes 'null' phrased test names with JUnit5 without @DisplayName

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
@@ -223,7 +223,14 @@ public class WrappedReportEntry
     @Override
     public String getReportNameWithGroup()
     {
-        return original.getReportNameWithGroup();
+        String reportNameWithGroup = original.getReportNameWithGroup();
+
+        if ( isBlank ( reportNameWithGroup ) )
+        {
+            return getNameWithGroup();
+        }
+
+        return reportNameWithGroup;
     }
 
     @Nonnull

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/WrappedReportEntryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/WrappedReportEntryTest.java
@@ -116,6 +116,42 @@ public class WrappedReportEntryTest
         assertTrue( wr.isSkipped() );
     }
 
+    public void testGetReportNameWithGroupWhenSourceTextIsNull()
+    {
+        String className = "ClassName";
+        String classText = null;
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 1L, className, classText, null, null );
+        WrappedReportEntry wr = new WrappedReportEntry( reportEntry, SKIPPED, 12, null, null );
+        assertEquals( className, wr.getReportNameWithGroup() );
+    }
+
+    public void testGetReportNameWithGroupWhenSourceTextIsEmpty()
+    {
+        String className = "ClassName";
+        String classText = "";
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 1L, className, classText, null, null );
+        WrappedReportEntry wr = new WrappedReportEntry( reportEntry, SKIPPED, 12, null, null );
+        assertEquals( className, wr.getReportNameWithGroup() );
+    }
+
+    public void testGetReportNameWithGroupWhenSourceTextIsBlank()
+    {
+        String className = "ClassName";
+        String classText = "  ";
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 1L, className, classText, null, null );
+        WrappedReportEntry wr = new WrappedReportEntry( reportEntry, SKIPPED, 12, null, null );
+        assertEquals( className, wr.getReportNameWithGroup() );
+    }
+
+    public void testGetReportNameWithGroupWhenSourceTextIsProvided()
+    {
+        String className = "ClassName";
+        String classText = "The Class Name";
+        ReportEntry reportEntry = new SimpleReportEntry( NORMAL_RUN, 1L, className, classText, null, null );
+        WrappedReportEntry wr = new WrappedReportEntry( reportEntry, SKIPPED, 12, null, null );
+        assertEquals( classText, wr.getReportNameWithGroup() );
+    }
+
     public void testElapsed()
     {
         String className = "[0] 1\u002C 2\u002C 3 (testSum)";

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/CategorizedReportEntry.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/CategorizedReportEntry.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.apache.maven.surefire.shared.utils.StringUtils.isBlank;
+
 /**
  * @author Kristian Rosenvold
  */
@@ -97,7 +99,14 @@ public class CategorizedReportEntry
     @Override
     public String getReportNameWithGroup()
     {
-        return isNameWithGroup() ? getSourceText() + GROUP_PREFIX + getGroup() + GROUP_SUFIX : getSourceText();
+        String sourceText = getSourceText();
+
+        if ( isBlank ( sourceText ) )
+        {
+            return null;
+        }
+
+        return isNameWithGroup() ? sourceText + GROUP_PREFIX + getGroup() + GROUP_SUFIX : sourceText;
     }
 
     @Override

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReportEntry.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReportEntry.java
@@ -105,7 +105,8 @@ public interface ReportEntry
     /**
      * A source text of the test case together with the group or category (if any exists).
      *
-     * @return A string with the test case text and group/category, or just the source text.
+     * @return A string with the test case text and group/category, or just the source text. If no
+     * source text is provided, then this will return null.
      */
     String getReportNameWithGroup();
 

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/report/CategorizedReportEntryTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/report/CategorizedReportEntryTest.java
@@ -1,0 +1,69 @@
+package org.apache.maven.surefire.api.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Ashley Scopes
+ */
+public class CategorizedReportEntryTest
+{
+    public void testGetReportNameWithGroupWhenSourceTextIsNull()
+    {
+        String className = "ClassName";
+        String classText = null;
+        String groupName = "The Group Name";
+        ReportEntry reportEntry = new CategorizedReportEntry(
+            NORMAL_RUN, 1L, className, classText, groupName, null, null );
+        assertEquals( "ClassName (of The Group Name)", reportEntry.getReportNameWithGroup() );
+    }
+
+    public void testGetReportNameWithGroupWhenSourceTextIsEmpty()
+    {
+        String className = "ClassName";
+        String classText = "";
+        String groupName = "The Group Name";
+        ReportEntry reportEntry = new CategorizedReportEntry(
+            NORMAL_RUN, 1L, className, classText, groupName, null, null );
+        assertEquals( "ClassName (of The Group Name)", reportEntry.getReportNameWithGroup() );
+    }
+
+    public void testGetReportNameWithGroupWhenSourceTextIsBlank()
+    {
+        String className = "ClassName";
+        String classText = "  ";
+        String groupName = "The Group Name";
+        ReportEntry reportEntry = new CategorizedReportEntry(
+            NORMAL_RUN, 1L, className, classText, groupName, null, null );
+        assertEquals( "ClassName (of The Group Name)", reportEntry.getReportNameWithGroup() );
+    }
+
+    public void testGetReportNameWithGroupWhenSourceTextIsProvided()
+    {
+        String className = "ClassName";
+        String classText = "The Class Name";
+        String groupName = "The Group Name";
+        ReportEntry reportEntry = new CategorizedReportEntry(
+            NORMAL_RUN, 1L, className, classText, groupName, null, null );
+        assertEquals( "The Class Name (of The Group Name)", reportEntry.getReportNameWithGroup() );
+    }
+}


### PR DESCRIPTION
When phrased test names are enabled, but an annotation such as DisplayName
in JUnit5 is missing from the test, the output to the console will now
fall back to using the original name rather than naming the test
'null'.

This amends this behaviour to provide a more meaningful name in these scenarios,
which can be important when migrating a large code base over to using 
phrased names incrementally.

An example of the existing output which can be problematic:

![image](https://user-images.githubusercontent.com/73482956/174481991-574ad9cd-342c-4ece-aabf-9a208f15729a.png)

----

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0

 - [x] As of Sunday 19th June 2022, I have submitted a signed copy of the Apache ICLA to `mailto:secretary@apache.org` in PDF form.
