### PR TITLE
[SUREFIRE-3239] allow override of statistics file checksum

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -369,6 +369,15 @@ public class IntegrationTestMojo extends AbstractSurefireMojo {
     private Long runOrderRandomSeed;
 
     /**
+     * Used to override the checksum in the name of the statistics file
+     * when {@code failsafe.runOrder} is set to "balanced".
+     *
+     * @since 3.5.5
+     */
+    @Parameter(property = "failsafe.runOrder.statisticsFile.checksum")
+    private String runOrderStatisticsFileChecksum;
+
+    /**
      * A file containing include patterns, each in a next line. Blank lines, or lines starting with # are ignored.
      * If {@code includes} are also specified, these patterns are appended. Example with path, simple and regex
      * includes:
@@ -928,6 +937,16 @@ public class IntegrationTestMojo extends AbstractSurefireMojo {
     @Override
     public void setRunOrderRandomSeed(Long runOrderRandomSeed) {
         this.runOrderRandomSeed = runOrderRandomSeed;
+    }
+
+    @Override
+    public String getRunOrderStatisticsFileChecksum() {
+        return runOrderStatisticsFileChecksum;
+    }
+
+    @Override
+    public void setRunOrderStatisticsFileChecksum(String runOrderStatisticsFileChecksum) {
+        this.runOrderStatisticsFileChecksum = runOrderStatisticsFileChecksum;
     }
 
     @Override

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoJava7PlusTest.java
@@ -787,6 +787,14 @@ public class AbstractSurefireMojoJava7PlusTest {
         public void setRunOrderRandomSeed(Long runOrderRandomSeed) {}
 
         @Override
+        public String getRunOrderStatisticsFileChecksum() {
+            return null;
+        }
+
+        @Override
+        public void setRunOrderStatisticsFileChecksum(String runOrderStatisticsFileChecksum) {}
+
+        @Override
         protected void handleSummary(RunResult summary, Exception firstForkException) {}
 
         @Override

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -2235,6 +2235,14 @@ public class AbstractSurefireMojoTest {
         public void setRunOrderRandomSeed(Long runOrderRandomSeed) {}
 
         @Override
+        public String getRunOrderStatisticsFileChecksum() {
+            return null;
+        }
+
+        @Override
+        public void setRunOrderStatisticsFileChecksum(String runOrderStatisticsFileChecksum) {}
+
+        @Override
         protected void handleSummary(RunResult summary, Exception firstForkException) {}
 
         @Override

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/MojoMocklessTest.java
@@ -57,7 +57,7 @@ public class MojoMocklessTest {
     public void testGetStartupReportConfiguration() throws Exception {
         AbstractSurefireMojo surefirePlugin = new Mojo(null, null);
         StartupReportConfiguration config =
-                invokeMethod(surefirePlugin, "getStartupReportConfiguration", "", false, mock(ProviderInfo.class));
+                invokeMethod(surefirePlugin, "getStartupReportConfiguration", false, mock(ProviderInfo.class));
 
         assertThat(config.getXmlReporter()).isNotNull().isInstanceOf(SurefireStatelessReporter.class);
 
@@ -77,7 +77,7 @@ public class MojoMocklessTest {
         setInternalState(surefirePlugin, "statelessTestsetInfoReporter", testsetInfoReporter);
 
         StartupReportConfiguration config =
-                invokeMethod(surefirePlugin, "getStartupReportConfiguration", "", false, mock(ProviderInfo.class));
+                invokeMethod(surefirePlugin, "getStartupReportConfiguration", false, mock(ProviderInfo.class));
 
         assertThat(config.getXmlReporter()).isNotNull().isSameAs(xmlReporter);
 
@@ -544,6 +544,14 @@ public class MojoMocklessTest {
 
         @Override
         public void setRunOrderRandomSeed(Long runOrderRandomSeed) {}
+
+        @Override
+        public String getRunOrderStatisticsFileChecksum() {
+            return "dummyStatistics";
+        }
+
+        @Override
+        public void setRunOrderStatisticsFileChecksum(String runOrderStatisticsFileChecksum) {}
 
         @Override
         public String[] getDependenciesToScan() {

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefireMojo.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefireMojo.java
@@ -348,6 +348,15 @@ public class SurefireMojo extends AbstractSurefireMojo implements SurefireReport
     private Long runOrderRandomSeed;
 
     /**
+     * Used to override the checksum in the name of the statistics file
+     * when {@code surefire.runOrder} is set to "balanced".
+     *
+     * @since 3.5.5
+     */
+    @Parameter(property = "surefire.runOrder.statisticsFile.checksum")
+    private String runOrderStatisticsFileChecksum;
+
+    /**
      * A file containing include patterns. Blank lines, or lines starting with # are ignored. If {@code includes} are
      * also specified, these patterns are appended. Example with path, simple and regex includes:
      * <pre><code>
@@ -849,6 +858,16 @@ public class SurefireMojo extends AbstractSurefireMojo implements SurefireReport
     @Override
     public void setRunOrderRandomSeed(Long runOrderRandomSeed) {
         this.runOrderRandomSeed = runOrderRandomSeed;
+    }
+
+    @Override
+    public String getRunOrderStatisticsFileChecksum() {
+        return runOrderStatisticsFileChecksum;
+    }
+
+    @Override
+    public void setRunOrderStatisticsFileChecksum(String runOrderStatisticsFileChecksum) {
+        this.runOrderStatisticsFileChecksum = runOrderStatisticsFileChecksum;
     }
 
     @Override

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/SurefireLauncher.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/SurefireLauncher.java
@@ -197,6 +197,11 @@ public final class SurefireLauncher {
         return this;
     }
 
+    public SurefireLauncher runOrderStatisticsFileChecksum(String runOrderStatisticsFileChecksum) {
+        mavenLauncher.sysProp("surefire.runOrder.statisticsFile.checksum", runOrderStatisticsFileChecksum);
+        return this;
+    }
+
     public SurefireLauncher failIfNoTests(boolean fail) {
         mavenLauncher.sysProp("failIfNoTests", fail);
         return this;


### PR DESCRIPTION
This is an escape hatch in scenarios where the configuration keeps changing for each CI run but the duration of test classes does not depend on the configuration at all.
By setting a fixed checksum users can make sure that test execution data from previous runs always gets used when balancing parallel execution buckets.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
