### PR TITLE
[Issue-3349] Handle absolute surefire tempDir on Windows

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -455,11 +455,12 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
     private boolean failIfNoTests;
 
     /**
-     * Relative path to <i>temporary-surefire-boot</i> directory containing internal Surefire temporary files.
+     * Path to <i>temporary-surefire-boot</i> directory containing internal Surefire temporary files.
      * <br>
      * The <i>temporary-surefire-boot</i> directory is <i>project.build.directory</i> on most platforms or
      * <i>system default temporary-directory</i> specified by the system property {@code java.io.tmpdir}
      * on Windows (see <a href="https://issues.apache.org/jira/browse/SUREFIRE-1400">SUREFIRE-1400</a>).
+     * Absolute paths and relative paths with directory separators are used as explicit directories on all platforms.
      * <br>
      * It is deleted after the test set has completed.
      *
@@ -3361,11 +3362,26 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
     }
 
     File createSurefireBootDirectoryInTemp() {
+        String tempDir = getTempDir();
+        if (isTempDirPath(tempDir)) {
+            File tmp = new File(tempDir);
+            if (!tmp.isAbsolute()) {
+                tmp = new File(getProjectBuildDirectory(), tempDir);
+            }
+            //noinspection ResultOfMethodCallIgnored
+            tmp.mkdirs();
+            return tmp;
+        }
+
         try {
-            return Files.createTempDirectory(getTempDir()).toFile();
-        } catch (IOException e) {
+            return Files.createTempDirectory(tempDir).toFile();
+        } catch (IOException | IllegalArgumentException e) {
             return createSurefireBootDirectoryInBuild();
         }
+    }
+
+    private static boolean isTempDirPath(String tempDir) {
+        return new File(tempDir).isAbsolute() || tempDir.indexOf('/') >= 0 || tempDir.indexOf('\\') >= 0;
     }
 
     @Override

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -817,6 +817,21 @@ public class AbstractSurefireMojoTest {
     }
 
     @Test
+    public void shouldUseAbsoluteTmpDirectory() throws IOException {
+        File targetDir = Files.createTempDirectory(tempFolder, "target").toFile();
+        File absoluteTempDir = tempFolder.resolve("surefire-tmp").toFile();
+
+        Mojo mojo = new Mojo();
+        mojo.setProjectBuildDirectory(targetDir);
+        mojo.setTempDir(absoluteTempDir.getAbsolutePath());
+
+        File bootDir = mojo.createSurefireBootDirectoryInTemp();
+
+        assertThat(bootDir).isDirectory();
+        assertThat(bootDir.getCanonicalFile()).isEqualTo(absoluteTempDir.getCanonicalFile());
+    }
+
+    @Test
     public void shouldSmartlyResolveJUnit5ProviderWithJUnit4() throws Exception {
         MavenProject mavenProject = new MavenProject();
         mavenProject.setArtifact(new DefaultArtifact(


### PR DESCRIPTION
Fixes #3349.

`tempDir` values that are absolute paths, or relative paths with directory separators, are now treated as explicit directories before creating the fork boot directory. Simple names still use the existing `Files.createTempDirectory(prefix)` behavior.

Verification:

- `/tmp/apache-maven-3.9.11/bin/mvn -pl maven-surefire-common -am -DskipTests -Dmaven.build.cache.enabled=false install`
- `/tmp/apache-maven-3.9.11/bin/mvn -pl maven-surefire-common -Dtest=AbstractSurefireMojoTest -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dspotless.check.skip=true -Danimal.sniffer.skip=true -Dmaven.build.cache.enabled=false test`

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
