### PR TITLE
[SUREFIRE-2049] Fix SHUTDOWN type lost during command serialization.

### DIFF
--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/lazytestprovider/TestLessInputStreamBuilderTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/lazytestprovider/TestLessInputStreamBuilderTest.java
@@ -72,7 +72,7 @@ public class TestLessInputStreamBuilderTest {
 
         builder.getCachableCommands().shutdown(KILL);
         assertTrue(iterator.hasNext());
-        assertThat(iterator.next(), is(new Command(SHUTDOWN, "KILL")));
+        assertThat(iterator.next(), is(new Command(SHUTDOWN, KILL.getParam())));
 
         builder.removeStream(is);
     }
@@ -178,7 +178,7 @@ public class TestLessInputStreamBuilderTest {
         Command bye = decoder.decode();
         assertThat(bye, is(notNullValue()));
         assertThat(bye.getCommandType(), is(SHUTDOWN));
-        assertThat(bye.getData(), is(KILL.name()));
+        assertThat(bye.getData(), is(KILL.getParam()));
         Command noop = decoder.decode();
         assertThat(noop, is(notNullValue()));
         assertThat(noop.getCommandType(), is(NOOP));

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/Command.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/Command.java
@@ -48,7 +48,7 @@ public final class Command {
     }
 
     public static Command toShutdown(Shutdown shutdownType) {
-        return new Command(MasterProcessCommand.SHUTDOWN, shutdownType.name());
+        return new Command(MasterProcessCommand.SHUTDOWN, shutdownType.getParam());
     }
 
     public static Command toRunClass(String runClass) {
@@ -65,13 +65,12 @@ public final class Command {
 
     /**
      * @return {@link Shutdown} or {@link Shutdown#DEFAULT} if {@link #getData()} is null or blank string
-     * @throws IllegalArgumentException if string data {@link #getData()} is not applicable to enum {@link Shutdown}
      */
     public Shutdown toShutdownData() {
         if (command != MasterProcessCommand.SHUTDOWN) {
             throw new IllegalStateException("expected MasterProcessCommand.SHUTDOWN");
         }
-        return isBlank(data) ? Shutdown.DEFAULT : Shutdown.valueOf(data);
+        return isBlank(data) ? Shutdown.DEFAULT : Shutdown.parameterOf(data);
     }
 
     @Override

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/CommandChannelDecoderTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/CommandChannelDecoderTest.java
@@ -144,7 +144,7 @@ public class CommandChannelDecoderTest {
         CommandChannelDecoder decoder = new CommandChannelDecoder(newChannel(is), args);
         Command command = decoder.decode();
         assertThat(command.getCommandType()).isSameAs(SHUTDOWN);
-        assertThat(command.getData()).isEqualTo(shutdownType.name());
+        assertThat(command.getData()).isEqualTo(shutdownType.getParam());
     }
 
     @Test
@@ -159,7 +159,7 @@ public class CommandChannelDecoderTest {
         CommandChannelDecoder decoder = new CommandChannelDecoder(newChannel(is), args);
         Command command = decoder.decode();
         assertThat(command.getCommandType()).isSameAs(SHUTDOWN);
-        assertThat(command.getData()).isEqualTo(shutdownType.name());
+        assertThat(command.getData()).isEqualTo(shutdownType.getParam());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class CommandChannelDecoderTest {
         CommandChannelDecoder decoder = new CommandChannelDecoder(newChannel(is), args);
         Command command = decoder.decode();
         assertThat(command.getCommandType()).isSameAs(SHUTDOWN);
-        assertThat(command.getData()).isEqualTo(shutdownType.name());
+        assertThat(command.getData()).isEqualTo(shutdownType.getParam());
     }
 
     @Test


### PR DESCRIPTION
### Problem

When `forkedProcessTimeoutInSeconds` is configured, the plugin correctly detects the timeout and sends a `SHUTDOWN(KILL)` command to the forked JVM through the binary command channel. However, the forked JVM receives `SHUTDOWN(DEFAULT)` instead of `SHUTDOWN(KILL)` due to a data format mismatch in the serialization. This causes the forked JVM to ignore the kill signal entirely — the build hangs for the full duration of the test instead of terminating after the configured timeout.

### Root Cause

The `Shutdown` enum has two string representations:

| Enum constant | `name()` (Java enum name) | `getParam()` (wire protocol value) |
|---|---|---|
| `DEFAULT` | `"DEFAULT"` | `"testset"` |
| `EXIT` | `"EXIT"` | `"exit"` |
| `KILL` | `"KILL"` | `"kill"` |

The sending side and receiving side used different representations:

**Sending side (plugin):**
`Command.toShutdown(Shutdown.KILL)` stored `shutdownType.name()` → `"KILL"`, which was then serialized by `CommandEncoder.sendShutdown("KILL")` and sent over the binary command channel.

**Receiving side (forked JVM):**
`CommandDecoder.toMessage()` extracted the string `"KILL"` from the wire and passed it to `Shutdown.parameterOf("KILL")`, which iterates through enum values comparing against `shutdown.param`:

- `"testset".equals("KILL")` → false
- `"exit".equals("KILL")` → false
- `"kill".equals("KILL")` → false (case mismatch)

Since nothing matched, `parameterOf()` fell through and returned `Shutdown.DEFAULT`. The forked JVM's `ForkedBooter.createExitHandler()` then entered the else branch (neither `isKill()` nor `isExit()`), which only dumps a thread trace — the JVM continues running.

### Fix
1. **`toShutdown()`**: Changed `shutdownType.name()` to `shutdownType.getParam()` so the wire protocol sends `"kill"` instead of `"KILL"`
2. **`toShutdownData()`**: Changed `Shutdown.valueOf(data)` to `Shutdown.parameterOf(data)` so the reverse conversion is consistent

This makes the sending side consistent with what the receiving side's `CommandDecoder` already expects via `Shutdown.parameterOf()`.

### Verification

Tested with a project containing a single test that sleeps for 5 minutes with `forkedProcessTimeoutInSeconds=5`. For the record, it is the sample that was shared here: https://github.com/apache/maven-surefire/issues/2049.

- **Before fix:** Build hangs for the full 5 minutes
- **After fix:** Build completes in ~6 seconds with the message:
  `Surefire is going to kill self fork JVM. Received SHUTDOWN {KILL} command from Maven shutdown hook.`

### Checklist

Following this checklist to help us incorporate your contribution quickly and easily:

- [X] Each commit in the pull request should have a meaningful subject line and body.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [X] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
