### PR TITLE
Align method filtering behavior between JUnit and TestNG

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/IncludesExcludesTestInheritanceIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/IncludesExcludesTestInheritanceIT.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class IncludesExcludesTestInheritanceIT extends SurefireJUnit4IntegrationTestCase {
+
+    @Parameter
+    @SuppressWarnings("checkstyle:visibilitymodifier")
+    public String provider;
+
+    @Parameters(name = "Provider: {0}")
+    public static List<String> providers() {
+        return Arrays.asList("JUnit", "TestNG");
+    }
+
+    private final String[] allTests = new String[] {
+        "OtherClass#testIncluded",
+        "OtherClass#testNotIncluded",
+        "SubClass#testInSubClass",
+        "SuperClass#testInSuperClass"
+    };
+
+    private final String[] subClassTests = new String[] {"SubClass#testInSubClass", "SuperClass#testInSuperClass"};
+
+    @Test
+    public void testInclusionOfInheritedTest() throws VerificationException {
+        // includesFile:
+        // SubClass
+        verifyOnlyExpectedTestsExecuted(unpack().activateProfile("profile1"), subClassTests);
+
+        // same with -Dtest option
+        verifyOnlyExpectedTestsExecuted(unpack().addGoal("-Dtest=SubClass"), subClassTests);
+    }
+
+    @Test
+    public void testInclusionOfInheritedTestWhenMethodFilterUsed() throws VerificationException {
+        // includesFile:
+        // SubClass
+        // OtherClass#testIncluded
+        verifyOnlyExpectedTestsExecuted(
+                unpack().activateProfile("profile2"),
+                "OtherClass#testIncluded",
+                "SubClass#testInSubClass",
+                "SuperClass#testInSuperClass");
+    }
+
+    @Test
+    public void testInclusionOfInheritedTestOnly() throws VerificationException {
+        // includesFile:
+        // SubClass#testInSuperClass
+        verifyOnlyExpectedTestsExecuted(unpack().activateProfile("profile3"), "SuperClass#testInSuperClass");
+
+        // same with -Dtest option
+        verifyOnlyExpectedTestsExecuted(
+                unpack().addGoal("-Dtest=SubClass#testInSuperClass"), "SuperClass#testInSuperClass");
+    }
+
+    @Test
+    public void testExclusionOfInheritedTest() throws VerificationException {
+        // includesFile:
+        // SubClass
+        // excludesFile:
+        // SubClass#testInSuperClass
+        verifyOnlyExpectedTestsExecuted(unpack().activateProfile("profile4"), "SubClass#testInSubClass");
+    }
+
+    @Test
+    public void testIncorrectExclusionOfInheritedTest() throws VerificationException {
+        // includesFile:
+        // SubClass
+        // excludesFile:
+        // SuperClass
+        verifyOnlyExpectedTestsExecuted(unpack().activateProfile("profile5"), subClassTests);
+
+        // same with <includes> and <excludes>
+        verifyOnlyExpectedTestsExecuted(unpack().activateProfile("profile6"), subClassTests);
+    }
+
+    @Test
+    public void testIncorrectExclusionOfInheritedTestWithMethodFilter() throws VerificationException {
+        // includesFile:
+        // SubClass
+        // excludesFile:
+        // SuperClass#testInSuperClass
+        verifyOnlyExpectedTestsExecuted(unpack().activateProfile("profile7"), subClassTests);
+    }
+
+    private void verifyOnlyExpectedTestsExecuted(SurefireLauncher launcher, String... expectedTests)
+            throws VerificationException {
+        verifyOnlyExpectedTestsExecuted(launcher, new HashSet<>(Arrays.asList(expectedTests)));
+    }
+
+    private void verifyOnlyExpectedTestsExecuted(SurefireLauncher launcher, Set<String> expectedTests)
+            throws VerificationException {
+        String module = provider.toLowerCase();
+        OutputValidator outputValidator = launcher.addGoal("-pl=" + module).executeTest();
+        for (String test : allTests) {
+            if (expectedTests.contains(test)) {
+                assertThatTestWasExecuted(outputValidator, test);
+            } else {
+                assertThatTestWasNotExecuted(outputValidator, test);
+            }
+        }
+        launcher.getSubProjectValidator(module).verifyErrorFree(expectedTests.size());
+    }
+
+    private void assertThatTestWasExecuted(OutputValidator outputValidator, String test) throws VerificationException {
+        assertEquals(
+                String.format("Test %s was not executed with %s provider.", test, provider),
+                1,
+                testExecutionLogOccurrences(outputValidator, test));
+    }
+
+    private void assertThatTestWasNotExecuted(OutputValidator outputValidator, String test)
+            throws VerificationException {
+        assertEquals(
+                String.format("Test %s was executed with %s provider.", test, provider),
+                0,
+                testExecutionLogOccurrences(outputValidator, test));
+    }
+
+    private int testExecutionLogOccurrences(OutputValidator outputValidator, String test) throws VerificationException {
+        return outputValidator
+                .loadLogLines(containsString(testExecutionLog(test)))
+                .size();
+    }
+
+    private String testExecutionLog(String test) {
+        return String.format("%s: %s executed", provider, test);
+    }
+
+    private SurefireLauncher unpack() {
+        return unpack("/includes-excludes-test-inheritance");
+    }
+}

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/exclusions4.txt
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/exclusions4.txt
@@ -1,0 +1,1 @@
+SubClass#testInSuperClass

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/exclusions5.txt
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/exclusions5.txt
@@ -1,0 +1,1 @@
+SuperClass

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/exclusions7.txt
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/exclusions7.txt
@@ -1,0 +1,1 @@
+SuperClass#testInSuperClass

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions1.txt
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions1.txt
@@ -1,0 +1,1 @@
+SubClass

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions2.txt
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions2.txt
@@ -1,0 +1,2 @@
+SubClass
+OtherClass#testIncluded

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions3.txt
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions3.txt
@@ -1,0 +1,1 @@
+SubClass#testInSuperClass

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions4.txt
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions4.txt
@@ -1,0 +1,1 @@
+SubClass

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions5.txt
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions5.txt
@@ -1,0 +1,1 @@
+SubClass

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions7.txt
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/inclusions7.txt
@@ -1,0 +1,1 @@
+SubClass

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/junit/pom.xml
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/junit/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>maven-it-includes-excludes-test-inheritance</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>junit</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.14.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/junit/src/test/java/OtherClass.java
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/junit/src/test/java/OtherClass.java
@@ -1,0 +1,17 @@
+package junit;
+
+import org.junit.jupiter.api.Test;
+
+public class OtherClass {
+
+    @Test
+    public void testIncluded() {
+        System.out.println("JUnit: OtherClass#testIncluded executed");
+    }
+
+    @Test
+    public void testNotIncluded() {
+        System.out.println("JUnit: OtherClass#testNotIncluded executed");
+    }
+
+}

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/junit/src/test/java/SubClass.java
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/junit/src/test/java/SubClass.java
@@ -1,0 +1,12 @@
+package junit;
+
+import org.junit.jupiter.api.Test;
+
+public class SubClass extends SuperClass {
+
+    @Test
+    public void testInSubClass() {
+        System.out.println("JUnit: SubClass#testInSubClass executed");
+    }
+
+}

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/junit/src/test/java/SuperClass.java
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/junit/src/test/java/SuperClass.java
@@ -1,0 +1,12 @@
+package junit;
+
+import org.junit.jupiter.api.Test;
+
+public abstract class SuperClass {
+
+    @Test
+    public void testInSuperClass() {
+        System.out.println("JUnit: SuperClass#testInSuperClass executed");
+    }
+
+}

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/pom.xml
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/pom.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>maven-it-includes-excludes-test-inheritance</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <modules>
+    <module>testng</module>
+    <module>junit</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>profile1</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includesFile>${project.parent.basedir}/inclusions1.txt</includesFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>profile2</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includesFile>${project.parent.basedir}/inclusions2.txt</includesFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>profile3</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includesFile>${project.parent.basedir}/inclusions3.txt</includesFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>profile4</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includesFile>${project.parent.basedir}/inclusions4.txt</includesFile>
+              <excludesFile>${project.parent.basedir}/exclusions4.txt</excludesFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>profile5</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includesFile>${project.parent.basedir}/inclusions5.txt</includesFile>
+              <excludesFile>${project.parent.basedir}/exclusions5.txt</excludesFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>profile6</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>SubClass</includes>
+              <excludes>SuperClass</excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>profile7</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includesFile>${project.parent.basedir}/inclusions7.txt</includesFile>
+              <excludesFile>${project.parent.basedir}/exclusions7.txt</excludesFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/testng/pom.xml
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/testng/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>maven-it-includes-excludes-test-inheritance</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>testng</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>7.5.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/testng/src/test/java/OtherClass.java
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/testng/src/test/java/OtherClass.java
@@ -1,0 +1,17 @@
+package testng;
+
+import org.testng.annotations.Test;
+
+public class OtherClass {
+
+    @Test
+    public void testIncluded() {
+        System.out.println("TestNG: OtherClass#testIncluded executed");
+    }
+
+    @Test
+    public void testNotIncluded() {
+        System.out.println("TestNG: OtherClass#testNotIncluded executed");
+    }
+
+}

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/testng/src/test/java/SubClass.java
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/testng/src/test/java/SubClass.java
@@ -1,0 +1,12 @@
+package testng;
+
+import org.testng.annotations.Test;
+
+public class SubClass extends SuperClass {
+
+    @Test
+    public void testInSubClass() {
+        System.out.println("TestNG: SubClass#testInSubClass executed");
+    }
+
+}

