### PR TITLE
[SUREFIRE-2109] Add suffix derived from current user to Surefire temp directory name

### DIFF
--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/util/SureFireFileManagerTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/util/SureFireFileManagerTest.java
@@ -1,0 +1,64 @@
+package org.apache.maven.surefire.api.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+/**
+ * Unit test for the surefire instance of temp file manager.
+ *
+ * @author Markus Spann
+ */
+public class SureFireFileManagerTest extends TestCase
+{
+
+    @Test
+    public void testCreateTempFile() throws IOException
+    {
+
+        File tempFile = SureFireFileManager.createTempFile( "sfprefix", "sfsuffix" );
+        assertThat( tempFile ).isWritable();
+        assertThat( tempFile.getName() ).startsWith( "sfprefix" ).endsWith( "sfsuffix" );
+
+        File tempDir = tempFile.getParentFile();
+        assertThat( tempDir ).isDirectory().isWritable();
+        assertThat( tempDir.getName() ).startsWith( "surefire-" ).doesNotMatch( "[^A-Za-z0-9\\\\-_]" );
+
+        boolean isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains( "posix" );
+        if ( isPosix )
+        {
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions( tempDir.toPath() );
+            assertEquals( "rwxrwxr-x", PosixFilePermissions.toString( permissions ) );
+        }
+
+    }
+
+}


### PR DESCRIPTION
This pull request offers a fix for bug [SUREFIRE-2109].

Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
