### PR TITLE
[SUREFIRE-1737] Fix disable in statelessTestsetReporter

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -708,7 +708,7 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
      * @since 2.2
      */
     @Deprecated // todo make readonly to handle system property
-    @Parameter(property = "disableXmlReport", defaultValue = "false")
+    @Parameter(property = "disableXmlReport")
     private Boolean disableXmlReport;
 
     /**
@@ -2060,8 +2060,8 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
         SurefireStatelessReporter xmlReporter =
                 statelessTestsetReporter == null ? new SurefireStatelessReporter() : statelessTestsetReporter;
 
-        if (isDisableXmlReport() != null) {
-            xmlReporter.setDisable(isDisableXmlReport());
+        if (disableXmlReport != null) {
+            xmlReporter.setDisable(disableXmlReport);
         }
 
         SurefireConsoleOutputReporter outReporter =
@@ -2613,7 +2613,7 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
         checksum.add(getParallel());
         checksum.add(isParallelOptimized());
         checksum.add(isTrimStackTrace());
-        checksum.add(isDisableXmlReport());
+        checksum.add(disableXmlReport);
         checksum.add(isUseSystemClassLoader());
         checksum.add(isUseManifestOnlyJar());
         checksum.add(getEncoding());
@@ -3594,15 +3594,6 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
     @SuppressWarnings("UnusedDeclaration")
     public void setTrimStackTrace(boolean trimStackTrace) {
         this.trimStackTrace = trimStackTrace;
-    }
-
-    public Boolean isDisableXmlReport() {
-        return disableXmlReport;
-    }
-
-    @SuppressWarnings("UnusedDeclaration")
-    public void setDisableXmlReport(Boolean disableXmlReport) {
-        this.disableXmlReport = disableXmlReport;
     }
 
     public boolean isEnableAssertions() {

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReporter.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/StatelessReporter.java
@@ -36,7 +36,6 @@ public abstract class StatelessReporter<R extends TestSetReportEntry, S, C exten
     /**
      * {@code false} by default
      */
-    // todo remove isDisableXmlReport() in AbstractSurefireMojo and use this param instead
     private boolean disable;
 
     /**

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/SurefireLauncher.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/SurefireLauncher.java
@@ -353,7 +353,12 @@ public final class SurefireLauncher {
     }
 
     public SurefireLauncher setForkJvm() {
-        mavenLauncher.setForkJvm(true);
+        setForkJvm(true);
+        return this;
+    }
+
+    public SurefireLauncher setForkJvm(boolean forkJvm) {
+        mavenLauncher.setForkJvm(forkJvm);
         return this;
     }
 

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1737IT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1737IT.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import java.io.File;
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration Tests for SUREFIRE-1737
+ */
+public class Surefire1737IT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void selectJUnit5UsingConfiguredProviderWithPlatformRunner() {
+        SurefireLauncher launcher = unpack("surefire-1737");
+        launcher.setForkJvm(false)
+                .forkNever()
+                .executeTest()
+                .verifyTextInLog("Running pkg.JUnit5Test")
+                .verifyTextInLog(
+                        "Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider");
+
+        File baseDir = launcher.getUnpackedAt();
+        assertTrue(new File(baseDir, "target/surefire-reports/pkg.JUnit5Test.txt").exists());
+        // xml report should be not generated
+        File xmlReport = new File(baseDir, "target/surefire-reports/TEST-pkg.JUnit5Test.xml");
+        assertFalse("xml report: " + xmlReport + " should not be generated", xmlReport.exists());
+    }
+}

--- a/surefire-its/src/test/resources/surefire-1737/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1737/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>surefire-1737</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+        <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.12.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <statelessTestsetReporter>
+                        <disable>true</disable>
+                    </statelessTestsetReporter>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-1737/src/test/java/pkg/JUnit5Test.java
+++ b/surefire-its/src/test/resources/surefire-1737/src/test/java/pkg/JUnit5Test.java
@@ -1,0 +1,9 @@
+package pkg;
+
+import org.junit.jupiter.api.Test;
+
+class JUnit5Test {
+    @Test
+    public void test() {
+    }
+}


### PR DESCRIPTION
- old property `disableXmlReport` should be null by default
- add ITs
- small cleanups

https://issues.apache.org/jira/browse/SUREFIRE-1737