--- a/surefire-its/src/test/resources/includes-excludes-test-inheritance/testng/src/test/java/SuperClass.java
+++ b/surefire-its/src/test/resources/includes-excludes-test-inheritance/testng/src/test/java/SuperClass.java
@@ -1,0 +1,12 @@
+package testng;
+
+import org.testng.annotations.Test;
+
+public abstract class SuperClass {
+
+    @Test
+    public void testInSuperClass() {
+        System.out.println("TestNG: SuperClass#testInSuperClass executed");
+    }
+
+}

--- a/surefire-providers/surefire-testng-utils/src/main/java/org/apache/maven/surefire/testng/utils/MethodSelector.java
+++ b/surefire-providers/surefire-testng-utils/src/main/java/org/apache/maven/surefire/testng/utils/MethodSelector.java
@@ -61,7 +61,9 @@ public class MethodSelector implements IMethodSelector {
         boolean hasTestResolver = resolver != null && !resolver.isEmpty();
         if (hasTestResolver) {
             boolean run = false;
-            for (Class<?> clazz = test.getRealClass();
+            Class<?> testClass =
+                    test.getTestClass() != null ? test.getTestClass().getRealClass() : test.getRealClass();
+            for (Class<?> clazz = testClass;
                     !run && clazz != null && clazz != Object.class;
                     clazz = clazz.getSuperclass()) {
                 run = resolver.shouldRun(clazz, test.getMethodName());

--- a/surefire-providers/surefire-testng-utils/src/test/java/testng/utils/MethodSelectorTest.java
+++ b/surefire-providers/surefire-testng-utils/src/test/java/testng/utils/MethodSelectorTest.java
@@ -44,6 +44,18 @@ public class MethodSelectorTest extends TestCase {
         assertTrue(include);
     }
 
+    public void testInclusionOfInheritedMethod() {
+        MethodSelector selector = new MethodSelector();
+        DefaultMethodSelectorContext context = new DefaultMethodSelectorContext();
+        ITestNGMethod testngMethod = new FakeTestNGMethod(
+                BaseClassSample.class, "baseClassMethodToBeIncluded", new FakeTestClass(ChildClassSample.class));
+        TestListResolver resolver =
+                new TestListResolver(ChildClassSample.class.getName() + "#baseClassMethodToBeIncluded");
+        MethodSelector.setTestListResolver(resolver);
+        boolean include = selector.includeMethod(context, testngMethod, true);
+        assertTrue(include);
+    }
+
     public void testNoInclusionOfMethodFromBaseClass() {
         MethodSelector selector = new MethodSelector();
         DefaultMethodSelectorContext context = new DefaultMethodSelectorContext();
@@ -67,10 +79,16 @@ public class MethodSelectorTest extends TestCase {
     private static class FakeTestNGMethod implements ITestNGMethod {
         private final Class<?> clazz;
         private final String methodName;
+        private final ITestClass testClass;
 
         FakeTestNGMethod(Class<?> clazz, String methodName) {
+            this(clazz, methodName, new FakeTestClass(clazz));
+        }
+
+        FakeTestNGMethod(Class<?> clazz, String methodName, ITestClass testClass) {
             this.clazz = clazz;
             this.methodName = methodName;
+            this.testClass = testClass;
         }
 
         @Override
@@ -80,7 +98,7 @@ public class MethodSelectorTest extends TestCase {
 
         @Override
         public ITestClass getTestClass() {
-            return null;
+            return testClass;
         }
 
         @Override
@@ -311,6 +329,103 @@ public class MethodSelectorTest extends TestCase {
         @Override
         public int compareTo(Object o) {
             return 0;
+        }
+    }
+
+    private static class FakeTestClass implements ITestClass {
+
+        private final Class<?> realClass;
+
+        FakeTestClass(Class<?> realClass) {
+            this.realClass = realClass;
+        }
+
+        @Override
+        public String getName() {
+            return "";
+        }
+
+        @Override
+        public String getTestName() {
+            return "";
+        }
+
+        @Override
+        public Class getRealClass() {
+            return realClass;
+        }
+
+        @Override
+        public Object[] getInstances(boolean reuse) {
+            return new Object[0];
+        }
+
+        @Override
+        public long[] getInstanceHashCodes() {
+            return new long[0];
+        }
+
+        @Override
+        public void addInstance(Object instance) {}
+
+        @Override
+        public int getInstanceCount() {
+            return 0;
+        }
+
+        @Override
+        public ITestNGMethod[] getTestMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getBeforeTestMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getAfterTestMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getBeforeClassMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getAfterClassMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getBeforeSuiteMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getAfterSuiteMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getBeforeTestConfigurationMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getAfterTestConfigurationMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getBeforeGroupsMethods() {
+            return new ITestNGMethod[0];
+        }
+
+        @Override
+        public ITestNGMethod[] getAfterGroupsMethods() {
+            return new ITestNGMethod[0];
         }
     }
 }


### PR DESCRIPTION
Closes #3225
This PR aligns the method filtering behavior between JUnit and TestNG by adjusting the TestNG MethodSelector.

### Problem

Given the following test classes:

```java
public class SubClass extends SuperClass {
    @Test
    public void testInSubClass() {}
}
```

```java
public abstract class SuperClass {
    @Test
    public void testInSuperClass() {}
}
```

```java
public class OtherClass {
    @Test
    public void testIncluded() {}

    @Test
    public void testNotIncluded() {}
}
```

When using an includesFile containing SubClass only, `testInSubClass` and `testInSuperClass` are executed (as expected).

If the includesFile does not only contain class filters but also method filters, the behavior is different (with TestNG only), and `testInSuperClass` is not executed anymore.
Example includesFile:
```
SubClass
OtherClass#testIncluded
```
With this, only `testInSubClass`  and `OtherClass#testIncluded` are executed. 

### Root Cause

TestNG uses the MethodSelector for filtering the tests. For `testInSuperClass()` the MethodSelector is invoked with an ITestNGMethod instance like this:

- `getRealClass()` returns SuperClass
- `getTestClass().getRealClass()` returns SubClass

The current MethodSelector implementation uses `getRealClass()` and then checks whether to run `SuperClass#testInSuperClass`. If we have SubClass in the includesFile, the test will not be executed, even though SubClass inherits it. This is different when using JUnit instead of TestNG.

### Fix

This PR changes the MethodSelector implementation to use `getTestClass().getRealClass()` to check whether to run a test. The behavior changes as follows:

- In the example above, `testInSuperClass` gets executed too.
- With `SubClass#testInSuperClass` in the includesFile, prior to this PR no test was executed. Now `SubClass#testInSuperClass` gets executed.
- With SubClass in the includesFile and `SuperClass#testInSuperClass` in the excludesFile, prior to this PR only `SubClass#testInSubClass` got executed. Now the inherited test `SubClass#testInSuperClass` gets executed too.

The PR includes tests that are executed with TestNG and JUnit to ensure the behavior aligns.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
