### PR TITLE
[SUREFIRE-1124] Support forkNumber in environment variables

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/DefaultForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/DefaultForkConfiguration.java
@@ -157,6 +157,9 @@ public abstract class DefaultForkConfiguration extends ForkConfiguration {
 
             for (Entry<String, String> entry : getEnvironmentVariables().entrySet()) {
                 String value = entry.getValue();
+                if (value != null) {
+                    value = replaceThreadNumberPlaceholders(value, forkNumber);
+                }
                 cli.addEnvironment(entry.getKey(), value == null ? "" : value);
             }
 

--- a/maven-surefire-plugin/src/site/apt/examples/fork-options-and-parallel-execution.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/fork-options-and-parallel-execution.apt.vm
@@ -281,16 +281,17 @@ public class TestSuite {
   specify variables and values to be added to the system properties during the
   test execution.
 
-  You can use the place holder <<<$\{surefire.forkNumber\}>>> within 
-  <<<argLine>>>, or within the system properties (both those specified via 
+  You can use the placeholder <<<$\{surefire.forkNumber\}>>> within <<<argLine>>>,
+  <<<environmentVariables>>> (since ${project.artifactId}:3.2.0),
+  or within the system properties (both those specified via
   <<<mvn test -D...>>> and via <<<systemPropertyVariables>>>). Before executing 
-  the tests, the ${thisPlugin.toLowerCase()} plugin replaces that place holder
+  the tests, the ${thisPlugin.toLowerCase()} plugin replaces that placeholder
   by the number of the actually executing process, counting from 1 to the
   effective value of <<<forkCount>>> times the maximum number of parallel
   executions in Maven parallel builds, i.e. the effective value of the <<<-T>>>
   command line argument of Maven core.
 
-  In case of disabled forking (<<<forkCount=0>>>), the place holder will be
+  In case of disabled forking (<<<forkCount=0>>>), the placeholder will be
   replaced with <1>.
 
   The following is an example configuration that makes use of up to three forked


### PR DESCRIPTION
Implementation for https://issues.apache.org/jira/browse/SUREFIRE-1124 including test and documentation updates. I also changed "place holder" to "placeholder" in the related documentation section as this is the common way to write it.

Thank you for having a look at this PR!

I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004