### PR TITLE
Fix capturing of output of JUnit `LauncherSessionListener`

### DIFF
--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -107,11 +107,11 @@ public class JUnitPlatformProvider extends AbstractProvider {
     public RunResult invoke(Object forkTestSet) throws TestSetFailedException, ReporterException {
         ReporterFactory reporterFactory = parameters.getReporterFactory();
         final RunResult runResult;
-        try (LauncherSessionAdapter launcherSession = launcherSessionFactory.openSession()) {
-            RunListenerAdapter adapter = new RunListenerAdapter(reporterFactory.createTestReportListener());
-            adapter.setRunMode(NORMAL_RUN);
+        RunListenerAdapter adapter = new RunListenerAdapter(reporterFactory.createTestReportListener());
+        adapter.setRunMode(NORMAL_RUN);
+        startCapture(adapter);
 
-            startCapture(adapter);
+        try (LauncherSessionAdapter launcherSession = launcherSessionFactory.openSession()) {
             setupJunitLogger();
             Launcher launcher = launcherSession.getLauncher();
             if (forkTestSet instanceof TestsToRun) {

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -702,12 +702,15 @@ public class JUnitPlatformProviderTest {
 
         ArgumentCaptor<TestOutputReportEntry> captor = ArgumentCaptor.forClass(TestOutputReportEntry.class);
         verify(runListener, times(6)).writeTestOutput(captor.capture());
-        assertThat(captor.getAllValues().get(0).getLog()).isEqualTo("stdout from launcherSessionOpened");
-        assertThat(captor.getAllValues().get(1).getLog()).isEqualTo("stderr from launcherSessionOpened");
-        assertThat(captor.getAllValues().get(2).getLog()).isEqualTo("stdout");
-        assertThat(captor.getAllValues().get(3).getLog()).isEqualTo("stderr");
-        assertThat(captor.getAllValues().get(4).getLog()).isEqualTo("stdout from launcherSessionClosed");
-        assertThat(captor.getAllValues().get(5).getLog()).isEqualTo("stderr from launcherSessionClosed");
+        assertThat(captor.getAllValues())
+                .extracting(TestOutputReportEntry::getLog)
+                .containsExactly(
+                        "stdout from launcherSessionOpened",
+                        "stderr from launcherSessionOpened",
+                        "stdout",
+                        "stderr",
+                        "stdout from launcherSessionClosed",
+                        "stderr from launcherSessionClosed");
     }
 
     @Test


### PR DESCRIPTION
[This PR](https://github.com/apache/maven-surefire/pull/863) introduces a change in the `JUnitPlatformProvider` class, which causes the output of registered [LauncherSessionListeners](https://docs.junit.org/current/api/org.junit.platform.launcher/org/junit/platform/launcher/LauncherSessionListener.html#launcherSessionOpened(org.junit.platform.launcher.LauncherSession)) during opening a JUnit launcher session to not be captured anymore. The reason for this bug is that the launcher session is opened before output capturing has started.

This PR aims to fix this by starting with output capturing before the JUnit launcher session is actually opened.

The PR also contains an adjusted `JUnitPlatformProviderTest.outputIsCaptured()` that verifies the output capturing of launcher session listeners.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
