### PR TITLE
Build only by the latest Maven on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ properties(
 )
 // final def oses = ['linux':'ubuntu && maven', 'windows':'windows-he']
 final def oses = ['linux':'ubuntu']
-final def mavens = env.BRANCH_NAME == 'master' ? ['3.x.x', '3.6.3'] : ['3.x.x']
+final def mavens = ['3.x.x']
 // all non-EOL versions and the first EA
 final def jdks = [21, 17, 11, 8]
 


### PR DESCRIPTION
We have did similar:

- https://github.com/apache/maven-jenkins-lib/pull/14

after upgrade to prant 47 - build on jenkins will failed

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
