### PR TITLE
Remove old junittoolbox dependency no longer used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,11 +325,6 @@
         <version>${jacocoVersion}</version>
         <classifier>runtime</classifier>
       </dependency>
-      <dependency>
-        <groupId>com.googlecode.junit-toolbox</groupId>
-        <artifactId>junit-toolbox</artifactId>
-        <version>2.4</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
Looks like we can get rid of this one. Let's see...