### PR TITLE
[SUREFIRE-2101] JUnit5 console reporting: Fall back to class name

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetStats.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetStats.java
@@ -297,7 +297,7 @@ public class TestSetStats
      */
     static String concatenateWithTestGroup( MessageBuilder builder, ReportEntry report, boolean phrasedClassName )
     {
-        if ( phrasedClassName )
+        if ( phrasedClassName && report.getReportNameWithGroup() != null )
         {
             return builder.strong( report.getReportNameWithGroup() )
                     .toString();

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/TestSetStatsTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/TestSetStatsTest.java
@@ -28,6 +28,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.apache.maven.surefire.shared.utils.logging.MessageUtils.buffer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -62,10 +63,27 @@ public class TestSetStatsTest
         when( reportEntry.getReportNameWithGroup() )
                 .thenReturn( "pkg.MyTest (my group)" );
         String actual = TestSetStats.concatenateWithTestGroup( buffer(), reportEntry, true );
-        verify( reportEntry, times( 1 ) ).getReportNameWithGroup();
+        verify( reportEntry, atLeastOnce() ).getReportNameWithGroup();
         verifyNoMoreInteractions( reportEntry );
         String expected = buffer().strong( "pkg.MyTest (my group)" ).toString();
         assertThat( actual )
                 .isEqualTo( expected );
     }
+
+    @Test
+    public void shouldFallBackToTestGroupIfJUnit5TestGroupIsNull()
+    {
+        when( reportEntry.getReportNameWithGroup() )
+            .thenReturn( null );
+        when( reportEntry.getNameWithGroup() )
+            .thenReturn( "pkg.MyTest (my group)" );
+        String actual = TestSetStats.concatenateWithTestGroup( buffer(), reportEntry, true );
+        verify( reportEntry, atLeastOnce() ).getReportNameWithGroup();
+        verify( reportEntry, atLeastOnce() ).getNameWithGroup();
+        verifyNoMoreInteractions( reportEntry );
+        String expected = buffer().a( "pkg." ).strong( "MyTest (my group)" ).toString();
+        assertThat( actual )
+            .isEqualTo( expected );
+    }
+
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnitPlatformEnginesIT.java
@@ -39,6 +39,7 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 
@@ -366,7 +367,7 @@ public class JUnitPlatformEnginesIT extends SurefireJUnit4IntegrationTestCase
     }
 
     @Test
-    public void testJupiterEngineWithDisplayNames()
+    public void testJupiterEngineWithDisplayNames() throws VerificationException
     {
         OutputValidator validator = unpack( "junit-platform-engine-jupiter", "-" + jupiter )
                 .sysProp( "junit5.version", jupiter )
@@ -410,6 +411,12 @@ public class JUnitPlatformEnginesIT extends SurefireJUnit4IntegrationTestCase
                         + "classname=\"junitplatformenginejupiter.BasicJupiterTest\"" )
                 .assertContainsText( "<testcase name=\"add(int, int, int) 1 + 100 = 101\" "
                         + "classname=\"junitplatformenginejupiter.BasicJupiterTest\"" );
+
+        validator
+            .assertThatLogLine( matchesRegex( ".*Running junitplatformenginejupiter.BasicJupiterTest$" ), is( 1 ) )
+            .assertThatLogLine( matchesRegex( ".*Tests run.* junitplatformenginejupiter.BasicJupiterTest$" ), is( 1 ) )
+            .assertThatLogLine( matchesRegex( ".*Running << . >>$" ), is( 1 ) )
+            .assertThatLogLine( matchesRegex( ".*Tests run.* << . >>$" ), is( 1 ) );
     }
 
     @Test


### PR DESCRIPTION
If phrased console reporting is active, but no @DisplayName annotation is set, fall back to using the class name in console output

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
