### PR TITLE
[SUREFIRE-2277] Fix bug in RunResult serialisation/deserialisation to (from) failsafe-summary.xml

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/util/FailsafeSummaryXmlUtils.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/util/FailsafeSummaryXmlUtils.java
@@ -92,6 +92,7 @@ public final class FailsafeSummaryXmlUtils {
                     parseInt(errors),
                     parseInt(failures),
                     parseInt(skipped),
+                    // Backwards compatability - to be replaced with parseInt in a future release
                     isBlank(flakes) ? 0 : parseInt(flakes),
                     isBlank(failureMessage) ? null : unescapeXml(failureMessage),
                     parseBoolean(timeout));

--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/util/FailsafeSummaryXmlUtils.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/util/FailsafeSummaryXmlUtils.java
@@ -64,6 +64,7 @@ public final class FailsafeSummaryXmlUtils {
             + "    <errors>%d</errors>\n"
             + "    <failures>%d</failures>\n"
             + "    <skipped>%d</skipped>\n"
+            + "    <flakes>%d</flakes>\n"
             + "    %s\n"
             + "</failsafe-summary>";
 
@@ -84,12 +85,14 @@ public final class FailsafeSummaryXmlUtils {
             String skipped = xpath.evaluate("/failsafe-summary/skipped", root);
             String failureMessage = xpath.evaluate("/failsafe-summary/failureMessage", root);
             String timeout = xpath.evaluate("/failsafe-summary/@timeout", root);
+            String flakes = xpath.evaluate("/failsafe-summary/flakes", root);
 
             return new RunResult(
                     parseInt(completed),
                     parseInt(errors),
                     parseInt(failures),
                     parseInt(skipped),
+                    isBlank(flakes) ? 0 : parseInt(flakes),
                     isBlank(failureMessage) ? null : unescapeXml(failureMessage),
                     parseBoolean(timeout));
         }
@@ -107,6 +110,7 @@ public final class FailsafeSummaryXmlUtils {
                 fromRunResult.getErrors(),
                 fromRunResult.getFailures(),
                 fromRunResult.getSkipped(),
+                fromRunResult.getFlakes(),
                 msg);
 
         Files.write(

--- a/maven-surefire-plugin/src/site/resources/xsd/failsafe-summary.xsd
+++ b/maven-surefire-plugin/src/site/resources/xsd/failsafe-summary.xsd
@@ -25,7 +25,7 @@
         <xsd:element name="errors" type="xsd:int"/>
         <xsd:element name="failures" type="xsd:int"/>
         <xsd:element name="skipped" type="xsd:int"/>
-        <xsd:element name="flakes" type="xsd:int" nillable="true"/>
+        <xsd:element name="flakes" type="xsd:int" minOccurs="0"/>
         <xsd:element name="failureMessage" type="xsd:string" nillable="true"/>
       </xsd:sequence>
       <xsd:attribute name="result" type="errorType" use="optional"/>
@@ -39,3 +39,4 @@
     </xsd:restriction>
   </xsd:simpleType>
 </xsd:schema>
+

--- a/maven-surefire-plugin/src/site/resources/xsd/failsafe-summary.xsd
+++ b/maven-surefire-plugin/src/site/resources/xsd/failsafe-summary.xsd
@@ -25,6 +25,7 @@
         <xsd:element name="errors" type="xsd:int"/>
         <xsd:element name="failures" type="xsd:int"/>
         <xsd:element name="skipped" type="xsd:int"/>
+        <xsd:element name="flakes" type="xsd:int" nillable="true"/>
         <xsd:element name="failureMessage" type="xsd:string" nillable="true"/>
       </xsd:sequence>
       <xsd:attribute name="result" type="errorType" use="optional"/>
@@ -38,4 +39,3 @@
     </xsd:restriction>
   </xsd:simpleType>
 </xsd:schema>
-

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/suite/RunResult.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/suite/RunResult.java
@@ -221,6 +221,7 @@ public class RunResult {
         result = 31 * result + errors;
         result = 31 * result + failures;
         result = 31 * result + skipped;
+        result = 31 * result + flakes;
         result = 31 * result + (failure != null ? failure.hashCode() : 0);
         result = 31 * result + (timeout ? 1 : 0);
         return result;

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/suite/RunResult.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/suite/RunResult.java
@@ -202,6 +202,9 @@ public class RunResult {
         if (skipped != runResult.skipped) {
             return false;
         }
+        if (flakes != runResult.flakes) {
+            return false;
+        }
         if (timeout != runResult.timeout) {
             return false;
         }


### PR DESCRIPTION
This PR fixes the bug described in https://issues.apache.org/jira/browse/SUREFIRE-2277

**Problem**

There is a bug in `RunResult.testAppendSerialization`. 

This test creates a `RunResult` object in-memory, serialises it, writes it to disk and then again deserialises the same file into a `RunResult` in-memory. I have run the test with the debugger and found that the final in-memory `RunResult` object is not the same as the initial one.

It shouldn't be passing on master, but is due to a bug in the `RunResult.equals` method which is used in an assertion in the test. The source of the bug is that the value of `RunResult.flakes` isn't preserved during serialisation to and from `failsafe-summary.xml`. The bug is slipping through and the test passes because the `RunResult.equals` method doesn't consider the `RunResult.flakes` field. 



**Fix**

I have modified the `failsafe-summary.xsd` to include an _optional_  `<flakes>` element,  which will allow `RunResult.flakes` to be persisted in the `failsafe-summary.xml` during serialisation. I have also changed the serialisation and deserialisation methods for `RunResult` to account for `flakes`. 

I have also added a test, `RunResultTest.testLegacyDeserialization` for backwards compatibility. It tests that deserialising a legacy `failsafe-summary.xml` still works. The behaviour is that when the `flakes` XML element is not present in the `failsafe-summary.xml`, the in-memory `RunResult` will have `RunResult.flakes` set to 0 after deserialisation.

-----
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SUREFIRE) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SUREFIRE-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `SUREFIRE-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
 
 Our company, Atlassian, has a corporate CLA signed, and we added our team to it.
Contributors: Alex Courtis, Bing Xu and Hubert Grzeskowiak
