### PR TITLE
Supporting WMIC and PowerShell

### DIFF
--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProcessInfo.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ProcessInfo.java
@@ -34,6 +34,7 @@ import javax.annotation.Nonnull;
 final class ProcessInfo {
     static final ProcessInfo INVALID_PROCESS_INFO = new ProcessInfo(null, 0);
     static final ProcessInfo ERR_PROCESS_INFO = new ProcessInfo(null, 0);
+    static final ProcessInfo ERR_CMD_NOT_FOUND = new ProcessInfo(null, 0);
 
     /**
      * On Unix we do not get PID due to the command is interested only to etime of PPID:
@@ -65,7 +66,7 @@ final class ProcessInfo {
     }
 
     boolean isError() {
-        return this == ERR_PROCESS_INFO;
+        return this == ERR_PROCESS_INFO || this == ERR_CMD_NOT_FOUND;
     }
 
     String getPID() {

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/PpidCheckerTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/PpidCheckerTest.java
@@ -371,7 +371,7 @@ public class PpidCheckerTest {
         assumeThat(System.getenv("SystemRoot"), is(not("")));
         assumeTrue(new File(System.getenv("SystemRoot"), "System32\\Wbem").isDirectory());
         assumeTrue(new File(System.getenv("SystemRoot"), "System32\\Wbem\\wmic.exe").isFile());
-        assertThat((Boolean) invokeMethod(PpidChecker.class, "hasWmicStandardSystemPath"))
+        assertThat((Boolean) invokeMethod(PpidChecker.class, "hasWmicStandardSystemPath32"))
                 .isTrue();
         assertThat(new File(System.getenv("SystemRoot"), "System32\\Wbem\\wmic.exe"))
                 .isFile();


### PR DESCRIPTION
@michael-o 
@olamy 
@slawekjaranowski 
The fix should be like this instead of making tons of unnecessary changes with Java 9. Microsoft removed WMIC command in Windows 11 and added PowerShell, so this is what we support as well.
If we are participating on this discussion in the mailing list and we are still not finished clarifying the things, we cannot push make a proactive commit since it is very childish and then it will be finished by the revert as before.
