### PR TITLE
Reduce log level for skipped tests result to info

### DIFF
--- a/surefire-logger-api/src/main/java/org/apache/maven/plugin/surefire/log/api/Level.java
+++ b/surefire-logger-api/src/main/java/org/apache/maven/plugin/surefire/log/api/Level.java
@@ -48,14 +48,18 @@ public enum Level {
 
     public static Level resolveLevel(
             boolean hasSuccessful, boolean hasFailure, boolean hasError, boolean hasSkipped, boolean hasFlake) {
-        boolean isRed = hasFailure | hasError;
-        if (isRed) {
+        if (hasFailure || hasError) {
             return FAILURE;
         }
-        boolean isYellow = hasSkipped | hasFlake;
-        if (isYellow) {
+        if (hasFlake) {
             return UNSTABLE;
         }
-        return hasSuccessful ? SUCCESS : NO_COLOR;
+        if (hasSkipped) {
+            return NO_COLOR;
+        }
+        if (hasSuccessful) {
+            return SUCCESS;
+        }
+        return NO_COLOR;
     }
 }

--- a/surefire-logger-api/src/test/java/org/apache/maven/plugin/surefire/log/api/LevelTest.java
+++ b/surefire-logger-api/src/test/java/org/apache/maven/plugin/surefire/log/api/LevelTest.java
@@ -54,7 +54,7 @@ public class LevelTest {
     @Test
     public void shouldBeSkipped() {
         Level level = resolveLevel(false, false, false, true, false);
-        assertThat(level).isEqualTo(Level.UNSTABLE);
+        assertThat(level).isEqualTo(Level.NO_COLOR);
     }
 
     @Test


### PR DESCRIPTION
This PR proposes to reduce the log level for skipped tests result to `info`.

In my opinion skipping tests during execution should not raise any concerns as it is usually an active choice by developers.
Utilizing `@Disabled` or `@Ignored` and the likes is very common in order to (temporarily) skip tests or even prevent execution on different environments and so on.

Issuing a warning in the log gives a false sense of something being wrong were in fact everything is just working as intended.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
