### PR TITLE
Avoid producing a trailing colon in `java.class.path`.

### DIFF
--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/Classpath.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/Classpath.java
@@ -96,11 +96,7 @@ public final class Classpath implements Iterable<String>, Cloneable {
     }
 
     public void writeToSystemProperty(@Nonnull String propertyName) {
-        StringBuilder sb = new StringBuilder();
-        for (String element : unmodifiableElements) {
-            sb.append(element).append(pathSeparatorChar);
-        }
-        System.setProperty(propertyName, sb.toString());
+        System.setProperty(propertyName, String.join(String.valueOf(pathSeparatorChar), unmodifiableElements));
     }
 
     @Override

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/ClasspathTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/ClasspathTest.java
@@ -57,9 +57,7 @@ public class ClasspathTest {
         Classpath classpath =
                 Classpath.emptyClasspath().addClassPathElementUrl(DUMMY_URL_1).addClassPathElementUrl(DUMMY_URL_2);
         classpath.writeToSystemProperty(DUMMY_PROPERTY_NAME);
-        assertEquals(
-                DUMMY_URL_1 + File.pathSeparatorChar + DUMMY_URL_2 + File.pathSeparatorChar,
-                System.getProperty(DUMMY_PROPERTY_NAME));
+        assertEquals(DUMMY_URL_1 + File.pathSeparatorChar + DUMMY_URL_2, System.getProperty(DUMMY_PROPERTY_NAME));
     }
 
     @Test


### PR DESCRIPTION
This is more consistent with how `java -cp ...` operates:

If I run...

`java -cp somejar:`

...then Java sees a trailing empty path, i.e., "the current directory."

But Surefire includes a trailing colon in all cases --
even when the current directory is not on the class path.

This behavior contributed to https://github.com/google/guava/issues/8295

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
