### PR TITLE
Add ITs for AfterAll/AfterClass teardown failure

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit4FailingAfterClassIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit4FailingAfterClassIT.java
@@ -29,14 +29,6 @@ import static org.hamcrest.Matchers.is;
 /**
  * Integration test for JUnit 4 @AfterClass that always fails.
  * Verifies that surefire properly reports errors when class-level teardown throws.
- *
- * <p>Current behavior on master is broken:
- * <ul>
- *   <li>The error is counted as a flake instead of an error in the XML summary</li>
- *   <li>tests count is inflated (3 instead of 2)</li>
- * </ul>
- *
- * <p>Once fixed, the XML should report errors="1".
  */
 public class JUnit4FailingAfterClassIT extends SurefireJUnit4IntegrationTestCase {
     private static final String VERSION = "4.13.2";
@@ -49,49 +41,33 @@ public class JUnit4FailingAfterClassIT extends SurefireJUnit4IntegrationTestCase
                 .withFailure()
                 .executeTest();
 
-        // The @AfterClass failure should be reported in the log
         outputValidator.verifyTextInLog("AfterClass always fails");
 
-        // The passing test class should still be error-free
         outputValidator
                 .getSurefireReportsXmlFile("TEST-junit4.PassingTest.xml")
                 .assertContainsText("tests=\"1\" errors=\"0\"");
 
-        // BUG: The XML summary says errors="0" despite the @AfterClass error being present as a testcase.
-        //      The error is misclassified as a flake.
-        //      After fix, this should assert errors="1" and flakes="0".
         outputValidator
                 .getSurefireReportsXmlFile("TEST-junit4.AlwaysFailingAfterClassTest.xml")
+                .assertContainsText("name=\"initializationError\"")
                 .assertContainsText("errors=\"0\"")
                 .assertContainsText("flakes=\"1\"");
-
-        // The @AfterClass error testcase is named "initializationError".
-        outputValidator
-                .getSurefireReportsXmlFile("TEST-junit4.AlwaysFailingAfterClassTest.xml")
-                .assertContainsText("name=\"initializationError\"");
     }
 
     @Test
     public void testAfterClassFailureWithRerun() throws VerificationException {
-        // BUG: With reruns, the build actually PASSES because the @AfterClass error is
-        //      misclassified as a flake. This is the scenario reported in PR #3329:
-        //      the error is swallowed and the build appears green.
-        //      After fix, the build should fail because the @AfterClass always errors.
         OutputValidator outputValidator = unpack("junit4-failing-after-class", "-rerun")
                 .setJUnitVersion(VERSION)
                 .maven()
                 .addGoal("-Dsurefire.rerunFailingTestsCount=2")
                 .executeTest();
 
-        // The error is misclassified as a flake in the XML
         outputValidator
                 .getSurefireReportsXmlFile("TEST-junit4.AlwaysFailingAfterClassTest.xml")
+                .assertContainsText("name=\"initializationError\"")
                 .assertContainsText("errors=\"0\"")
                 .assertContainsText("flakes=\"1\"");
 
-        // BUG: The passing test methods get re-executed 3 times (rerunFailingTestsCount + 1)
-        //      because the @AfterClass error triggers a class-level rerun.
-        //      After fix, passing test methods should not be rerun due to a teardown failure.
         outputValidator.assertThatLogLine(containsString("testOne passed"), is(3));
         outputValidator.assertThatLogLine(containsString("testTwo passed"), is(3));
     }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit4FailingAfterClassIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit4FailingAfterClassIT.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Integration test for JUnit 4 @AfterClass that always fails.
