### PR TITLE
[Issue-3315] Restore console output fallback report name

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ConsoleOutputFileReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/ConsoleOutputFileReporter.java
@@ -70,6 +70,7 @@ public class ConsoleOutputFileReporter implements TestcycleConsoleOutputReceiver
     @Override
     public void testSetStarting(TestSetReportEntry reportEntry) {
         String className = usePhrasedFileName ? reportEntry.getSourceText() : reportEntry.getSourceName();
+        reportEntryName = className;
         try {
             File file = getReportFile(reportsDirectory, className, reportNameSuffix, "-output.txt");
             if (!reportsDirectory.exists()) {

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/report/ConsoleOutputFileReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/report/ConsoleOutputFileReporterTest.java
@@ -135,6 +135,31 @@ public class ConsoleOutputFileReporterTest {
     }
 
     @Test
+    public void testOutputWithoutStackTraceUsesCurrentReportFile() throws IOException {
+        File reportDir = new File(new File(System.getProperty("user.dir"), "target"), "tmp3-without-stack");
+        if (Files.exists(reportDir.toPath())) {
+            FileUtils.deleteDirectory(reportDir);
+        }
+        Files.createDirectories(reportDir.toPath());
+        TestSetReportEntry reportEntry = new SimpleReportEntry(
+                NORMAL_RUN, 1L, getClass().getName(), null, getClass().getName(), null);
+        ConsoleOutputFileReporter reporter = new ConsoleOutputFileReporter(reportDir, null, false, null, "UTF-8");
+        reporter.testSetStarting(reportEntry);
+        reporter.writeTestOutput(new TestOutputReportEntry("some text", true, false, NORMAL_RUN, 1L, null));
+        reporter.close();
+
+        File expectedReportFile = new File(reportDir, getClass().getName() + "-output.txt");
+        File nullReportFile = new File(reportDir, "null-output.txt");
+
+        assertThat(expectedReportFile).exists();
+        assertThat(FileUtils.fileRead(expectedReportFile, US_ASCII.name())).contains("some text");
+        assertThat(nullReportFile).doesNotExist();
+
+        //noinspection ResultOfMethodCallIgnored
+        expectedReportFile.delete();
+    }
+
+    @Test
     public void testConcurrentAccessReportFile() throws Exception {
         File reportDir = new File(new File(System.getProperty("user.dir"), "target"), "tmp4");
         if (Files.exists(reportDir.toPath())) {


### PR DESCRIPTION
Fixes #3315.

Console output events without a stack trace now use the active test set report name instead of falling back to `null-output.txt`. This restores the fallback report name when a test set starts while preserving stack-trace-based output attribution.

Verification:

- `/tmp/apache-maven-3.9.11/bin/mvn -pl maven-surefire-common -am -DskipTests -Dmaven.build.cache.enabled=false install`
- `/tmp/apache-maven-3.9.11/bin/mvn -pl maven-surefire-common -Dtest=ConsoleOutputFileReporterTest -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dspotless.check.skip=true -Danimal.sniffer.skip=true -Dmaven.build.cache.enabled=false test`

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
