### PR TITLE
[Issue-3309] Clarify forkNode default communication docs

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -455,7 +455,7 @@ public class IntegrationTestMojo extends AbstractSurefireMojo {
     /**
      * This parameter configures the forked node. Currently, you can select the communication protocol, i.e. process
      * pipes or TCP/IP sockets.
-     * The plugin uses process pipes by default which will be turned to TCP/IP in the version 3.0.0.
+     * The plugin uses process pipes by default. The TCP/IP implementation is available as an alternative.
      * Alternatively, you can implement your own factory and SPI.
      * <br>
      * See the documentation for more details:<br>

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefireMojo.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefireMojo.java
@@ -433,7 +433,7 @@ public class SurefireMojo extends AbstractSurefireMojo implements SurefireReport
     /**
      * This parameter configures the forked node. Currently, you can select the communication protocol, i.e. process
      * pipes or TCP/IP sockets.
-     * The plugin uses process pipes by default which will be turned to TCP/IP in the version 3.0.0.
+     * The plugin uses process pipes by default. The TCP/IP implementation is available as an alternative.
      * Alternatively, you can implement your own factory and SPI.
      * <br>
      * See the documentation for more details:<br>

--- a/maven-surefire-plugin/src/site/apt/examples/process-communication.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/process-communication.apt.vm
@@ -42,7 +42,7 @@ Communication Channels used between the Maven Process and Surefire Process
 
   The ${thisPlugin} plugin uses process pipes by default. The implementation class for default configuration
   is <<<org.apache.maven.plugin.surefire.extensions.LegacyForkNodeFactory>>> and it does not have to be specified.
-  The TCP/IP channel can be selected as follows and the implementation class has to be specified:
+  The TCP/IP channel is supported as an alternative and can be selected as follows:
 
 +---+
 <project>

--- a/maven-surefire-plugin/src/site/fml/faq.fml
+++ b/maven-surefire-plugin/src/site/fml/faq.fml
@@ -166,7 +166,9 @@ under the License.
         <p>
           Surefire and Failsafe plugin may kill forked Surefire JVM when the standard-input stream is closed.
           This works when you stop Maven process by CTRL+C but it is not guaranteed on all platforms.
-          Since version 3.0.0-M5, TCP/IP sockets are used for interprocess communication.
+          By default, the plugins use process pipes for interprocess communication.
+          Since version 3.0.0-M5, TCP/IP sockets are also available and can be
+          selected with the forkNode configuration parameter.
           See the documentation of the configuration parameter
           "enableProcessChecker" for mechanisms to detect and kill orphan forked JVMs.
           These mechanisms have some drawbacks regarding your


### PR DESCRIPTION
Fixes #3309.

The forkNode parameter and site documentation no longer say that TCP/IP would become the default in 3.0.0. They now state that process pipes remain the default and that TCP/IP sockets are available as an opt-in alternative.

Verification:

- `/tmp/apache-maven-3.9.11/bin/mvn -pl maven-surefire-plugin,maven-failsafe-plugin -am -DskipTests -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dspotless.check.skip=true -Danimal.sniffer.skip=true -Dmaven.build.cache.enabled=false package`

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
