### PR TITLE
Fixes #3264 : tests inside @Suite incorrectly classified as flakes

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1787JUnit45IT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1787JUnit45IT.java
@@ -143,7 +143,7 @@ public class Surefire1787JUnit45IT extends SurefireJUnit4IntegrationTestCase {
                 .verifyTextInLog("Running pkg.domain.AxTest")
                 .assertThatLogLine(containsString("Running pkg.domain.BxTest"), equalTo(0));
 
-        TestFile xmlReportFile = outputValidator.getSurefireReportsXmlFile("TEST-pkg.JUnit5Tests.xml");
+        TestFile xmlReportFile = outputValidator.getSurefireReportsXmlFile("TEST-pkg.domain.AxTest.xml");
         xmlReportFile.assertFileExists();
 
         Source source = Input.fromFile(xmlReportFile.getFile()).build();

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -311,7 +311,29 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                 // use deprecated method
                 testPlan.getTestIdentifier(
                         testIdentifier.getParentIdObject().get().toString());
-        return !parent.getParentIdObject().isPresent() ? testIdentifier : findTopParent(parent);
+        if (!parent.getParentIdObject().isPresent()) {
+            return testIdentifier;
+        }
+        // Stop traversing at engine boundaries. When a test runs inside a Suite,
+        // the hierarchy contains a nested engine (e.g., junit-jupiter under junit-platform-suite).
+        // Without this check, tests would be incorrectly attributed to the Suite class
+        // instead of their actual test class.
+        if (isEngineIdentifier(parent)) {
+            return testIdentifier;
+        }
+        return findTopParent(parent);
+    }
+
+    private static boolean isEngineIdentifier(TestIdentifier testIdentifier) {
+        String uniqueId = testIdentifier.getUniqueId();
+        int lastOpen = uniqueId.lastIndexOf('[');
+        if (lastOpen >= 0) {
+            int colon = uniqueId.indexOf(':', lastOpen);
+            if (colon > lastOpen) {
+                return "engine".equals(uniqueId.substring(lastOpen + 1, colon));
+            }
+        }
+        return false;
     }
 
     /**

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -314,14 +314,19 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         if (!parent.getParentIdObject().isPresent()) {
             return testIdentifier;
         }
-        // Stop traversing at engine boundaries. When a test runs inside a Suite,
-        // the hierarchy contains a nested engine (e.g., junit-jupiter under junit-platform-suite).
-        // Without this check, tests would be incorrectly attributed to the Suite class
-        // instead of their actual test class.
-        if (isEngineIdentifier(parent)) {
+        // Inside a Suite the hierarchy contains a nested engine (like junit-jupiter under
+        // junit-platform-suite). Stop at that boundary so the test is attributed to its real test
+        // class rather than the Suite class. The ClassSource guard keeps traversing up for engines
+        // that expose no test class below them (like Cucumber features/scenarios), so those tests
+        // fall back to the enclosing Suite class instead of being dropped.
+        if (isEngineIdentifier(parent) && hasClassSource(testIdentifier)) {
             return testIdentifier;
         }
         return findTopParent(parent);
+    }
+
+    private static boolean hasClassSource(TestIdentifier testIdentifier) {
+        return testIdentifier.getSource().filter(ClassSource.class::isInstance).isPresent();
     }
 
     private static boolean isEngineIdentifier(TestIdentifier testIdentifier) {

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -602,6 +602,62 @@ public class RunListenerAdapterTest {
         assertEquals("some display name", value.getNameText());
     }
 
+    @Test
+    public void notifiedWithActualTestClassNameWhenRunInsideSuite() throws Exception {
+        // Build a Suite hierarchy: SuiteEngine -> SuiteClass -> JupiterEngine -> TestClass -> method
+        // This simulates @Suite @SelectPackages("...") running tests from another class.
+        EngineDescriptor suiteEngine =
+                new EngineDescriptor(UniqueId.forEngine("junit-platform-suite"), "JUnit Platform Suite");
+
+        TestDescriptor suiteClass = new ClassTestDescriptor(
+                suiteEngine.getUniqueId().append("suite", MySuiteClass.class.getName()),
+                MySuiteClass.class,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        suiteEngine.addChild(suiteClass);
+
+        TestDescriptor jupiterEngine =
+                new AbstractTestDescriptor(
+                        suiteClass.getUniqueId().append("engine", "junit-jupiter"), "JUnit Jupiter") {
+                    @Override
+                    public Type getType() {
+                        return Type.CONTAINER;
+                    }
+                };
+        suiteClass.addChild(jupiterEngine);
+
+        TestDescriptor testClass = new ClassTestDescriptor(
+                jupiterEngine.getUniqueId().append("class", MyTestClass.class.getName()),
+                MyTestClass.class,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        jupiterEngine.addChild(testClass);
+
+        TestDescriptor method = new TestMethodTestDescriptor(
+                testClass.getUniqueId().append("method", MY_TEST_METHOD_NAME),
+                MyTestClass.class,
+                MyTestClass.class.getDeclaredMethod(MY_TEST_METHOD_NAME),
+                Collections::emptyList,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        testClass.addChild(method);
+
+        TestPlan plan = TestPlan.from(false, singletonList(suiteEngine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(suiteEngine));
+        adapter.executionStarted(TestIdentifier.from(suiteClass));
+        adapter.executionStarted(TestIdentifier.from(jupiterEngine));
+        adapter.executionStarted(TestIdentifier.from(testClass));
+        adapter.executionStarted(TestIdentifier.from(method));
+
+        ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
+        adapter.executionFinished(TestIdentifier.from(method), failed(new AssertionError("fail")));
+        verify(listener).testFailed(entryCaptor.capture());
+
+        ReportEntry entry = entryCaptor.getValue();
+        // The source name must be the actual test class, not the Suite class
+        assertEquals(MyTestClass.class.getName(), entry.getSourceName());
+        assertEquals(MY_TEST_METHOD_NAME, entry.getName());
+    }
+
     private static TestIdentifier newMethodIdentifier() throws Exception {
         return TestIdentifier.from(newMethodDescriptor());
     }
@@ -719,6 +775,8 @@ public class RunListenerAdapterTest {
         @org.junit.jupiter.api.Test
         void myNamedTestMethod() {}
     }
+
+    private static class MySuiteClass {}
 
     static class TestMethodTestDescriptorWithDisplayName extends AbstractTestDescriptor {
         private TestMethodTestDescriptorWithDisplayName(

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -658,6 +658,67 @@ public class RunListenerAdapterTest {
         assertEquals(MY_TEST_METHOD_NAME, entry.getName());
     }
 
+    @Test
+    public void notifiedWithSuiteClassNameWhenEngineHasNoTestClass() {
+        // Build a Suite hierarchy whose nested engine exposes no test class right below it, as
+        // Cucumber does: SuiteEngine -> SuiteClass -> CucumberEngine -> feature -> scenario.
+        // The feature/scenario nodes carry no ClassSource, so the test must be attributed to the
+        // enclosing Suite class instead of being dropped (see issue #3264 follow-up / Cucumber IT).
+        EngineDescriptor suiteEngine =
+                new EngineDescriptor(UniqueId.forEngine("junit-platform-suite"), "JUnit Platform Suite");
+
+        TestDescriptor suiteClass = new ClassTestDescriptor(
+                suiteEngine.getUniqueId().append("suite", MySuiteClass.class.getName()),
+                MySuiteClass.class,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        suiteEngine.addChild(suiteClass);
+
+        TestDescriptor cucumberEngine =
+                new AbstractTestDescriptor(suiteClass.getUniqueId().append("engine", "cucumber"), "Cucumber") {
+                    @Override
+                    public Type getType() {
+                        return Type.CONTAINER;
+                    }
+                };
+        suiteClass.addChild(cucumberEngine);
+
+        TestDescriptor feature =
+                new AbstractTestDescriptor(cucumberEngine.getUniqueId().append("feature", "sum.feature"), "Sum test") {
+                    @Override
+                    public Type getType() {
+                        return Type.CONTAINER;
+                    }
+                };
+        cucumberEngine.addChild(feature);
+
+        TestDescriptor scenario =
+                new AbstractTestDescriptor(feature.getUniqueId().append("scenario", "1"), "Invalid test") {
+                    @Override
+                    public Type getType() {
+                        return Type.TEST;
+                    }
+                };
+        feature.addChild(scenario);
+
+        TestPlan plan = TestPlan.from(false, singletonList(suiteEngine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(suiteEngine));
+        adapter.executionStarted(TestIdentifier.from(suiteClass));
+        adapter.executionStarted(TestIdentifier.from(cucumberEngine));
+        adapter.executionStarted(TestIdentifier.from(feature));
+        adapter.executionStarted(TestIdentifier.from(scenario));
+
+        ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
+        adapter.executionFinished(TestIdentifier.from(scenario), failed(new AssertionError("fail")));
+        verify(listener).testFailed(entryCaptor.capture());
+
+        ReportEntry entry = entryCaptor.getValue();
+        // No test class exists below the Cucumber engine, so the Suite class is the attribution.
+        assertEquals(MySuiteClass.class.getName(), entry.getSourceName());
+        assertEquals("Invalid test", entry.getName());
+    }
+
     private static TestIdentifier newMethodIdentifier() throws Exception {
         return TestIdentifier.from(newMethodDescriptor());
     }


### PR DESCRIPTION
 When `rerunFailingTestsCount` is used with JUnit Platform `@Suite`, tests from different classes that share a method name are merged under the Suite class name. It causes real failures to be misclassified as flakes. With the changes in the PR, `findTopParent()` now stops at engine boundaries (parents with no `ClassSource`), correctly attributing tests to their actual class while preserving `@Nested`.

  - [x] New unit test added
  - [x] Verified with the small project shared in the original issue: build correctly fails after fix

-------

Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
