### PR TITLE
[SUREFIRE-823] Decouple -DskipTests from Failsafe plugin

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -72,6 +72,22 @@ public class IntegrationTestMojo extends AbstractSurefireMojo {
     private boolean skipITs;
 
     /**
+     * Set this to "true" to skip running integration tests, but still compile them. Its use is NOT RECOMMENDED, but
+     * quite convenient on occasion.
+     * <p>
+     * Unlike Surefire's {@code skipTests}, this Failsafe parameter is <strong>not</strong> bound to the
+     * {@code skipTests} user property. Use {@code -DskipITs} on the command line to skip integration tests,
+     * or {@code -Dmaven.test.skip} to skip both unit and integration tests. The {@code <skipTests>} element
+     * is still honored when set explicitly in the plugin {@code <configuration>}.
+     *
+     * @since 3.6.0
+     * @deprecated use {@code skipITs} instead
+     */
+    @Deprecated
+    @Parameter
+    private boolean skipTests;
+
+    /**
      * Base directory where all reports are written to.
      */
     @Parameter(defaultValue = "${project.build.directory}/failsafe-reports")

--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
@@ -54,12 +54,18 @@ import static org.apache.maven.surefire.shared.utils.StringUtils.capitalizeFirst
 public class VerifyMojo extends AbstractMojo implements SurefireReportParameters {
 
     /**
-     * Set this to 'true' to skip running tests, but still compile them. Its use is NOT RECOMMENDED, but quite
-     * convenient on occasion.
+     * Set this to 'true' to skip verifying integration test results.
+     * <p>
+     * Unlike Surefire's {@code skipTests}, this Failsafe parameter is <strong>not</strong> bound to the
+     * {@code skipTests} user property. Use {@code -DskipITs} on the command line to skip integration tests
+     * (including this verification step), or {@code -Dmaven.test.skip} to skip everything. The
+     * {@code <skipTests>} element is still honored when set explicitly in the plugin {@code <configuration>}.
      *
      * @since 2.4
+     * @deprecated use {@code skipITs} instead
      */
-    @Parameter(property = "skipTests")
+    @Deprecated
+    @Parameter
     private boolean skipTests;
 
     /**

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -193,8 +193,11 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
     /**
      * Set this to "true" to skip running tests, but still compile them. Its use is NOT RECOMMENDED, but quite
      * convenient on occasion.<br>
-     * Failsafe plugin deprecated the parameter {@code skipTests} and the parameter will be removed in
-     * <i>Failsafe 3.0.0</i> as it is a source of conflicts between Failsafe and Surefire plugin.
+     * <p>
+     * As of Failsafe 3.6.0, the Failsafe plugin no longer binds its own {@code skipTests} parameter to the
+     * {@code skipTests} user property, so {@code -DskipTests=true} now skips only Surefire (unit tests) while
+     * leaving Failsafe (integration tests) untouched. Use {@code -DskipITs} to skip integration tests, or
+     * {@code -Dmaven.test.skip} to skip both.
      *
      * @since 2.4
      */

--- a/maven-surefire-plugin/src/site/apt/examples/skipping-tests.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/skipping-tests.apt.vm
@@ -88,9 +88,15 @@ mvn install -DskipTests
 mvn install -DskipTests
 +---+
 
+#{if}(${project.artifactId}=="maven-surefire-plugin")
  Since <<<skipTests>>> is also supported by the ${thatPlugin} Plugin, this will have the effect
- of not running any tests.  If, instead, you want to skip only the integration tests
- being run by the ${thisPlugin} Plugin, you would use the <<<skipITs>>> property instead:
+ of not running any tests. If, instead, you want to skip only the integration tests
+ being run by the ${thatPlugin} Plugin, you would use the <<<skipITs>>> property instead:
+#{else}
+ The <<<-DskipTests>>> command-line property only skips tests run by the Surefire Plugin and
+ does <<not>> skip the integration tests run by the ${thisPlugin} Plugin (since 3.6.0).
+ To skip integration tests from the command line use the <<<skipITs>>> property:
+#{end}
 
 +---+
 mvn install -DskipITs

--- a/maven-surefire-plugin/src/site/apt/examples/skipping-tests.apt.vm
+++ b/maven-surefire-plugin/src/site/apt/examples/skipping-tests.apt.vm
@@ -89,9 +89,9 @@ mvn install -DskipTests
 +---+
 
 #{if}(${project.artifactId}=="maven-surefire-plugin")
- Since <<<skipTests>>> is also supported by the ${thatPlugin} Plugin, this will have the effect
- of not running any tests. If, instead, you want to skip only the integration tests
- being run by the ${thatPlugin} Plugin, you would use the <<<skipITs>>> property instead:
+ The <<<-DskipTests>>> command-line property only skips tests run by the ${thisPlugin} Plugin and
+ does <<not>> skip the integration tests run by the ${thatPlugin} Plugin (since 3.6.0).
+ To skip integration tests from the command line use the <<<skipITs>>> property:
 #{else}
  The <<<-DskipTests>>> command-line property only skips tests run by the Surefire Plugin and
  does <<not>> skip the integration tests run by the ${thisPlugin} Plugin (since 3.6.0).

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1766SkipTestsDecoupledIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1766SkipTestsDecoupledIT.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import org.apache.maven.surefire.its.fixture.FailsafeOutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Verifies that {@code -DskipTests} only skips Surefire (unit tests) and no longer skips
+ * Failsafe (integration tests), while {@code -DskipITs} and {@code -Dmaven.test.skip}
+ * continue to control Failsafe execution.
+ *
+ * @see <a href="https://github.com/apache/maven-surefire/issues/1766">Surefire #1766 / SUREFIRE-823</a>
+ */
+public class Surefire1766SkipTestsDecoupledIT extends SurefireJUnit4IntegrationTestCase {
+
+    @Test
+    public void skipTestsShouldOnlySkipSurefireNotFailsafe() {
+        FailsafeOutputValidator validator =
+                unpack().sysProp("skipTests", "true").executeVerify();
+
+        validator.verifyErrorFreeLog();
+        // Surefire (unit tests) is skipped: the surefire skip log message is emitted
+        // and no surefire-reports directory is produced.
+        validator.verifyTextInLog("Tests are skipped.");
+        assertFalse(
+                validator.getSubFile("target/surefire-reports").exists(),
+                "surefire-reports should not exist when -DskipTests is used");
+        // Failsafe (integration tests) still runs the IT
+        validator.assertIntegrationTestSuiteResults(1, 0, 0, 0);
+    }
+
+    @Test
+    public void skipITsShouldSkipFailsafeOnly() {
+        FailsafeOutputValidator validator = unpack().sysProp("skipITs", "true").executeVerify();
+
+        validator.verifyErrorFreeLog();
+        // Surefire still runs the unit test
+        validator.assertTestSuiteResults(1, 0, 0, 0);
+        // Failsafe is skipped: no failsafe-reports directory is produced
+        assertFalse(
+                validator.getSubFile("target/failsafe-reports").exists(),
+                "failsafe-reports should not exist when -DskipITs is used");
+    }
+
+    @Test
+    public void mavenTestSkipShouldSkipBoth() {
+        FailsafeOutputValidator validator =
+                unpack().sysProp("maven.test.skip", "true").executeVerify();
+
+        validator.verifyErrorFreeLog();
+        assertFalse(
+                validator.getSubFile("target/surefire-reports").exists(),
+                "surefire-reports should not exist when -Dmaven.test.skip is used");
+        assertFalse(
+                validator.getSubFile("target/failsafe-reports").exists(),
+                "failsafe-reports should not exist when -Dmaven.test.skip is used");
+    }
+
+    private SurefireLauncher unpack() {
+        return unpack("failsafe-1766-skip-decoupled");
+    }
+}

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1766SkipTestsDecoupledIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire1766SkipTestsDecoupledIT.java
@@ -24,6 +24,7 @@ import org.apache.maven.surefire.its.fixture.SurefireLauncher;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies that {@code -DskipTests} only skips Surefire (unit tests) and no longer skips
@@ -33,6 +34,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * @see <a href="https://github.com/apache/maven-surefire/issues/1766">Surefire #1766 / SUREFIRE-823</a>
  */
 public class Surefire1766SkipTestsDecoupledIT extends SurefireJUnit4IntegrationTestCase {
+
+    @Test
+    public void noSkipShouldRunBoth() {
+        FailsafeOutputValidator validator = unpack().executeVerify();
+
+        validator.verifyErrorFreeLog();
+        // Baseline: with no skip flag, both Surefire (unit tests) and Failsafe (integration tests) run
+        validator.assertTestSuiteResults(1, 0, 0, 0);
+        validator.assertIntegrationTestSuiteResults(1, 0, 0, 0);
+    }
 
     @Test
     public void skipTestsShouldOnlySkipSurefireNotFailsafe() {
@@ -47,6 +58,9 @@ public class Surefire1766SkipTestsDecoupledIT extends SurefireJUnit4IntegrationT
                 validator.getSubFile("target/surefire-reports").exists(),
                 "surefire-reports should not exist when -DskipTests is used");
         // Failsafe (integration tests) still runs the IT
+        assertTrue(
+                validator.getSubFile("target/failsafe-reports").exists(),
+                "failsafe-reports should exist when -DskipTests is used (ITs still run)");
         validator.assertIntegrationTestSuiteResults(1, 0, 0, 0);
     }
 
@@ -57,6 +71,9 @@ public class Surefire1766SkipTestsDecoupledIT extends SurefireJUnit4IntegrationT
         validator.verifyErrorFreeLog();
         // Surefire still runs the unit test
         validator.assertTestSuiteResults(1, 0, 0, 0);
+        assertTrue(
+                validator.getSubFile("target/surefire-reports").exists(),
+                "surefire-reports should exist when -DskipITs is used (unit tests still run)");
         // Failsafe is skipped: no failsafe-reports directory is produced
         assertFalse(
                 validator.getSubFile("target/failsafe-reports").exists(),

--- a/surefire-its/src/test/resources/failsafe-1766-skip-decoupled/pom.xml
+++ b/surefire-its/src/test/resources/failsafe-1766-skip-decoupled/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>localhost</groupId>
+    <artifactId>failsafe-1766-skip-decoupled</artifactId>
+    <version>1.0</version>
+    <name>failsafe-1766-skip-decoupled</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/failsafe-1766-skip-decoupled/src/test/java/MyIT.java
+++ b/surefire-its/src/test/resources/failsafe-1766-skip-decoupled/src/test/java/MyIT.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MyIT {
+    @Test
+    public void testIntegration() {
+        assertTrue(true);
+    }
+}

--- a/surefire-its/src/test/resources/failsafe-1766-skip-decoupled/src/test/java/MyTest.java
+++ b/surefire-its/src/test/resources/failsafe-1766-skip-decoupled/src/test/java/MyTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MyTest {
+    @Test
+    public void testUnit() {
+        assertTrue(true);
+    }
+}


### PR DESCRIPTION
 The Failsafe plugin's skipTests parameter is no longer bound to the
 skipTests user property. -DskipTests now only skips Surefire (unit tests)
 while leaving Failsafe (integration tests) untouched.
 
 Use -DskipITs to skip integration tests from the command line, or
 -Dmaven.test.skip to skip both. The <skipTests> plugin configuration
 element is still honoured when set explicitly.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
