### PR TITLE
Issue #2613 Debugging failsafe tests: Message 'Listening for transport dt_socket at address' is not displayed anymore when using maven.surefire.debug (#3353)

### DIFF
--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoder.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/stream/AbstractStreamDecoder.java
@@ -112,9 +112,28 @@ public abstract class AbstractStreamDecoder<M, MT extends Enum<MT>, ST extends E
 
     protected MT readMessageType(@Nonnull Memento memento) throws IOException, MalformedFrameException {
         byte[] header = getEncodedMagicNumber();
-        int readCount = DELIMITER_LENGTH + header.length + DELIMITER_LENGTH + BYTE_LENGTH + DELIMITER_LENGTH;
-        read(memento, readCount);
-        checkHeader(memento);
+        // Read the header one byte at a time so that non-protocol output (e.g. the JDWP
+        // "Listening for transport dt_socket at address: ..." line) is flushed to the console
+        // before the decoder blocks. That line contains ':' which looks like a frame start;
+        // checking each magic-number byte individually lets us bail out immediately on a
+        // mismatch instead of stalling on a 24-byte read that never completes.
+        read(memento, DELIMITER_LENGTH);
+        ByteBuffer bb = memento.getByteBuffer();
+        if ((bb.array()[bb.arrayOffset() + bb.position()] & 0xff) != ':') {
+            checkHeader(memento); // not ':', immediately throws MalformedFrameException
+        }
+        checkDelimiter(memento); // consume the ':'
+        for (int i = 0; i < header.length; i++) {
+            read(memento, DELIMITER_LENGTH);
+            bb = memento.getByteBuffer();
+            if ((bb.array()[bb.arrayOffset() + bb.position()] & 0xff) != (header[i] & 0xff)) {
+                // Mismatch: report the ':' plus all bytes read so far in this frame attempt.
+                throw new MalformedFrameException(memento.getLine().getPositionByteBuffer(), bb.position() + 1);
+            }
+            bb.position(bb.position() + 1);
+        }
+        read(memento, DELIMITER_LENGTH);
+        checkDelimiter(memento);
         return messageTypes.get(readSegment(memento));
     }
 


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
