### PR TITLE
Remove long-deprecated unused encoding property from VerifyMojo

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
@@ -147,15 +147,6 @@ public class VerifyMojo extends AbstractMojo implements SurefireReportParameters
     private int failOnFlakeCount;
 
     /**
-     * No effect. UTF-8 is always used for <code>failsafe-summary.xml</code>.
-     *
-     * @deprecated since 2.20.1
-     */
-    @Deprecated
-    @Parameter(property = "encoding", defaultValue = "${project.reporting.outputEncoding}")
-    private String encoding;
-
-    /**
      * The current build session instance.
      */
     @Parameter(defaultValue = "${session}", readonly = true)


### PR DESCRIPTION
Since 2.20.1 this is deprecated, but as far as I cheked this encoding property in VerifyMojo is not used anywhere.
It's a minor iconvenience to see a warning about it in every build log.
<img width="1099" height="142" alt="image" src="https://github.com/user-attachments/assets/f9b29c16-dc2c-4ee2-8316-b0c8db85cba6" />


 - [ x ] Each commit in the pull request should have a meaningful subject line and body.
 - [ x ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ x ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ x ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

 - [ x ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
