### PR TITLE
[SUREFIRE-2152] Include name of JUnit5 templated-tests in test description

### DIFF
--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -255,8 +255,14 @@ final class RunListenerAdapter
         {
             methodText = null;
         }
-        StackTraceWriter stw =
-                testExecutionResult == null ? null : toStackTraceWriter( className, methodName, testExecutionResult );
+        String methodNameForSTW = methodName;
+        if ( methodNameForSTW != null && methodNameForSTW.contains( ")[" ) )
+        {
+            // don't pass suffix of templated-tests ("[1] ...") on to STW, as it's not part of the method signature
+            methodNameForSTW = methodNameForSTW.substring( 0, methodNameForSTW.indexOf( ")[" ) + 1 );
+        }
+        StackTraceWriter stw = testExecutionResult == null ? null
+            : toStackTraceWriter( className, methodNameForSTW, testExecutionResult );
         return new SimpleReportEntry( runMode, classMethodIndexer.indexClassMethod( className, methodName ), className,
             classText, methodName, methodText, stw, elapsedTime, reason, systemProperties );
     }

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -374,6 +374,9 @@ final class RunListenerAdapter
 
             // Override resulting methodDesc/methodDisp values again, for invocations of
             // JUnit5 templated-tests (such as @ParameterizedTest/@RepeatedTest)
+            // => Include the display-name of the actual invocation as well in the methodDesc of
+            //    each invocation (also according to the 'name=' values of such tests), to have
+            //    more context of what failed also e.g. from output of console reporter
             Integer templatedTestInvocationId = extractTemplatedInvocationId( testIdentifier );
             if ( templatedTestInvocationId != null )
             {
@@ -384,8 +387,14 @@ final class RunListenerAdapter
                 String methodSignature = methodName + '(' + simpleClassNames + ')';
 
                 String invocationIdStr = "[" + templatedTestInvocationId + "]";
-
-                methodDesc = methodSignature + invocationIdStr;
+                String displayForDesc = display;
+                if ( displayForDesc.startsWith( invocationIdStr ) )
+                {
+                    // a bit hacky, try to prevent including ID multiple times in most default cases
+                    // "foo()[1][1] abc def" -> "foo()[1] abc def"
+                    displayForDesc = displayForDesc.substring( invocationIdStr.length() );
+                }
+                methodDesc = methodSignature + invocationIdStr + displayForDesc;
                 methodDisp = parentDisplay + display;
             }
 

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -640,27 +640,27 @@ public class JUnitPlatformProviderTest
 
         assertEquals( TestClass7.class.getName(), reportEntries.get( 0 ).getSourceName() );
         assertNull( reportEntries.get( 0 ).getSourceText() );
-        assertEquals( "testParameterizedTestCases(String, boolean)[1]", reportEntries.get( 0 ).getName() );
         assertEquals( "testParameterizedTestCases(String, boolean)[1] Always pass, true",
-                       reportEntries.get( 0 ).getNameText() );
+            reportEntries.get( 0 ).getName() );
+        assertEquals( null, reportEntries.get( 0 ).getNameText() );
 
         assertEquals( TestClass7.class.getName(), reportEntries.get( 1 ).getSourceName() );
         assertNull( reportEntries.get( 1 ).getSourceText() );
-        assertEquals( "testParameterizedTestCases(String, boolean)[2]", reportEntries.get( 1 ).getName() );
         assertEquals( "testParameterizedTestCases(String, boolean)[2] Always fail, false",
-                      reportEntries.get( 1 ).getNameText() );
+            reportEntries.get( 1 ).getName() );
+        assertEquals( null, reportEntries.get( 1 ).getNameText() );
 
         assertEquals( TestClass7.class.getName(), reportEntries.get( 2 ).getSourceName() );
         assertNull( reportEntries.get( 2 ).getSourceText() );
-        assertEquals( "testParameterizedTestCases(String, boolean)[2]", reportEntries.get( 2 ).getName() );
         assertEquals( "testParameterizedTestCases(String, boolean)[2] Always fail, false",
-                      reportEntries.get( 2 ).getNameText() );
+            reportEntries.get( 2 ).getName() );
+        assertEquals( null, reportEntries.get( 2 ).getNameText() );
 
         assertEquals( TestClass7.class.getName(), reportEntries.get( 3 ).getSourceName() );
         assertNull( reportEntries.get( 3 ).getSourceText() );
-        assertEquals( "testParameterizedTestCases(String, boolean)[2]", reportEntries.get( 3 ).getName() );
         assertEquals( "testParameterizedTestCases(String, boolean)[2] Always fail, false",
-                      reportEntries.get( 3 ).getNameText() );
+            reportEntries.get( 3 ).getName() );
+        assertEquals( null, reportEntries.get( 3 ).getNameText() );
 
         TestExecutionSummary summary = executionListener.summaries.get( 0 );
         assertEquals( 2, summary.getTestsFoundCount() );


### PR DESCRIPTION
Suggestion to support SUREFIRE-2152, helping developers identify problematic invocations of templated tests much quicker, especially also based on the console output.

The initial commit a87457bb to handle JUnit5 templated tests quite separately in `RunListenerAdapter` also fixes another issue mentioned recently on SUREFIRE-2087, namely this one:
* https://issues.apache.org/jira/browse/SUREFIRE-2087?focusedCommentId=17690951#comment-17690951

I could assume that especially ff694485 might be controversial in this, since it mixes up the separation between the `methodDesc` and `methodDisp` (introduced in SUREFIRE-1546, AFAICS) to some extent. However, I would argue that it's quite important to be able to see the display-name of templated tests in general (i.e., in particular also in the default output of the console reporter), else it can be tedious to figure out more details.

Still, it might be useful to make the changes of ff694485 conditional of a configuration flag - i.e. keeping it disabled by default and have a flag for opt-in (I don't really know how a config-flag would need to be done, help welcome if you'd consider that useful too)

Validation:
- [x] `mvn clean install` is successful
- [ ] `mvn -Prun-its clean install`
  - This fails on me unfortunately with error below (doesn't seem related to my changes, maybe linked #543?):

```
Failed to install project dependencies: MavenProject: org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M10-SNAPSHOT
[...]
cannot install /home/me/.m2/repository/org/apache/maven/maven-parent/36/maven-parent-36.pom to same path
```
 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)