### PR TITLE
[SUREFIRE-1934] Ability to disable system-out/system-err for successfully passed tests

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -691,6 +691,16 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
     private boolean enableAssertions;
 
     /**
+     * Flag for including/excluding {@code <system-out />} and {@code <system-err />} elements for
+     * successfully passed tests in XML reports.
+     * Note that the default value may change to {@code false} is a future version.
+     *
+     * @since 3.3.1
+     */
+    @Parameter(property = "enableOutErrElements", defaultValue = "true")
+    private boolean enableOutErrElements;
+
+    /**
      * The current build session instance.
      */
     @Parameter(defaultValue = "${session}", required = true, readonly = true)
@@ -1474,6 +1484,10 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
                         Double.toString(getParallelTestsTimeoutForcedInSeconds()));
         getProperties()
                 .setProperty(ProviderParameterNames.PARALLEL_OPTIMIZE_PROP, Boolean.toString(isParallelOptimized()));
+        getProperties()
+                .setProperty(
+                        ProviderParameterNames.ENABLE_OUT_ERR_ELEMENTS_PROP,
+                        Boolean.toString(isEnableOutErrElements()));
 
         String message = "parallel='" + usedParallel + '\''
                 + ", perCoreThreadCount=" + getPerCoreThreadCount()
@@ -1482,7 +1496,8 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
                 + ", threadCountSuites=" + getThreadCountSuites()
                 + ", threadCountClasses=" + getThreadCountClasses()
                 + ", threadCountMethods=" + getThreadCountMethods()
-                + ", parallelOptimized=" + isParallelOptimized();
+                + ", parallelOptimized=" + isParallelOptimized()
+                + ", enableOutErrElements=" + isEnableOutErrElements();
 
         logDebugOrCliShowErrors(message);
     }
@@ -1976,6 +1991,7 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
                 getReportSchemaLocation(),
                 getEncoding(),
                 isForking,
+                isEnableOutErrElements(),
                 xmlReporter,
                 outReporter,
                 testsetReporter);
@@ -2516,6 +2532,7 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
         checksum.add(getTempDir());
         checksum.add(useModulePath());
         checksum.add(getEnableProcessChecker());
+        checksum.add(isEnableOutErrElements());
         addPluginSpecificChecksumItems(checksum);
         return checksum.getSha1();
     }
