### PR TITLE
Missing many files in the GH Artifacts of CI ex-post.

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -32,9 +32,21 @@ jobs:
       ff-site-goal: '-v'
       verify-goal: 'clean install -nsu -P run-its'
       verify-fail-fast: false
+      # Investigation reasons: Some tests generate custom files, standard reports and logs.
+      # Remove the line with `*-jvmRun*-events.bin` pattern if large streams should be investigated.
       failure-upload-path: |
-        surefire-its/target/*/log.txt
-        surefire-its/target/**/surefire-reports/*
-        surefire-its/target/**/failsafe-reports/*
+        **/*
+        !**/pom.xml
+        !**/*.java
+        !**/*.class
+        !**/*.jar
+        !**/*.war
+        !**/*.tar.gz
+        !**/*.tgz
+        !**/*.zip
+        !**/target/site/*
+        !**/target/staging/*
+        !**/hs_err_pid*
+        !surefire-its/target/ConsoleOutputIT_*/target/surefire-reports/*-jvmRun*-events.bin
       timeout-minutes: 600
       os-matrix: '[ "ubuntu-latest", "windows-2022", "macos-latest" ]'


### PR DESCRIPTION
According to the [build result](https://github.com/apache/maven-surefire/actions/runs/18348935990/job/54055098597?pr=3200) we have found out that the test failed (**ForkedBooterTest.testThreadDump:190  NullPointer**), the build crashed  but we have no Artifact for the analysis.
We are missing a lots of files in the archive. Currently we can see only some XML reports of the ITs but that's not enough for the complete analysis. We are missing logs, dump files, etc. We are missing unit tests, and another ITs from the Failsafe module.


To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

