### PR TITLE
[SUREFIRE-2135] Use native.encoding for parsing ps

### DIFF
--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/PpidChecker.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/PpidChecker.java
@@ -26,7 +26,6 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Queue;
@@ -170,7 +169,8 @@ final class PpidChecker
     // http://hg.openjdk.java.net/jdk7/jdk7/jdk/file/9b8c96f96a0f/test/java/lang/ProcessBuilder/Basic.java#L167
     ProcessInfo unix()
     {
-        ProcessInfoConsumer reader = new ProcessInfoConsumer( Charset.defaultCharset().name() )
+        String charset = System.getProperty( "native.encoding", System.getProperty( "file.encoding", "UTF-8" ) );
+        ProcessInfoConsumer reader = new ProcessInfoConsumer( charset )
         {
             @Override
             @Nonnull

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/PpidCheckerTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/PpidCheckerTest.java
@@ -122,7 +122,6 @@ public class PpidCheckerTest
     public void shouldHavePid() throws Exception
     {
         String expectedPid = ManagementFactory.getRuntimeMXBean().getName().split( "@" )[0].trim();
-        System.out.println( "java version " + System.getProperty( "java.version" ) + " expectedPid=" + expectedPid );
 
         PpidChecker checker = new PpidChecker( expectedPid );
         setInternalState( checker, "parentProcessInfo",


### PR DESCRIPTION
- Use the value of the system property native.encoding as charset for parsing the output of the ps command that ForkedBooter issues on Unix-like OSes when checking if the forked process is still alive
- Fall back to UTF-8 in case the system property is absent (pre-JDK17)
- Remove an unnecessary System.out.println in a test that was probably committed by accident

This fixes the ConsoleOutputIT on Java 18 and above.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
