### PR TITLE
[SUREFIRE-2219] Add test stdErr/stdOut output to ReportTestCase

### DIFF
--- a/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/ReportTestCase.java
+++ b/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/ReportTestCase.java
@@ -41,6 +41,8 @@ public final class ReportTestCase {
     private String failureErrorLine;
 
     private String failureDetail;
+    private String systemOut;
+    private String systemErr;
 
     private boolean hasFailure;
 
@@ -136,6 +138,24 @@ public final class ReportTestCase {
         hasError = isNotBlank(type);
         hasSkipped = false;
         return setFailureMessage(message).setFailureType(type);
+    }
+
+    public String getSystemOut() {
+        return systemOut;
+    }
+
+    public ReportTestCase setSystemOut(String message) {
+        systemOut = message;
+        return this;
+    }
+
+    public String getSystemErr() {
+        return systemErr;
+    }
+
+    public ReportTestCase setSystemErr(String message) {
+        systemErr = message;
+        return this;
     }
 
     public ReportTestCase setSkipped(String message) {

--- a/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/TestSuiteXmlParser.java
+++ b/surefire-report-parser/src/main/java/org/apache/maven/plugins/surefire/report/TestSuiteXmlParser.java
@@ -171,6 +171,11 @@ public final class TestSuiteXmlParser extends DefaultHandler {
                         testCase.setError(attributes.getValue("message"), attributes.getValue("type"));
                         currentSuite.incrementNumberOfErrors();
                         break;
+                    case "system-out":
+                    case "system-err":
+                        currentElement = new StringBuilder();
+                        parseContent = true;
+                        break;
                     case "skipped":
                         String message = attributes.getValue("message");
                         testCase.setSkipped(message != null ? message : "skipped");
@@ -209,6 +214,12 @@ public final class TestSuiteXmlParser extends DefaultHandler {
             case "error":
                 testCase.setFailureDetail(currentElement.toString())
                         .setFailureErrorLine(parseErrorLine(currentElement, testCase.getFullClassName()));
+                break;
+            case "system-out":
+                testCase.setSystemOut(currentElement.toString());
+                break;
+            case "system-err":
+                testCase.setSystemErr(currentElement.toString());
                 break;
             case "time":
                 try {


### PR DESCRIPTION
`TestSuiteXmlParser` no longer ignores the `system-out` and `system-err` tags from the Surefire report XML. It parses them and sets the corresponding properties in `ReportTestCase`.

@michael-o, this is a bare PR for the back-end. It contains no tests and no changes to `SurefireReportRenderer::constructTestCaseSection`. I leave these up to you. But now you have the raw data to work from. Sorry, I do not have more time than this. Hope it helps a bit anyway. You can just commit on top of this draft PR.

To do:
- [ ] unit tests
- [ ] integration tests (make existing ones pass again, in case they are failing, add new ones)
- [ ] add option to include console logs into the HTML test report
- [ ] depending on the option, render monospaced code sections in `ReportTestCase`, representing `System.out` and `System.err` outputs

---

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
