### PR TITLE
parse element content only if needed to prevent OOME

### DIFF
--- a/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/TestSuiteXmlParser.java
+++ b/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/TestSuiteXmlParser.java
@@ -60,6 +60,8 @@ public final class TestSuiteXmlParser extends DefaultHandler {
 
     private boolean valid;
 
+    private boolean parseContent;
+
     public TestSuiteXmlParser(ConsoleLogger consoleLogger) {
         this.consoleLogger = consoleLogger;
     }
@@ -157,12 +159,14 @@ public final class TestSuiteXmlParser extends DefaultHandler {
                         break;
                     case "failure":
                         currentElement = new StringBuilder();
+                        parseContent = true;
 
                         testCase.setFailure(attributes.getValue("message"), attributes.getValue("type"));
                         currentSuite.incrementNumberOfFailures();
                         break;
                     case "error":
                         currentElement = new StringBuilder();
+                        parseContent = true;
 
                         testCase.setError(attributes.getValue("message"), attributes.getValue("type"));
                         currentSuite.incrementNumberOfErrors();
@@ -181,6 +185,7 @@ public final class TestSuiteXmlParser extends DefaultHandler {
                         break;
                     case "time":
                         currentElement = new StringBuilder();
+                        parseContent = true;
                         break;
                     default:
                         break;
@@ -215,6 +220,7 @@ public final class TestSuiteXmlParser extends DefaultHandler {
             default:
                 break;
         }
+        parseContent = false;
         // TODO extract real skipped reasons
     }
 
@@ -225,7 +231,7 @@ public final class TestSuiteXmlParser extends DefaultHandler {
     public void characters(char[] ch, int start, int length) {
         assert start >= 0;
         assert length >= 0;
-        if (valid && isNotBlank(start, length, ch)) {
+        if (valid && parseContent && isNotBlank(start, length, ch)) {
             currentElement.append(ch, start, length);
         }
     }


### PR DESCRIPTION
While parsing large reports, we identified `OutOfMemoryError` being raised in the `surefire-report-parser` in case the test file contains large CDATA sections below `system-err` / `system-out` in the report.

While this is using a SAX parser, it parses all element contents into a string and that can cause issues for large test reports.
Proposed fix: only keep element contents in memory in case the value is used somewhere for the result.
i.e. `system-err` / `system-out` is just discarded.

Sample project which is demonstrating the issue by creating a huge dummy test report and then uses the parser:
https://github.com/bisswanger/surefire-parser-sample  (see README for details)

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
   `I requested access to the Maven JIRA but still pending access. Once granted, I will raise an issue and update the PR`
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
