### PR TITLE
[SUREFIRE-2090] - Xref link to source code with specified line number doesn't work. Missing "L" in anchor

### DIFF
--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportGenerator.java
@@ -608,7 +608,7 @@ public final class SurefireReportGenerator
                 if ( xrefLocation != null )
                 {
                     String path = fullClassName.replace( '.', '/' );
-                    sink.link( xrefLocation + "/" + path + ".html#" + errorLineNumber );
+                    sink.link( xrefLocation + "/" + path + ".html#L" + errorLineNumber );
                 }
                 sink.text( fullClassName + ":" + errorLineNumber );
 

--- a/maven-surefire-report-plugin/src/test/java/org/apache/maven/plugins/surefire/report/SurefireReportMojoTest.java
+++ b/maven-surefire-report-plugin/src/test/java/org/apache/maven/plugins/surefire/report/SurefireReportMojoTest.java
@@ -170,7 +170,7 @@ public class SurefireReportMojoTest
 
         String htmlContent = FileUtils.fileRead( report );
 
-        int idx = htmlContent.indexOf( "./xref-test/com/shape/CircleTest.html#44" );
+        int idx = htmlContent.indexOf( "./xref-test/com/shape/CircleTest.html#L44" );
 
         assertTrue( idx == -1 );
     }
@@ -195,7 +195,7 @@ public class SurefireReportMojoTest
 
         String htmlContent = FileUtils.fileRead( report );
 
-        int idx = htmlContent.indexOf( "./xref-test/com/shape/CircleTest.html#44" );
+        int idx = htmlContent.indexOf( "./xref-test/com/shape/CircleTest.html#L44" );
 
         assertTrue( idx < 0 );
     }
@@ -276,7 +276,7 @@ public class SurefireReportMojoTest
 
         assertThat( htmlContent, containsString( ">surefire.MyTest:13</a>" ) );
 
-        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest.html#13" ) );
+        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest.html#L13" ) );
 
         assertThat( htmlContent, containsString( toSystemNewLine( "<pre>"
         + "java.lang.RuntimeException: java.lang.IndexOutOfBoundsException\n"
@@ -361,7 +361,7 @@ public class SurefireReportMojoTest
         assertThat( htmlContent,
                     containsString( ">surefire.MyTest:13</a>" ) );
 
-        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest.html#13" ) );
+        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest.html#L13" ) );
 
         assertThat( htmlContent, containsString( toSystemNewLine( "<pre>"
         + "java.lang.RuntimeException: java.lang.IndexOutOfBoundsException\n"
@@ -424,7 +424,7 @@ public class SurefireReportMojoTest
         assertThat( htmlContent,
                     containsString( ">surefire.MyTest:13</a>" ) );
 
-        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest.html#13" ) );
+        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest.html#L13" ) );
 
         assertThat( htmlContent, containsString( toSystemNewLine( "<pre>"
         + "java.lang.RuntimeException: java.lang.IndexOutOfBoundsException\n"
@@ -511,7 +511,7 @@ public class SurefireReportMojoTest
 
         assertThat( htmlContent, containsString( ">surefire.MyTest$A:45</a>" ) );
 
-        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest$A.html#45" ) );
+        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest$A.html#L45" ) );
 
         assertThat( htmlContent, containsString( toSystemNewLine( "<pre>"
         + "java.lang.RuntimeException: java.lang.IndexOutOfBoundsException\n"
@@ -573,7 +573,7 @@ public class SurefireReportMojoTest
 
         assertThat( htmlContent, containsString( ">surefire.MyTest$A:45</a>" ) );
 
-        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest$A.html#45" ) );
+        assertThat( htmlContent, containsString( "./xref-test/surefire/MyTest$A.html#L45" ) );
 
         assertThat( htmlContent, containsString( toSystemNewLine(
             "<pre>" + "java.lang.RuntimeException: java.lang.IndexOutOfBoundsException\n"


### PR DESCRIPTION
Hi there,

last December Karl Heinz Marbaise showed me the "up for grabs" JIRA issues. Thanks again Karl Heinz! Unfortunately it took me much longer than expected. 

Anyway, here is a tiny contribution on my behalf. This fixes [SUREFIRE-2090](https://issues.apache.org/jira/browse/SUREFIRE-2090). The fix was more more less stated in the comments by Michael Osipov. I added the 'L' and updated the test cases in `SurefireReportMojoTest`. I also made sure it works in a pet project of mine.

Since this is my first contribution to Apache Maven I am unaware if I did everything according to the conventions. I am unsure where to communicate: the dev mailing, JIRA or here at GitHub. I will leave a comment pointing to this PR in the JIRA issue.

 - [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
