### PR TITLE
Add null guard before setting context map in Pumper thread

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ThreadedStreamConsumer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ThreadedStreamConsumer.java
@@ -82,7 +82,9 @@ public final class ThreadedStreamConsumer implements EventHandler<Event>, Closea
             // copy mdc context map from parent thread so that mvn
             // tools that build in parallel can use it in there logging
             // to make clear what module is producing the logs
-            MDC.setContextMap(parentThreadsMdcContextMap);
+            if (parentThreadsMdcContextMap != null) {
+                MDC.setContextMap(parentThreadsMdcContextMap);
+            }
             while (!stop.get() || !synchronizer.isEmptyQueue()) {
                 try {
                     Event item = synchronizer.awaitNext();


### PR DESCRIPTION
# Details

Improvement to  <https://github.com/apache/maven-surefire/pull/3241> with null guard before setting the context map in `ThreadedStreamConsumer$Pumper`. In the original PR, introduced in 3.5.5, the `Pumper` constructor captures the parent thread's MDC context map via `MDC.getCopyOfContextMap()`, and `Pumper.run()` restores it via `MDC.setContextMap(parentThreadsMdcContextMap)`

`MDC.getCopyOfContextMap()` [is documented](https://www.slf4j.org/api/org/slf4j/MDC.html#getCopyOfContextMap()) as able to return `null` values, while `MDC.setContextMap()` only supports nulled arguments since SLF4J version 2.0.0

When using an adapter conforming to a previous version (for example, [Logback](https://github.com/qos-ch/logback/commit/7e3e2ae770) <1.4.2), this can cause an NPE, killing the `Pumper` daemon thread.

# Checklist

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