+ * Verifies that surefire properly reports errors when class-level teardown throws.
+ *
+ * <p>Current behavior on master is broken:
+ * <ul>
+ *   <li>The error is counted as a flake instead of an error in the XML summary</li>
+ *   <li>tests count is inflated (3 instead of 2)</li>
+ * </ul>
+ *
+ * <p>Once fixed, the XML should report errors="1".
+ */
+public class JUnit4FailingAfterClassIT extends SurefireJUnit4IntegrationTestCase {
+    private static final String VERSION = "4.13.2";
+
+    @Test
+    public void testAfterClassFailureIsReported() {
+        OutputValidator outputValidator = unpack("junit4-failing-after-class", "-norerun")
+                .setJUnitVersion(VERSION)
+                .maven()
+                .withFailure()
+                .executeTest();
+
+        // The @AfterClass failure should be reported in the log
+        outputValidator.verifyTextInLog("AfterClass always fails");
+
+        // The passing test class should still be error-free
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit4.PassingTest.xml")
+                .assertContainsText("tests=\"1\" errors=\"0\"");
+
+        // BUG: The XML summary says errors="0" despite the @AfterClass error being present as a testcase.
+        //      The error is misclassified as a flake.
+        //      After fix, this should assert errors="1" and flakes="0".
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit4.AlwaysFailingAfterClassTest.xml")
+                .assertContainsText("errors=\"0\"")
+                .assertContainsText("flakes=\"1\"");
+
+        // The @AfterClass error testcase is named "initializationError".
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit4.AlwaysFailingAfterClassTest.xml")
+                .assertContainsText("name=\"initializationError\"");
+    }
+
+    @Test
+    public void testAfterClassFailureWithRerun() throws VerificationException {
+        // BUG: With reruns, the build actually PASSES because the @AfterClass error is
+        //      misclassified as a flake. This is the scenario reported in PR #3329:
+        //      the error is swallowed and the build appears green.
+        //      After fix, the build should fail because the @AfterClass always errors.
+        OutputValidator outputValidator = unpack("junit4-failing-after-class", "-rerun")
+                .setJUnitVersion(VERSION)
+                .maven()
+                .addGoal("-Dsurefire.rerunFailingTestsCount=2")
+                .executeTest();
+
+        // The error is misclassified as a flake in the XML
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit4.AlwaysFailingAfterClassTest.xml")
+                .assertContainsText("errors=\"0\"")
+                .assertContainsText("flakes=\"1\"");
+
+        // BUG: The passing test methods get re-executed 3 times (rerunFailingTestsCount + 1)
+        //      because the @AfterClass error triggers a class-level rerun.
+        //      After fix, passing test methods should not be rerun due to a teardown failure.
+        outputValidator.assertThatLogLine(containsString("testOne passed"), is(3));
+        outputValidator.assertThatLogLine(containsString("testTwo passed"), is(3));
+    }
+}

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit5FailingAfterAllIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit5FailingAfterAllIT.java
@@ -29,14 +29,6 @@ import static org.hamcrest.Matchers.is;
 /**
  * Integration test for JUnit 5 @AfterAll that always fails.
  * Verifies that surefire properly reports errors when class-level teardown throws.
- *
- * <p>Current behavior on master is broken:
- * <ul>
- *   <li>The error is counted as a flake instead of an error in the XML summary</li>
- *   <li>tests count is inflated (3 instead of 2)</li>
- * </ul>
- *
- * <p>Once fixed, the XML should report errors="1".
  */
 public class JUnit5FailingAfterAllIT extends SurefireJUnit4IntegrationTestCase {
     private static final String VERSION = "5.9.1";
@@ -49,49 +41,33 @@ public class JUnit5FailingAfterAllIT extends SurefireJUnit4IntegrationTestCase {
                 .withFailure()
                 .executeTest();
 
-        // The @AfterAll failure should be reported in the log
         outputValidator.verifyTextInLog("AfterAll always fails");
 
-        // The passing test class should still be error-free
         outputValidator
                 .getSurefireReportsXmlFile("TEST-junit5.PassingTest.xml")
                 .assertContainsText("tests=\"1\" errors=\"0\"");
 
-        // BUG: The XML summary says errors="0" despite the @AfterAll error being present as a testcase.
-        //      The error is misclassified as a flake.
-        //      After fix, this should assert errors="1" and flakes="0".
         outputValidator
                 .getSurefireReportsXmlFile("TEST-junit5.AlwaysFailingAfterAllTest.xml")
+                .assertContainsText("name=\"initializationError\"")
                 .assertContainsText("errors=\"0\"")
                 .assertContainsText("flakes=\"1\"");
-
-        // The @AfterAll error testcase is named "initializationError".
-        outputValidator
-                .getSurefireReportsXmlFile("TEST-junit5.AlwaysFailingAfterAllTest.xml")
-                .assertContainsText("name=\"initializationError\"");
     }
 
     @Test
     public void testAfterAllFailureWithRerun() throws VerificationException {
-        // BUG: With reruns, the build actually PASSES because the @AfterAll error is
-        //      misclassified as a flake. This is the scenario reported in PR #3329:
-        //      the error is swallowed and the build appears green.
-        //      After fix, the build should fail because the @AfterAll always errors.
         OutputValidator outputValidator = unpack("junit5-failing-after-all", "-rerun")
                 .setJUnitVersion(VERSION)
                 .maven()
                 .addGoal("-Dsurefire.rerunFailingTestsCount=2")
                 .executeTest();
 
-        // The error is misclassified as a flake in the XML
         outputValidator
                 .getSurefireReportsXmlFile("TEST-junit5.AlwaysFailingAfterAllTest.xml")
+                .assertContainsText("name=\"initializationError\"")
                 .assertContainsText("errors=\"0\"")
                 .assertContainsText("flakes=\"1\"");
 
-        // BUG: The passing test methods get re-executed 3 times (rerunFailingTestsCount + 1)
-        //      because the @AfterAll error triggers a class-level rerun.
-        //      After fix, passing test methods should not be rerun due to a teardown failure.
         outputValidator.assertThatLogLine(containsString("testOne passed"), is(3));
         outputValidator.assertThatLogLine(containsString("testTwo passed"), is(3));
     }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit5FailingAfterAllIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit5FailingAfterAllIT.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Integration test for JUnit 5 @AfterAll that always fails.
+ * Verifies that surefire properly reports errors when class-level teardown throws.
+ *
+ * <p>Current behavior on master is broken:
+ * <ul>
+ *   <li>The error is counted as a flake instead of an error in the XML summary</li>
+ *   <li>tests count is inflated (3 instead of 2)</li>
+ * </ul>
+ *
+ * <p>Once fixed, the XML should report errors="1".
+ */
+public class JUnit5FailingAfterAllIT extends SurefireJUnit4IntegrationTestCase {
+    private static final String VERSION = "5.9.1";
+
+    @Test
+    public void testAfterAllFailureIsReported() {
+        OutputValidator outputValidator = unpack("junit5-failing-after-all", "-norerun")
+                .setJUnitVersion(VERSION)
+                .maven()
+                .withFailure()
+                .executeTest();
+
+        // The @AfterAll failure should be reported in the log
+        outputValidator.verifyTextInLog("AfterAll always fails");
+
+        // The passing test class should still be error-free
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit5.PassingTest.xml")
+                .assertContainsText("tests=\"1\" errors=\"0\"");
+
+        // BUG: The XML summary says errors="0" despite the @AfterAll error being present as a testcase.
+        //      The error is misclassified as a flake.
+        //      After fix, this should assert errors="1" and flakes="0".
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit5.AlwaysFailingAfterAllTest.xml")
+                .assertContainsText("errors=\"0\"")
+                .assertContainsText("flakes=\"1\"");
+
+        // The @AfterAll error testcase is named "initializationError".
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit5.AlwaysFailingAfterAllTest.xml")
+                .assertContainsText("name=\"initializationError\"");
+    }
+
+    @Test
+    public void testAfterAllFailureWithRerun() throws VerificationException {
+        // BUG: With reruns, the build actually PASSES because the @AfterAll error is
+        //      misclassified as a flake. This is the scenario reported in PR #3329:
+        //      the error is swallowed and the build appears green.
+        //      After fix, the build should fail because the @AfterAll always errors.
+        OutputValidator outputValidator = unpack("junit5-failing-after-all", "-rerun")
+                .setJUnitVersion(VERSION)
+                .maven()
+                .addGoal("-Dsurefire.rerunFailingTestsCount=2")
+                .executeTest();
+
+        // The error is misclassified as a flake in the XML
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit5.AlwaysFailingAfterAllTest.xml")
+                .assertContainsText("errors=\"0\"")
+                .assertContainsText("flakes=\"1\"");
+
+        // BUG: The passing test methods get re-executed 3 times (rerunFailingTestsCount + 1)
+        //      because the @AfterAll error triggers a class-level rerun.
+        //      After fix, passing test methods should not be rerun due to a teardown failure.
+        outputValidator.assertThatLogLine(containsString("testOne passed"), is(3));
+        outputValidator.assertThatLogLine(containsString("testTwo passed"), is(3));
+    }
+}

--- a/surefire-its/src/test/resources/junit4-failing-after-class/pom.xml
+++ b/surefire-its/src/test/resources/junit4-failing-after-class/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit4-failing-after-class</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Test for failing @AfterClass in JUnit 4</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/surefire-its/src/test/resources/junit4-failing-after-class/src/test/java/junit4/AlwaysFailingAfterClassTest.java
+++ b/surefire-its/src/test/resources/junit4-failing-after-class/src/test/java/junit4/AlwaysFailingAfterClassTest.java
@@ -1,0 +1,29 @@
+package junit4;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+
+/**
+ * Test class with @AfterClass that always fails.
+ * All test methods pass, but the class-level teardown always throws.
+ */
+public class AlwaysFailingAfterClassTest
+{
+    @AfterClass
+    public static void tearDown()
+    {
+        throw new IllegalStateException( "AfterClass always fails" );
+    }
+
+    @Test
+    public void testOne()
+    {
+        System.out.println( "testOne passed" );
+    }
+
+    @Test
+    public void testTwo()
+    {
+        System.out.println( "testTwo passed" );
+    }
+}

--- a/surefire-its/src/test/resources/junit4-failing-after-class/src/test/java/junit4/PassingTest.java
+++ b/surefire-its/src/test/resources/junit4-failing-after-class/src/test/java/junit4/PassingTest.java
@@ -1,0 +1,16 @@
+package junit4;
+
+import org.junit.Test;
+
+/**
+ * A simple passing test class to verify that other tests are unaffected
+ * by the failing @AfterClass in another test class.
+ */
+public class PassingTest
+{
+    @Test
+    public void testPassingOne()
+    {
+        System.out.println( "testPassingOne passed" );
+    }
+}

--- a/surefire-its/src/test/resources/junit5-failing-after-all/pom.xml
+++ b/surefire-its/src/test/resources/junit5-failing-after-all/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit5-failing-after-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Test for failing @AfterAll in JUnit 5</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/surefire-its/src/test/resources/junit5-failing-after-all/src/test/java/junit5/AlwaysFailingAfterAllTest.java
+++ b/surefire-its/src/test/resources/junit5-failing-after-all/src/test/java/junit5/AlwaysFailingAfterAllTest.java
@@ -1,0 +1,29 @@
+package junit5;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class with @AfterAll that always fails.
+ * All test methods pass, but the class-level teardown always throws.
+ */
+public class AlwaysFailingAfterAllTest
+{
+    @AfterAll
+    static void tearDown()
+    {
+        throw new IllegalStateException( "AfterAll always fails" );
+    }
+
+    @Test
+    public void testOne()
+    {
+        System.out.println( "testOne passed" );
+    }
+
+    @Test
+    public void testTwo()
+    {
+        System.out.println( "testTwo passed" );
+    }
+}

--- a/surefire-its/src/test/resources/junit5-failing-after-all/src/test/java/junit5/PassingTest.java
+++ b/surefire-its/src/test/resources/junit5-failing-after-all/src/test/java/junit5/PassingTest.java
@@ -1,0 +1,16 @@
+package junit5;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A simple passing test class to verify that other tests are unaffected
+ * by the failing @AfterAll in another test class.
+ */
+public class PassingTest
+{
+    @Test
+    public void testPassingOne()
+    {
+        System.out.println( "testPassingOne passed" );
+    }
+}


### PR DESCRIPTION
Add integration tests exposing broken surefire behavior when JUnit 4
`@AfterClass` or JUnit 5 `@AfterAll` methods always throw. The tests
document the following bugs on master:

- XML report has `errors="0"` despite an `<error>` element in a testcase
- The teardown error is misclassified as a flake (`flakes="1"`)
- With `rerunFailingTestsCount`, the build passes green because the
  deterministic teardown failure is swallowed as a flake
- Passing test methods are needlessly re-executed (`rerunCount + 1` times)

--------

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)