### PR TITLE
[SUREFIRE-2232] StatelessXmlReporter: handle failed test result without a throwable

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -47,6 +47,7 @@ import static org.apache.maven.plugin.surefire.report.FileReporterUtils.stripIll
 import static org.apache.maven.plugin.surefire.report.ReportEntryType.SKIPPED;
 import static org.apache.maven.plugin.surefire.report.ReportEntryType.SUCCESS;
 import static org.apache.maven.surefire.shared.utils.StringUtils.isBlank;
+import static org.apache.maven.surefire.shared.utils.StringUtils.isNotBlank;
 
 // CHECKSTYLE_OFF: LineLength
 /**
@@ -451,7 +452,9 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
                     String type = delimiter == -1 ? stackTrace : stackTrace.substring(0, delimiter);
                     ppw.addAttribute("type", type);
                 } else {
-                    ppw.addAttribute("type", new StringTokenizer(stackTrace).nextToken());
+                    if (isNotBlank(stackTrace)) {
+                        ppw.addAttribute("type", new StringTokenizer(stackTrace).nextToken());
+                    }
                 }
             }
         }

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -522,6 +522,23 @@ public class StatelessXmlReporterTest extends TestCase {
         assertThat((boolean) getInternalState(out, "closed")).isTrue();
     }
 
+    public void testReporterHandlesATestWithoutMessageAndWithEmptyStackTrace() {
+        StackTraceWriter stackTraceWriterOne = new DeserializedStacktraceWriter(null, null, "");
+
+        WrappedReportEntry testReport = new WrappedReportEntry(
+                new SimpleReportEntry(
+                        NORMAL_RUN, 1L, getClass().getName(), null, "a test name", null, stackTraceWriterOne, 5),
+                ERROR,
+                5,
+                null,
+                null);
+
+        StatelessXmlReporter reporter = new StatelessXmlReporter(
+                reportDir, null, false, 1, new HashMap<>(), XSD, "3.0.1", false, false, false, false);
+
+        reporter.testSetCompleted(testReport, stats);
+    }
+
     private boolean defaultCharsetSupportsSpecialChar() {
         // some charsets are not able to deal with \u0115 on both ways of the conversion
         return "\u0115\u00DC".equals(new String("\u0115\u00DC".getBytes()));


### PR DESCRIPTION
> A regression bug appeared in 3.0.0-M6:
>
> A testNG test class has a listener which updates results from SUCCESS to FAILURE:
 
``` java
@Override
public void onTestSuccess(ITestResult result) {
    result.setStatus(ITestResult.FAILURE);
    result.getTestContext().getPassedTests().removeResult(result);
    result.getTestContext().getFailedTests().addResult(result);
}
```

> Surefire fails to process a failed test result without a throwable and reports 0 total tests. 

```
ForkStarter IOException: java.util.NoSuchElementException.
org.apache.maven.plugin.surefire.booterclient.output.MultipleFailureException: java.util.NoSuchElementException
	at org.apache.maven.plugin.surefire.booterclient.output.ThreadedStreamConsumer$Pumper.<init>(ThreadedStreamConsumer.java:59)
	at org.apache.maven.plugin.surefire.booterclient.output.ThreadedStreamConsumer.<init>(ThreadedStreamConsumer.java:107)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:546)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:285)
	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:250) 
...
Suppressed: java.util.NoSuchElementException
		at java.base/java.util.StringTokenizer.nextToken(StringTokenizer.java:347)
		at org.apache.maven.plugin.surefire.report.StatelessXmlReporter.getTestProblems(StatelessXmlReporter.java:454)
		at org.apache.maven.plugin.surefire.report.StatelessXmlReporter.serializeTestClassWithoutRerun(StatelessXmlReporter.java:221)
		at org.apache.maven.plugin.surefire.report.StatelessXmlReporter.serializeTestClass(StatelessXmlReporter.java:211)
		at org.apache.maven.plugin.surefire.report.StatelessXmlReporter.testSetCompleted(StatelessXmlReporter.java:161)
		at org.apache.maven.plugin.surefire.report.StatelessXmlReporter.testSetCompleted(StatelessXmlReporter.java:85)
		at org.apache.maven.plugin.surefire.report.TestSetRunListener.testSetCompleted(TestSetRunListener.java:193)
		at org.apache.maven.plugin.surefire.booterclient.output.ForkClient$TestSetCompletedListener.handle(ForkClient.java:143)
```
The fix is to set a hardcoded value - `UndefinedException` as `error type` in case stack trace is empty.

<details>
  <summary>checklist </summary>
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
</details>