@@ -3470,6 +3487,15 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
     @SuppressWarnings("UnusedDeclaration")
     public void setEnableAssertions(boolean enableAssertions) {
         this.enableAssertions = enableAssertions;
+    }
+
+    public boolean isEnableOutErrElements() {
+        return enableOutErrElements;
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public void setEnableOutErrElements(boolean enableOutErrElements) {
+        this.enableOutErrElements = enableOutErrElements;
     }
 
     public MavenSession getSession() {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/CommonReflector.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/CommonReflector.java
@@ -86,6 +86,7 @@ public class CommonReflector {
                 String.class,
                 String.class,
                 boolean.class,
+                boolean.class,
                 statelessTestsetReporter,
                 consoleOutputReporter,
                 statelessTestsetInfoReporter);
@@ -103,6 +104,7 @@ public class CommonReflector {
             reporterConfiguration.getXsdSchemaLocation(),
             reporterConfiguration.getEncoding().name(),
             reporterConfiguration.isForking(),
+            reporterConfiguration.isEnableOutErrElements(),
             reporterConfiguration.getXmlReporter().clone(surefireClassLoader),
             reporterConfiguration.getConsoleOutputReporter().clone(surefireClassLoader),
             reporterConfiguration.getTestsetReporter().clone(surefireClassLoader)

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/StartupReportConfiguration.java
@@ -85,6 +85,8 @@ public final class StartupReportConfiguration {
 
     private final boolean isForking;
 
+    private final boolean enableOutErrElements;
+
     private final SurefireStatelessReporter xmlReporter;
 
     private final SurefireConsoleOutputReporter consoleOutputReporter;
@@ -108,6 +110,7 @@ public final class StartupReportConfiguration {
             String xsdSchemaLocation,
             String encoding,
             boolean isForking,
+            boolean enableOutErrElements,
             SurefireStatelessReporter xmlReporter,
             SurefireConsoleOutputReporter consoleOutputReporter,
             SurefireStatelessTestsetInfoReporter testsetReporter) {
@@ -127,6 +130,7 @@ public final class StartupReportConfiguration {
         String charset = trimToNull(encoding);
         this.encoding = charset == null ? UTF_8 : Charset.forName(charset);
         this.isForking = isForking;
+        this.enableOutErrElements = enableOutErrElements;
         this.xmlReporter = xmlReporter;
         this.consoleOutputReporter = consoleOutputReporter;
         this.testsetReporter = testsetReporter;
@@ -177,6 +181,7 @@ public final class StartupReportConfiguration {
                 trimStackTrace,
                 rerunFailingTestsCount,
                 xsdSchemaLocation,
+                enableOutErrElements,
                 testClassMethodRunHistory);
 
         return xmlReporter.isDisable() ? null : xmlReporter.createListener(xmlReporterConfig);
@@ -237,6 +242,10 @@ public final class StartupReportConfiguration {
 
     public boolean isForking() {
         return isForking;
+    }
+
+    public boolean isEnableOutErrElements() {
+        return enableOutErrElements;
     }
 
     private File resolveReportsDirectory(Integer forkNumber) {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/DefaultStatelessReportMojoConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/DefaultStatelessReportMojoConfiguration.java
@@ -43,8 +43,15 @@ public class DefaultStatelessReportMojoConfiguration extends StatelessReportMojo
             boolean trimStackTrace,
             int rerunFailingTestsCount,
             String xsdSchemaLocation,
+            boolean enableOutErrElements,
             Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory) {
-        super(reportsDirectory, reportNameSuffix, trimStackTrace, rerunFailingTestsCount, xsdSchemaLocation);
+        super(
+                reportsDirectory,
+                reportNameSuffix,
+                trimStackTrace,
+                rerunFailingTestsCount,
+                xsdSchemaLocation,
+                enableOutErrElements);
         this.testClassMethodRunHistory = testClassMethodRunHistory;
     }
 

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireStatelessReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/SurefireStatelessReporter.java
@@ -68,7 +68,8 @@ public class SurefireStatelessReporter
                 false,
                 false,
                 false,
-                false);
+                false,
+                configuration.isEnableOutErrElements());
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5Xml30StatelessReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/extensions/junit5/JUnit5Xml30StatelessReporter.java
@@ -107,7 +107,8 @@ public class JUnit5Xml30StatelessReporter extends SurefireStatelessReporter {
                 getUsePhrasedFileName(),
                 getUsePhrasedTestSuiteClassName(),
                 getUsePhrasedTestCaseClassName(),
-                getUsePhrasedTestCaseMethodName());
+                getUsePhrasedTestCaseMethodName(),
+                configuration.isEnableOutErrElements());
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/NullStatelessXmlReporter.java
@@ -29,7 +29,7 @@ class NullStatelessXmlReporter extends StatelessXmlReporter {
     static final NullStatelessXmlReporter INSTANCE = new NullStatelessXmlReporter();
 
     private NullStatelessXmlReporter() {
-        super(null, null, false, 0, null, null, null, false, false, false, false);
+        super(null, null, false, 0, null, null, null, false, false, false, false, true);
     }
 
     @Override

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -116,6 +116,8 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
 
     private final boolean phrasedMethodName;
 
+    private final boolean enableOutErrElements;
+
     public StatelessXmlReporter(
             File reportsDirectory,
             String reportNameSuffix,
@@ -127,13 +129,15 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
             boolean phrasedFileName,
             boolean phrasedSuiteName,
             boolean phrasedClassName,
-            boolean phrasedMethodName) {
+            boolean phrasedMethodName,
+            boolean enableOutErrElements) {
         this.reportsDirectory = reportsDirectory;
         this.reportNameSuffix = reportNameSuffix;
         this.trimStackTrace = trimStackTrace;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
         this.testClassMethodRunHistoryMap = testClassMethodRunHistoryMap;
         this.xsdSchemaLocation = xsdSchemaLocation;
+        this.enableOutErrElements = enableOutErrElements;
         this.xsdVersion = xsdVersion;
         this.phrasedFileName = phrasedFileName;
         this.phrasedSuiteName = phrasedSuiteName;
@@ -228,7 +232,9 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
                         methodEntry.getReportEntryType().getXmlTag(),
                         false);
             }
-            createOutErrElements(fw, ppw, methodEntry, outputStream);
+            if (methodEntry.getReportEntryType() != SUCCESS || enableOutErrElements) {
+                createOutErrElements(fw, ppw, methodEntry, outputStream);
+            }
             ppw.endElement();
         }
     }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/CommonReflectorTest.java
@@ -82,6 +82,7 @@ public class CommonReflectorTest {
                 null,
                 null,
                 false,
+                true,
                 xmlReporter,
                 consoleOutputReporter,
                 infoReporter);

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
@@ -162,6 +162,7 @@ public class ForkStarterTest {
                 null,
                 null,
                 true,
+                true,
                 xmlReporter,
                 outputReporter,
                 statelessTestsetInfoReporter);
@@ -246,6 +247,7 @@ public class ForkStarterTest {
                 0,
                 null,
                 null,
+                true,
                 true,
                 xmlReporter,
                 outputReporter,

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/TestSetMockReporterFactory.java
@@ -66,6 +66,7 @@ public class TestSetMockReporterFactory extends DefaultReporterFactory {
                 null,
                 null,
                 true,
+                true,
                 new SurefireStatelessReporter(),
                 new SurefireConsoleOutputReporter(),
                 new SurefireStatelessTestsetInfoReporter());

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/StatelessReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/extensions/StatelessReporterTest.java
@@ -66,7 +66,7 @@ public class StatelessReporterTest {
         String schema = "https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd";
         Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory = new HashMap<>();
         DefaultStatelessReportMojoConfiguration config = new DefaultStatelessReportMojoConfiguration(
-                reportsDirectory, reportNameSuffix, true, 5, schema, testClassMethodRunHistory);
+                reportsDirectory, reportNameSuffix, true, 5, schema, true, testClassMethodRunHistory);
         SurefireStatelessReporter extension = new SurefireStatelessReporter();
 
         assertThat(extension.getVersion()).isEqualTo("3.0.1");
@@ -141,7 +141,7 @@ public class StatelessReporterTest {
         String schema = "https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd";
         Map<String, Deque<WrappedReportEntry>> testClassMethodRunHistory = new HashMap<>();
         DefaultStatelessReportMojoConfiguration config = new DefaultStatelessReportMojoConfiguration(
-                reportsDirectory, reportNameSuffix, true, 5, schema, testClassMethodRunHistory);
+                reportsDirectory, reportNameSuffix, true, 5, schema, true, testClassMethodRunHistory);
         JUnit5Xml30StatelessReporter extension = new JUnit5Xml30StatelessReporter();
 
         assertThat(extension.getVersion()).isEqualTo("3.0.1");

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
@@ -85,6 +85,7 @@ public class DefaultReporterFactoryTest extends TestCase {
                 null,
                 null,
                 false,
+                true,
                 new SurefireStatelessReporter(),
                 new SurefireConsoleOutputReporter(),
                 new SurefireStatelessTestsetInfoReporter());
@@ -288,6 +289,7 @@ public class DefaultReporterFactoryTest extends TestCase {
                 null,
                 null,
                 false,
+                true,
                 new SurefireStatelessReporter(),
                 new SurefireConsoleOutputReporter(),
                 new SurefireStatelessTestsetInfoReporter());
@@ -352,6 +354,7 @@ public class DefaultReporterFactoryTest extends TestCase {
                 null,
                 null,
                 false,
+                true,
                 new SurefireStatelessReporter(),
                 new SurefireConsoleOutputReporter(),
                 new SurefireStatelessTestsetInfoReporter());

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -109,7 +109,8 @@ public class StatelessXmlReporterTest extends TestCase {
                 false,
                 false,
                 false,
-                false);
+                false,
+                true);
         reporter.cleanTestHistoryMap();
 
         ReportEntry reportEntry = new SimpleReportEntry(
@@ -169,7 +170,8 @@ public class StatelessXmlReporterTest extends TestCase {
                 false,
                 false,
                 false,
-                false);
+                false,
+                true);
         reporter.testSetCompleted(testSetReportEntry, stats);
 
         FileInputStream fileInputStream = new FileInputStream(expectedReportFile);
@@ -271,7 +273,8 @@ public class StatelessXmlReporterTest extends TestCase {
                 false,
                 false,
                 false,
-                false);
+                false,
+                true);
 
         reporter.testSetCompleted(testSetReportEntry, stats);
         reporter.testSetCompleted(testSetReportEntry, rerunStats);
@@ -370,7 +373,7 @@ public class StatelessXmlReporterTest extends TestCase {
         rerunStats.testSucceeded(testTwoSecondError);
 
         StatelessXmlReporter reporter = new StatelessXmlReporter(
-                reportDir, null, false, 1, new HashMap<>(), XSD, "3.0.1", false, false, false, false);
+                reportDir, null, false, 1, new HashMap<>(), XSD, "3.0.1", false, false, false, false, true);
 
         WrappedReportEntry testSetReportEntry = new WrappedReportEntry(
                 new SimpleReportEntry(
@@ -534,7 +537,7 @@ public class StatelessXmlReporterTest extends TestCase {
                 null);
 
         StatelessXmlReporter reporter = new StatelessXmlReporter(
-                reportDir, null, false, 1, new HashMap<>(), XSD, "3.0.1", false, false, false, false);
+                reportDir, null, false, 1, new HashMap<>(), XSD, "3.0.1", false, false, false, false, true);
 
         reporter.testSetCompleted(testReport, stats);
     }

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ProviderParameterNames.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ProviderParameterNames.java
@@ -45,4 +45,6 @@ public class ProviderParameterNames {
     public static final String PARALLEL_TIMEOUTFORCED_PROP = "paralleltimeoutforced";
 
     public static final String PARALLEL_OPTIMIZE_PROP = "paralleloptimization";
+
+    public static final String ENABLE_OUT_ERR_ELEMENTS_PROP = "enableouterrelements";
 }

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportMojoConfiguration.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReportMojoConfiguration.java
@@ -36,17 +36,21 @@ public class StatelessReportMojoConfiguration {
 
     private final String xsdSchemaLocation;
 
+    private final boolean enableOutErrElements;
+
     public StatelessReportMojoConfiguration(
             File reportsDirectory,
             String reportNameSuffix,
             boolean trimStackTrace,
             int rerunFailingTestsCount,
-            String xsdSchemaLocation) {
+            String xsdSchemaLocation,
+            boolean enableOutErrElements) {
         this.reportsDirectory = reportsDirectory;
         this.reportNameSuffix = reportNameSuffix;
         this.trimStackTrace = trimStackTrace;
         this.rerunFailingTestsCount = rerunFailingTestsCount;
         this.xsdSchemaLocation = xsdSchemaLocation;
+        this.enableOutErrElements = enableOutErrElements;
     }
 
     public File getReportsDirectory() {
@@ -67,5 +71,9 @@ public class StatelessReportMojoConfiguration {
 
     public String getXsdSchemaLocation() {
         return xsdSchemaLocation;
+    }
+
+    public boolean isEnableOutErrElements() {
+        return enableOutErrElements;
     }
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1934OutErrElementsIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1934OutErrElementsIT.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.TestFile;
+import org.junit.Test;
+
+/**
+ * Test for SUREFURE-1934. Enabling and disabling system-out and system-err elements in plugin configuration.
+ *
+ * @author NissMoony
+ */
+public class Surefire1934OutErrElementsIT extends SurefireJUnit4IntegrationTestCase {
+
+    @Test
+    public void testOutErrElementsDisabled() {
+        final OutputValidator outputValidator = unpack("/surefire-1934-disable-out-err-elements")
+                .maven()
+                .withFailure()
+                .executeTest();
+        final TestFile reportFile =
+                outputValidator.getSurefireReportsXmlFile("TEST-disableOutErrElements.TestOutErrElements.xml");
+
+        reportFile.assertNotContainsText("<system-out><![CDATA[System-out output not expected in the report.");
+        reportFile.assertNotContainsText(
+                "<system-err><![CDATA[[main] INFO disableOutErrElements.TestOutErrElements - Log output not expected in test report.");
+        reportFile.assertContainsText("<system-out><![CDATA[System-out output expected in the report.");
+        reportFile.assertContainsText(
+                "<system-err><![CDATA[[main] INFO disableOutErrElements.TestOutErrElements - Log output expected in test report.");
+    }
+
+    @Test
+    public void testOutErrElementsEnabled() {
+        final OutputValidator outputValidator =
+                unpack("/surefire-1934-enable-out-err-elements").executeTest();
+        final TestFile reportFile =
+                outputValidator.getSurefireReportsXmlFile("TEST-enableOutErrElements.TestOutErrElements.xml");
+
+        reportFile.assertContainsText("<system-out>");
+        reportFile.assertContainsText("<system-err>");
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1934-disable-out-err-elements/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1934-disable-out-err-elements/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>surefire-1934-disable-out-err-elements</artifactId>
+  <version>1.0</version>
+  <url>http://maven.apache.org</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.36</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <enableOutErrElements>false</enableOutErrElements>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-1934-disable-out-err-elements/src/test/java/disableOutErrElements/TestOutErrElements.java
+++ b/surefire-its/src/test/resources/surefire-1934-disable-out-err-elements/src/test/java/disableOutErrElements/TestOutErrElements.java
@@ -1,0 +1,23 @@
+package disableOutErrElements;
+
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+public class TestOutErrElements {
+
+    @Test
+    public void successfulTestWithLogs() {
+        LoggerFactory.getLogger(TestOutErrElements.class).info("Log output not expected in test report.");
+        System.out.println("System-out output not expected in the report.");
+        System.err.println("System-err output not expected in the report.");
+    }
+
+    @Test
+    public void failedTestWithLogs() throws Exception {
+        LoggerFactory.getLogger(TestOutErrElements.class).info("Log output expected in test report.");
+        System.out.println("System-out output expected in the report.");
+        System.err.println("System-err output expected in the report.");
+        throw new Exception("Expected to fail");
+    }
+
+}

--- a/surefire-its/src/test/resources/surefire-1934-enable-out-err-elements/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1934-enable-out-err-elements/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.surefire</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>surefire-1934-disable-out-err-elements</artifactId>
+  <version>1.0</version>
+  <url>http://maven.apache.org</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.36</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <!-- Default value, but setting it explicitly for test -->
+          <enableOutErrElements>true</enableOutErrElements>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-1934-enable-out-err-elements/src/test/java/enableOutErrElements/TestOutErrElements.java
+++ b/surefire-its/src/test/resources/surefire-1934-enable-out-err-elements/src/test/java/enableOutErrElements/TestOutErrElements.java
@@ -1,0 +1,15 @@
+package enableOutErrElements;
+
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+public class TestOutErrElements {
+
+    @Test
+    public void successfulTestWithLogs() {
+        LoggerFactory.getLogger(TestOutErrElements.class).info("Log output expected in test report.");
+        System.out.println("System-out output expected in the report.");
+        System.err.println("System-err output expected in the report.");
+    }
+
+}

--- a/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreParameters.java
+++ b/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/JUnitCoreParameters.java
@@ -48,6 +48,8 @@ public final class JUnitCoreParameters {
 
     public static final String PARALLEL_OPTIMIZE_KEY = ProviderParameterNames.PARALLEL_OPTIMIZE_PROP;
 
+    public static final String ENABLE_OUT_ERR_ELEMENTS_KEY = ProviderParameterNames.ENABLE_OUT_ERR_ELEMENTS_PROP;
+
     private final String parallel;
 
     private final boolean perCoreThreadCount;
@@ -68,6 +70,8 @@ public final class JUnitCoreParameters {
 
     private final boolean parallelOptimization;
 
+    private final boolean enableOutErrElements;
+
     public JUnitCoreParameters(Map<String, String> properties) {
         parallel = property(properties, PARALLEL_KEY, "none").toLowerCase();
         perCoreThreadCount = property(properties, PERCORETHREADCOUNT_KEY, true);
@@ -79,6 +83,7 @@ public final class JUnitCoreParameters {
         parallelTestsTimeoutInSeconds = Math.max(property(properties, PARALLEL_TIMEOUT_KEY, 0d), 0);
         parallelTestsTimeoutForcedInSeconds = Math.max(property(properties, PARALLEL_TIMEOUTFORCED_KEY, 0d), 0);
         parallelOptimization = property(properties, PARALLEL_OPTIMIZE_KEY, true);
+        enableOutErrElements = property(properties, ENABLE_OUT_ERR_ELEMENTS_KEY, true);
     }
 
     private static Collection<String> lowerCase(String... elements) {
@@ -164,13 +169,18 @@ public final class JUnitCoreParameters {
         return parallelOptimization;
     }
 
+    public boolean isEnableOutErrElements() {
+        return enableOutErrElements;
+    }
+
     @Override
     public String toString() {
         return "parallel='" + parallel + '\'' + ", perCoreThreadCount=" + perCoreThreadCount + ", threadCount="
                 + threadCount + ", useUnlimitedThreads=" + useUnlimitedThreads + ", threadCountSuites="
                 + threadCountSuites
                 + ", threadCountClasses=" + threadCountClasses + ", threadCountMethods=" + threadCountMethods
-                + ", parallelOptimization=" + parallelOptimization;
+                + ", parallelOptimization=" + parallelOptimization
+                + ", enableOutErrElements=" + enableOutErrElements;
     }
 
     private static boolean property(Map<String, String> properties, String key, boolean fallback) {

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreParametersTest.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreParametersTest.java
@@ -45,6 +45,7 @@ public class JUnitCoreParametersTest {
         assertThat(newTestSetDefault().getParallelTestsTimeoutInSeconds(), is(0d));
         assertThat(newTestSetDefault().getParallelTestsTimeoutForcedInSeconds(), is(0d));
         assertTrue(newTestSetDefault().isParallelOptimization());
+        assertTrue(newTestSetDefault().isEnableOutErrElements());
     }
 
     @Test

--- a/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
+++ b/surefire-providers/surefire-junit47/src/test/java/org/apache/maven/surefire/junitcore/JUnitCoreTester.java
@@ -109,6 +109,7 @@ public class JUnitCoreTester {
                 null,
                 null,
                 false,
+                true,
                 new SurefireStatelessReporter(),
                 new SurefireConsoleOutputReporter(),
                 new SurefireStatelessTestsetInfoReporter());


### PR DESCRIPTION
Added ability to disable system-out and system-err blocks through the plugin configuration.
For some tests the output too big and our pipeline tool cannot parse it.
Added it-tests.