### PR TITLE
Upgrade to Maven 4

### DIFF
--- a/maven-surefire-common/pom.xml
+++ b/maven-surefire-common/pom.xml
@@ -78,6 +78,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>

--- a/maven-surefire-report-plugin/pom.xml
+++ b/maven-surefire-report-plugin/pom.xml
@@ -99,7 +99,6 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-shared-utils</artifactId>
-      <version>3.3.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>
@@ -192,6 +191,16 @@
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http-lightweight</artifactId>
       <version>3.5.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- Issue: current code expect version 0.9.0-M3, but Maven 4 uses 0.9.0-M4 and this is the version
+           that we get in the class-path no matter which version we declare here. It causes a compilation
+           failure because of API change in `org.codehaus.plexus.PlexusTestCase.lookup(Class)`, where the
+           `Class` argument has been removed. The `lookup` method now requires a `String`, and I don't
+           know what should be the value of that string (I saw no documentation). -->
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
   </distributionManagement>
 
   <properties>
-    <javaVersion>8</javaVersion>
-    <mavenVersion>3.6.3</mavenVersion>
+    <javaVersion>17</javaVersion>
+    <mavenVersion>4.0.0-rc-4</mavenVersion>
     <resolverVersion>1.4.1</resolverVersion>
     <commonsLang3Version>3.19.0</commonsLang3Version>
     <commonsCompress>1.28.0</commonsCompress>
@@ -103,8 +103,9 @@
     <maven.site.path>surefire-archives/surefire-LATEST</maven.site.path>
     <maven.compiler.testSource>${javaVersion}</maven.compiler.testSource>
     <maven.compiler.testTarget>${javaVersion}</maven.compiler.testTarget>
-    <jvm9ArgsTests />
-    <jvm.args.tests>${jvm9ArgsTests} -Xms32m -Xmx144m -XX:SoftRefLRUPolicyMSPerMB=50 -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</jvm.args.tests>
+    <!-- TODO: needs to check why this plugin wants to open core Java classes. -->
+    <jvm9ArgsTests>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.stream=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/sun.nio.fs=ALL-UNNAMED --add-opens java.base/sun.nio.cs=ALL-UNNAMED --add-opens java.base/java.nio.file=ALL-UNNAMED --add-opens java.base/java.nio.charset=ALL-UNNAMED</jvm9ArgsTests>
+    <jvm.args.tests>${jvm9ArgsTests} -XX:SoftRefLRUPolicyMSPerMB=50 -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</jvm.args.tests>
     <project.build.outputTimestamp>2025-09-10T02:02:34Z</project.build.outputTimestamp>
     <slf4jVersion>1.7.36</slf4jVersion>
   </properties>
@@ -483,15 +484,6 @@
       <id>ide-development</id>
       <properties>
         <surefire-shared-utils.version>3-SNAPSHOT</surefire-shared-utils.version>
-      </properties>
-    </profile>
-    <profile>
-      <id>jdk9+</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <properties>
-        <jvm9ArgsTests>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.stream=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/sun.nio.fs=ALL-UNNAMED --add-opens java.base/sun.nio.cs=ALL-UNNAMED --add-opens java.base/java.nio.file=ALL-UNNAMED --add-opens java.base/java.nio.charset=ALL-UNNAMED</jvm9ArgsTests>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
This is a first attempt to migrate the Maven Surefire Plugin to Maven 4. Before this pull request can be merged, there is two issues to resolves:

* Upgrade the `org.eclipse.sisu.plexus` dependency from 0.9.0-M3 to 0.9.0-M4. There is breaking API change, since the `org.codehaus.plexus.PlexusTestCase.lookup(Class)` method has been removed and I don't know what is the replacement. We would need this upgrade to be done by someone familiar with this API.
* Create a `maven-surefire-plugin-3.x` branch before to merge this pull request or an equivalent one.

A Maven 4 branch is needed before pull requests for testing multi-release projects and improved JPMS support can be submitted.