### PR TITLE
Test Indexes and Reporters

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
@@ -291,6 +291,8 @@ public class DefaultReporterFactory
         // Merge all the stats for tests from listeners
         for ( TestSetRunListener listener : listeners )
         {
+            // this method should not be here
+            // it should be centralized in one place in the state machine - processor
             for ( TestMethodStats methodStats : listener.getTestMethodStats() )
             {
                 List<TestMethodStats> currentMethodStats =

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ReportEntryType.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ReportEntryType.java
@@ -19,13 +19,18 @@ package org.apache.maven.plugin.surefire.report;
  * under the License.
  */
 
+import static java.util.Objects.requireNonNull;
+
 /**
- * Type of an entry in the report
+ * Type of entry in the report.
  *
  */
 public enum ReportEntryType
 {
-
+    TEST_SET_STARTING(),
+    TEST_SET_COMPLETED(),
+    TEST_STARTING(),
+    TEST_ASSUMPTION_FAILURE(),
     ERROR( "error", "flakyError", "rerunError" ),
     FAILURE( "failure", "flakyFailure", "rerunFailure" ),
     SKIPPED( "skipped", "", "" ),
@@ -37,6 +42,11 @@ public enum ReportEntryType
 
     private final String rerunXmlTag;
 
+    ReportEntryType()
+    {
+        this( null, null, null );
+    }
+
     ReportEntryType( String xmlTag, String flakyXmlTag, String rerunXmlTag )
     {
         this.xmlTag = xmlTag;
@@ -46,16 +56,16 @@ public enum ReportEntryType
 
     public String getXmlTag()
     {
-        return xmlTag;
+        return requireNonNull( xmlTag );
     }
 
     public String getFlakyXmlTag()
     {
-        return flakyXmlTag;
+        return requireNonNull( flakyXmlTag );
     }
 
     public String getRerunXmlTag()
     {
-        return rerunXmlTag;
+        return requireNonNull( rerunXmlTag );
     }
 }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ReportersAggregator.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ReportersAggregator.java
@@ -1,0 +1,135 @@
+package org.apache.maven.plugin.surefire.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.surefire.runorder.StatisticsReporter;
+import org.apache.maven.surefire.extensions.ConsoleOutputReportEventListener;
+import org.apache.maven.surefire.extensions.StatelessReportEventListener;
+import org.apache.maven.surefire.extensions.StatelessTestSetSummaryListener;
+import org.apache.maven.surefire.extensions.StatelessTestsetInfoConsoleReportEventListener;
+import org.apache.maven.surefire.extensions.StatelessTestsetInfoFileReportEventListener;
+
+/**
+ *
+ */
+public final class ReportersAggregator
+{
+    private StatelessTestsetInfoConsoleReportEventListener<WrappedReportEntry, TestSetStats> consoleReporter;
+    private StatelessTestsetInfoFileReportEventListener<WrappedReportEntry, TestSetStats> fileReporter;
+    private StatelessReportEventListener<WrappedReportEntry, TestSetStats> simpleXMLReporter;
+    private ConsoleOutputReportEventListener testOutputReceiver;
+    private StatisticsReporter statisticsReporter;
+    private StatelessTestSetSummaryListener testSetSummaryReporter;
+    private boolean trimStackTrace;
+    private boolean isPlainFormat;
+    private boolean briefOrPlainFormat;
+
+    public StatelessTestsetInfoConsoleReportEventListener<WrappedReportEntry, TestSetStats> getConsoleReporter()
+    {
+        return consoleReporter;
+    }
+
+    public void setConsoleReporter(
+        StatelessTestsetInfoConsoleReportEventListener<WrappedReportEntry, TestSetStats> consoleReporter )
+    {
+        this.consoleReporter = consoleReporter;
+    }
+
+    public StatelessTestsetInfoFileReportEventListener<WrappedReportEntry, TestSetStats> getFileReporter()
+    {
+        return fileReporter;
+    }
+
+    public void setFileReporter(
+        StatelessTestsetInfoFileReportEventListener<WrappedReportEntry, TestSetStats> fileReporter )
+    {
+        this.fileReporter = fileReporter;
+    }
+
+    public StatelessReportEventListener<WrappedReportEntry, TestSetStats> getSimpleXMLReporter()
+    {
+        return simpleXMLReporter;
+    }
+
+    public void setSimpleXMLReporter( StatelessReportEventListener<WrappedReportEntry, TestSetStats> simpleXMLReporter )
+    {
+        this.simpleXMLReporter = simpleXMLReporter;
+    }
+
+    public ConsoleOutputReportEventListener getTestOutputReceiver()
+    {
+        return testOutputReceiver;
+    }
+
+    public void setTestOutputReceiver( ConsoleOutputReportEventListener testOutputReceiver )
+    {
+        this.testOutputReceiver = testOutputReceiver;
+    }
+
+    public StatisticsReporter getStatisticsReporter()
+    {
+        return statisticsReporter;
+    }
+
+    public void setStatisticsReporter( StatisticsReporter statisticsReporter )
+    {
+        this.statisticsReporter = statisticsReporter;
+    }
+
+    public StatelessTestSetSummaryListener getTestSetSummaryReporter()
+    {
+        return testSetSummaryReporter;
+    }
+
+    public void setTestSetSummaryReporter( StatelessTestSetSummaryListener testSetSummaryReporter )
+    {
+        this.testSetSummaryReporter = testSetSummaryReporter;
+    }
+
+    public boolean isTrimStackTrace()
+    {
+        return trimStackTrace;
+    }
+
+    public void setTrimStackTrace( boolean trimStackTrace )
+    {
+        this.trimStackTrace = trimStackTrace;
+    }
+
+    public boolean isPlainFormat()
+    {
+        return isPlainFormat;
+    }
+
+    public void setPlainFormat( boolean plainFormat )
+    {
+        isPlainFormat = plainFormat;
+    }
+
+    public boolean isBriefOrPlainFormat()
+    {
+        return briefOrPlainFormat;
+    }
+
+    public void setBriefOrPlainFormat( boolean briefOrPlainFormat )
+    {
+        this.briefOrPlainFormat = briefOrPlainFormat;
+    }
+}

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestMethodCalls.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestMethodCalls.java
@@ -1,0 +1,40 @@
+package org.apache.maven.plugin.surefire.report;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.maven.surefire.api.report.UniqueID;
+import org.apache.maven.surefire.extensions.ReportData;
+import org.apache.maven.surefire.extensions.testoperations.TestOperation;
+
+import static java.util.stream.Collectors.toMap;
+
+final class TestMethodCalls
+{
+    private final ReportData reportData = new ReportData();
+
+    void addOperation( TestOperation<?> op )
+    {
+        reportData.addOperation( op );
+    }
+
+    void addRerunOperation( TestOperation<?> op )
+    {
+        reportData.addRetryOperation( op );
+    }
+
+    Map<UniqueID, ReportData> mapTestStats()
+    {
+        return reportData.getIds()
+            .stream()
+            .collect( toMap(
+                id -> id,
+                id ->
+                {
+                    ReportData rep = new ReportData();
+                    reportData.filterOperations( id ).forEach( rep::addOperation );
+                    reportData.filterRerunOperations( id ).forEach( rep::addRetryOperation );
+                    return rep;
+                }, (u, v) -> { throw new IllegalStateException(); }, LinkedHashMap::new ) );
+    }
+}

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestStatsProcessor.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestStatsProcessor.java
@@ -1,0 +1,5 @@
+package org.apache.maven.plugin.surefire.report;
+
+public class TestStatsProcessor
+{
+}

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
@@ -23,6 +23,7 @@ import org.apache.maven.surefire.api.report.ReportEntry;
 import org.apache.maven.surefire.api.report.RunMode;
 import org.apache.maven.surefire.api.report.StackTraceWriter;
 import org.apache.maven.surefire.api.report.TestSetReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
@@ -237,6 +238,11 @@ public class WrappedReportEntry
     public Long getTestRunId()
     {
         return original.getTestRunId();
+    }
+
+    public UniqueID getTestRunUniqueId()
+    {
+        return getTestRunId() == null ? null : new UniqueID( getTestRunId() );
     }
 
     @Override

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReportEntry.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/ReportEntry.java
@@ -21,6 +21,9 @@ package org.apache.maven.surefire.api.report;
 
 import javax.annotation.Nonnull;
 
+import static org.apache.maven.surefire.api.util.internal.ReportEntryUtils.toNameId;
+import static org.apache.maven.surefire.api.util.internal.ReportEntryUtils.toSourceId;
+
 /**
  * Describes a single entry for a test report
  *
@@ -41,6 +44,12 @@ public interface ReportEntry
      */
     String getSourceText();
 
+    default Integer getSourceId()
+    {
+        Long id = getTestRunId();
+        return id == null ? null : toSourceId( id );
+    }
+
     /**
      * The name of the test case
      *
@@ -54,6 +63,12 @@ public interface ReportEntry
      * @return name text
      */
     String getNameText();
+
+    default Integer getNameId()
+    {
+        Long id = getTestRunId();
+        return id == null ? null : toNameId( id );
+    }
 
     /**
      * The group/category of the testcase
@@ -123,4 +138,10 @@ public interface ReportEntry
      * @return id
      */
     Long getTestRunId();
+
+    default UniqueID getUniqueId()
+    {
+        Long id = getTestRunId();
+        return id == null ? null : new UniqueID( id );
+    }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/TestOutputReportEntry.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/TestOutputReportEntry.java
@@ -19,6 +19,9 @@ package org.apache.maven.surefire.api.report;
  * under the License.
  */
 
+import static org.apache.maven.surefire.api.util.internal.ReportEntryUtils.toNameId;
+import static org.apache.maven.surefire.api.util.internal.ReportEntryUtils.toSourceId;
+
 /**
  * This report entry should be used in {@link TestOutputReceiver#writeTestOutput(OutputReportEntry)}.
  *
@@ -117,5 +120,15 @@ public final class TestOutputReportEntry implements OutputReportEntry
     public static TestOutputReportEntry stdErrln( String log )
     {
         return new TestOutputReportEntry( log, false, true );
+    }
+
+    public Integer getSourceId()
+    {
+        return toSourceId( getTestRunId() );
+    }
+
+    public Integer getNameId()
+    {
+        return toNameId( getTestRunId() );
     }
 }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/UniqueID.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/UniqueID.java
@@ -1,0 +1,70 @@
+package org.apache.maven.surefire.api.report;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Objects;
+
+import static org.apache.maven.surefire.api.util.internal.ReportEntryUtils.toSourceId;
+import static org.apache.maven.surefire.api.util.internal.ReportEntryUtils.toTestRunId;
+
+/**
+ *
+ */
+public final class UniqueID
+{
+    private final Long id;
+
+    public UniqueID( int sourceId, Integer testId )
+    {
+        this( testId == null ? toTestRunId( sourceId ) : toTestRunId( sourceId, testId ) );
+    }
+
+    public UniqueID( Long id )
+    {
+        this.id = id;
+
+    }
+
+    public UniqueID toSourceUniqueId()
+    {
+        return new UniqueID( id == null ? null : toTestRunId( toSourceId( id ) ) );
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        UniqueID uniqueID = (UniqueID) o;
+        return Objects.equals( id, uniqueID.id );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( id );
+    }
+}

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/ReportEntryUtils.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/internal/ReportEntryUtils.java
@@ -1,0 +1,79 @@
+package org.apache.maven.surefire.api.util.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Utility class for {@link org.apache.maven.surefire.api.report.ReportEntry}.
+ */
+public final class ReportEntryUtils
+{
+    private ReportEntryUtils()
+    {
+        throw new IllegalStateException( "no instantiable constructor" );
+    }
+
+    /**
+     * @param sourceId class id or source id (parent)
+     * @param testId   test child
+     * @return shifts {@code sourceId} to 32-bit MSB of long and encodes {@code testId} to LSB
+     */
+    public static long toTestRunId( int sourceId, int testId )
+    {
+        return toTestRunId( sourceId ) | testId;
+    }
+
+    /**
+     * @param sourceId class id or source id (parent)
+     * @return shifts in 32 bits
+     */
+    public static long toTestRunId( int sourceId )
+    {
+        return ( (long) sourceId ) << 32;
+    }
+
+    /**
+     * @param testRunId encoded 32-bit MSB source and 32-bit LSB name in 64-bit value
+     * @return shifts {@code testRunId} in 32 bits right
+     */
+    public static int toSourceId( long testRunId )
+    {
+        return (int) ( 0x00000000ffffffffL & ( testRunId >>> 32 ) );
+    }
+
+    public static boolean existsSourceId( Long testRunId )
+    {
+        return testRunId != null && toSourceId( testRunId ) != 0;
+    }
+
+    /**
+     *
+     * @param testRunId encoded 32-bit MSB source and 32-bit LSB name in 64-bit value
+     * @return 32-bit LSB of {@code testRunId}
+     */
+    public static int toNameId( long testRunId )
+    {
+        return (int) ( 0x00000000ffffffffL & testRunId );
+    }
+
+    public static boolean existsNameId( Long testRunId )
+    {
+        return testRunId != null && toNameId( testRunId ) != 0;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/ReportData.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/ReportData.java
@@ -1,0 +1,96 @@
+package org.apache.maven.surefire.extensions;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.surefire.api.report.UniqueID;
+import org.apache.maven.surefire.extensions.testoperations.TestOperation;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ *
+ */
+public final class ReportData
+{
+    private final List<TestOperation<?>> operations = new ArrayList<>();
+    private final List<TestOperation<?>> rerunOperations = new ArrayList<>();
+
+    public void addOperation( TestOperation<?> op )
+    {
+        operations.add( requireNonNull( op ) );
+    }
+
+    public void addRetryOperation( TestOperation<?> op )
+    {
+        rerunOperations.add( requireNonNull( op ) );
+    }
+
+    public Set<UniqueID> getIds()
+    {
+        return operations.stream()
+            .map( TestOperation::getSourceId )
+            .collect( toCollection( LinkedHashSet::new ) );
+    }
+
+    public List<TestOperation<?>> filterOperations( UniqueID sourceId )
+    {
+        return filterBySourceId( sourceId, operations );
+    }
+
+    public List<TestOperation<?>> filterRerunOperations( UniqueID sourceId )
+    {
+        return filterBySourceId( sourceId, rerunOperations );
+    }
+
+    public void removeSourceId( UniqueID sourceId )
+    {
+        removeBySourceId( sourceId, operations.iterator() );
+        removeBySourceId( sourceId, rerunOperations.iterator() );
+    }
+
+    private List<TestOperation<?>> filterBySourceId( UniqueID sourceId, List<TestOperation<?>> sources )
+    {
+        return sources.stream()
+            .filter( op -> op.getSourceId().equals( sourceId ) )
+            .collect( toList() );
+    }
+
+    private void removeBySourceId( UniqueID sourceId, Iterator<TestOperation<?>> it )
+    {
+        for ( TestOperation<?> op; it.hasNext(); )
+        {
+            op = it.next();
+            if ( op.getSourceId().equals( sourceId ) )
+            {
+                it.remove();
+            }
+        }
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportEventListener.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportEventListener.java
@@ -19,7 +19,7 @@ package org.apache.maven.surefire.extensions;
  * under the License.
  */
 
-import org.apache.maven.surefire.api.report.TestSetReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
 
 /**
  * Creates a report upon handled event "<em>testSetCompleted</em>".
@@ -28,16 +28,12 @@ import org.apache.maven.surefire.api.report.TestSetReportEntry;
  *
  * author <a href="mailto:tibordigana@apache.org">Tibor Digana (tibor17)</a>
  * @since 3.0.0-M4
- * @param <R> report entry type, see <em>WrappedReportEntry</em> from module the <em>maven-surefire-common</em>
- * @param <S> test-set statistics, see <em>TestSetStats</em> from module the <em>maven-surefire-common</em>
  */
-public interface StatelessReportEventListener<R extends TestSetReportEntry, S>
+public interface StatelessReportEventListener
 {
     /**
      * The callback is called after the test class has been completed and the state of report is final.
-     *
-     * @param report <em>WrappedReportEntry</em>
-     * @param testSetStats <em>TestSetStats</em>
+     * @param testSetStats <em>StatelessReportData</em>
      */
-     void testSetCompleted( R report, S testSetStats );
+     void testSetCompleted( UniqueID sourceId, ReportData testSetStats );
 }

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessTestSetSummaryListener.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessTestSetSummaryListener.java
@@ -1,0 +1,6 @@
+package org.apache.maven.surefire.extensions;
+
+public interface StatelessTestSetSummaryListener
+{
+    void testSetCompleted(  );
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestAssumptionFailureOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestAssumptionFailureOperation.java
@@ -1,0 +1,22 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public final class TestAssumptionFailureOperation extends TestOperation<ReportEntry>
+{
+    private final ReportEntry event;
+    private final UniqueID sourceId;
+
+    public TestAssumptionFailureOperation( ReportEntry event )
+    {
+        this.event = event;
+        sourceId = event.getUniqueId();
+    }
+
+    @Override
+    public UniqueID getSourceId()
+    {
+        return sourceId;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestErrorOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestErrorOperation.java
@@ -1,0 +1,22 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public final class TestErrorOperation extends TestOperation<ReportEntry>
+{
+    private final ReportEntry event;
+    private final UniqueID sourceId;
+
+    public TestErrorOperation( ReportEntry event )
+    {
+        this.event = event;
+        sourceId = event.getUniqueId();
+    }
+
+    @Override
+    public UniqueID getSourceId()
+    {
+        return sourceId;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestExecutionSkippedByUserOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestExecutionSkippedByUserOperation.java
@@ -1,0 +1,22 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public final class TestExecutionSkippedByUserOperation extends TestOperation<ReportEntry>
+{
+    private final ReportEntry event;
+    private final UniqueID sourceId;
+
+    public TestExecutionSkippedByUserOperation( ReportEntry event )
+    {
+        this.event = event;
+        sourceId = event.getUniqueId();
+    }
+
+    @Override
+    public UniqueID getSourceId()
+    {
+        return sourceId;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestFailedOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestFailedOperation.java
@@ -1,0 +1,22 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public final class TestFailedOperation extends TestOperation<ReportEntry>
+{
+    private final ReportEntry event;
+    private final UniqueID sourceId;
+
+    public TestFailedOperation( ReportEntry event )
+    {
+        this.event = event;
+        sourceId = event.getUniqueId();
+    }
+
+    @Override
+    public UniqueID getSourceId()
+    {
+        return sourceId;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestOperation.java
@@ -1,0 +1,15 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public abstract class TestOperation<T extends ReportEntry>
+{
+    private final long createdAt = System.currentTimeMillis();
+    public abstract UniqueID getSourceId();
+
+    public final long createdAt()
+    {
+        return createdAt;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestSetCompletedOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestSetCompletedOperation.java
@@ -1,0 +1,22 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.TestSetReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public final class TestSetCompletedOperation extends TestOperation<TestSetReportEntry>
+{
+    private final TestSetReportEntry event;
+    private final UniqueID sourceId;
+
+    public TestSetCompletedOperation( TestSetReportEntry event )
+    {
+        this.event = event;
+        sourceId = event.getUniqueId();
+    }
+
+    @Override
+    public UniqueID getSourceId()
+    {
+        return sourceId;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestSetStartingOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestSetStartingOperation.java
@@ -1,0 +1,22 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.TestSetReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public final class TestSetStartingOperation extends TestOperation<TestSetReportEntry>
+{
+    private final TestSetReportEntry event;
+    private final UniqueID sourceId;
+
+    public TestSetStartingOperation( TestSetReportEntry event )
+    {
+        this.event = event;
+        sourceId = event.getUniqueId();
+    }
+
+    @Override
+    public UniqueID getSourceId()
+    {
+        return sourceId;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestSkippedOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestSkippedOperation.java
@@ -1,0 +1,22 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public final class TestSkippedOperation extends TestOperation<ReportEntry>
+{
+    private final ReportEntry event;
+    private final UniqueID sourceId;
+
+    public TestSkippedOperation( ReportEntry event )
+    {
+        this.event = event;
+        sourceId = event.getUniqueId();
+    }
+
+    @Override
+    public UniqueID getSourceId()
+    {
+        return sourceId;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestStartingOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestStartingOperation.java
@@ -1,0 +1,22 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public final class TestStartingOperation extends TestOperation<ReportEntry>
+{
+    private final ReportEntry event;
+    private final UniqueID sourceId;
+
+    public TestStartingOperation( ReportEntry event )
+    {
+        this.event = event;
+        sourceId = event.getUniqueId();
+    }
+
+    @Override
+    public UniqueID getSourceId()
+    {
+        return sourceId;
+    }
+}

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestSucceededOperation.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/testoperations/TestSucceededOperation.java
@@ -1,0 +1,22 @@
+package org.apache.maven.surefire.extensions.testoperations;
+
+import org.apache.maven.surefire.api.report.ReportEntry;
+import org.apache.maven.surefire.api.report.UniqueID;
+
+public final class TestSucceededOperation extends TestOperation<ReportEntry>
+{
+    private final ReportEntry event;
+    private final UniqueID sourceId;
+
+    public TestSucceededOperation( ReportEntry event )
+    {
+        this.event = event;
+        sourceId = event.getUniqueId();
+    }
+
+    @Override
+    public UniqueID getSourceId()
+    {
+        return sourceId;
+    }
+}

--- a/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/ClassMethodIndexer.java
+++ b/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/ClassMethodIndexer.java
@@ -26,6 +26,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.maven.surefire.api.util.internal.ReportEntryUtils.toSourceId;
+import static org.apache.maven.surefire.api.util.internal.ReportEntryUtils.toTestRunId;
 
 /**
  * Creates an index for class/method.
@@ -44,10 +46,10 @@ public final class ClassMethodIndexer
         return testIdMapping.computeIfAbsent( key, cm ->
         {
             Long classId = testIdMapping.get( new ClassMethod( requireNonNull( clazz ), null ) );
-            long c = classId == null ? ( ( (long) classIndex.getAndIncrement() ) << 32 ) : classId;
+            int c = classId == null ? classIndex.getAndIncrement() : toSourceId( classId );
             int m = method == null ? 0 : methodIndex.getAndIncrement();
             long id = c | m;
-            testLocalMapping.set( id );
+            testLocalMapping.set( toTestRunId( c, m ) );
             return id;
         } );
     }
@@ -60,5 +62,10 @@ public final class ClassMethodIndexer
     public Long getLocalIndex()
     {
         return testLocalMapping.get();
+    }
+
+    public void removeLocalIndex()
+    {
+        testLocalMapping.remove();
     }
 }

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -180,10 +180,10 @@ public class JUnitPlatformProvider
         }
         // Rerun failing tests if requested
         int count = parameters.getTestRequest().getRerunFailingTestsCount();
-        if ( count > 0 && adapter.hasFailingTests() )
+        if ( count > 0 )
         {
             adapter.setRunMode( RERUN_TEST_AFTER_FAILURE );
-            for ( int i = 0; i < count; i++ )
+            for ( int i = 0; i < count && adapter.hasFailingTests(); i++ )
             {
                 try
                 {
@@ -193,11 +193,6 @@ public class JUnitPlatformProvider
                     // Reset adapter's recorded failures and invoke the failed tests again
                     adapter.reset();
                     launcher.execute( discoveryRequest, adapter );
-                    // If no tests fail in the rerun, we're done
-                    if ( !adapter.hasFailingTests() )
-                    {
-                        break;
-                    }
                 }
                 finally
                 {

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -172,6 +172,7 @@ final class RunListenerAdapter
                                 createReportEntry( testIdentifier, null, systemProps(), null, elapsed ) );
                     }
             }
+            classMethodIndexer.removeLocalIndex();
         }
 
         runningTestIdentifiersByUniqueId.remove( testIdentifier.getUniqueId() );
@@ -234,9 +235,14 @@ final class RunListenerAdapter
         {
             methodText = null;
         }
+
         StackTraceWriter stw =
                 testExecutionResult == null ? null : toStackTraceWriter( className, methodName, testExecutionResult );
-        return new SimpleReportEntry( runMode, classMethodIndexer.indexClassMethod( className, methodName ), className,
+
+        long uniqueId = classMethodIndexer.indexClassMethod(
+            testIdentifier.getParentId().orElse( className ), testIdentifier.getUniqueId() );
+
+        return new SimpleReportEntry( runMode, uniqueId, className,
             classText, methodName, methodText, stw, elapsedTime, reason, systemProperties );
     }
 


### PR DESCRIPTION
@slawekjaranowski This is a work in progress.
The test reporters must not determine the test status upon timings of test events.
The test reporters must not identify the test run upon text literals (e.g. class and method) of the test entry.

These are all the causes why parallel tests are chaotic in JUnit5 report.
These are the causes why JUnit5 and JUnit4 parameterized tests give different reports.
These are the causes why Cucumber is not able to work with dynamic tests.
Nevertheless this would fix the issue with memory consumption in JUnit47 parallel test and the provider.

So I have some doubts about #516 #544 and #608 and I will make the audit there as well.