### PR TITLE
Fix TestNG web site URL

### DIFF
--- a/maven-surefire-plugin/src/site/apt/examples/testng.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/testng.apt.vm
@@ -281,7 +281,7 @@ Using TestNG
 </plugins>
 +---+
 
-  For more information on TestNG, see the {{{http://www.testng.org}TestNG web site}}.
+  For more information on TestNG, see the {{{https://testng.org}TestNG web site}}.
 
   You can implement TestNG listener interface <<<org.testng.ITestListener>>> in
   a separate test artifact <<<your-testng-listener-artifact>>> with scope=test, or in project test source code


### PR DESCRIPTION
`http://www.testng.org` does not work anymore. Changed to `https://testng.org`

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
