### PR TITLE
Fix reportNameSuffix in XML testcase classname

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
@@ -174,21 +174,25 @@ public class WrappedReportEntry implements TestSetReportEntry {
     }
 
     String getReportSourceName(String suffix) {
-        return isBlank(suffix) ? getReportSourceName() : getReportSourceName() + "(" + suffix + ")";
+        return withReportNameSuffix(getReportSourceName(), suffix);
     }
 
     String getSourceName(String suffix) {
-        return isBlank(suffix) ? getSourceName() : getSourceName() + "(" + suffix + ")";
+        return withReportNameSuffix(getSourceName(), suffix);
     }
 
     String getSourceQualifiedName(String suffix) {
         String qualifiedName = original.getSourceQualifiedName();
         if (qualifiedName != null) {
-            return isBlank(suffix) ? qualifiedName : qualifiedName + "(" + suffix + ")";
+            return withReportNameSuffix(qualifiedName, suffix);
         }
-        // Fall back to pre-existing behaviour: sourceText if set, else sourceName (with suffix)
+        // Fall back to the same source selected before qualified names were tracked.
         String sourceText = getSourceText();
-        return sourceText != null ? sourceText : getSourceName(suffix);
+        return sourceText != null ? withReportNameSuffix(sourceText, suffix) : getSourceName(suffix);
+    }
+
+    private static String withReportNameSuffix(String sourceName, String suffix) {
+        return isBlank(suffix) ? sourceName : sourceName + "(" + suffix + ")";
     }
 
     String getReportName() {

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/WrappedReportEntryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/WrappedReportEntryTest.java
@@ -75,6 +75,14 @@ public class WrappedReportEntryTest {
     }
 
     @Test
+    public void sourceQualifiedNameFallsBackToSourceTextWithSuffix() {
+        ReportEntry reportEntry = new SimpleReportEntry(
+                NORMAL_RUN, 1L, "JunitParamsTest", "surefire.testcase.JunitParamsTest", "testSum", null);
+        WrappedReportEntry wr = new WrappedReportEntry(reportEntry, null, 1771085631L, 12, null, null);
+        assertEquals("surefire.testcase.JunitParamsTest(BDD)", wr.getSourceQualifiedName("BDD"));
+    }
+
+    @Test
     public void testDisplayNames() {
         ReportEntry reportEntry = new SimpleReportEntry(
                 NORMAL_RUN, 0L, "surefire.testcase.JunitParamsTest", "dn1", "testSum", "dn2", "exception");

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3210ReportNameSuffixIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3210ReportNameSuffixIT.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.TestFile;
+import org.junit.jupiter.api.Test;
+
+public class Surefire3210ReportNameSuffixIT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void reportNameSuffixIsUsedInTestcaseClassname() {
+        OutputValidator validator =
+                unpack("surefire-3210-report-name-suffix").executeTest().verifyErrorFree(1);
+
+        TestFile reportFile = validator.getSurefireReportsXmlFile("TEST-jira3210.MonkeyTest-Linux.xml");
+        reportFile
+                .assertContainsText("name=\"jira3210.MonkeyTest(Linux)\"")
+                .assertContainsText("<testcase name=\"testMonkeyConvert\" classname=\"jira3210.MonkeyTest(Linux)\"");
+    }
+}

--- a/surefire-its/src/test/resources/surefire-3210-report-name-suffix/pom.xml
+++ b/surefire-its/src/test/resources/surefire-3210-report-name-suffix/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-3210-report-name-suffix</artifactId>
+    <version>1.0</version>
+    <name>Test for SUREFIRE-3210: reportNameSuffix in XML report classname</name>
+
+    <properties>
+        <junit5.version>5.13.4</junit5.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <reportNameSuffix>Linux</reportNameSuffix>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-3210-report-name-suffix/src/test/java/jira3210/MonkeyTest.java
+++ b/surefire-its/src/test/resources/surefire-3210-report-name-suffix/src/test/java/jira3210/MonkeyTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package jira3210;
+
+import org.junit.jupiter.api.Test;
+
+class MonkeyTest {
+    @Test
+    void testMonkeyConvert() {}
+}


### PR DESCRIPTION
Fixes #3210

## Summary

This preserves `reportNameSuffix` on the XML `<testcase classname="...">` attribute when Surefire falls back from a missing qualified source name to the report source text.

The XML reporter already applies the suffix when a qualified source name is available. The missing case was the fallback path, where `sourceText` was returned without applying the configured suffix.

## Changes

- apply `reportNameSuffix` consistently through `WrappedReportEntry#getSourceQualifiedName`
- add focused unit coverage for the fallback path
- add an integration test fixture that verifies the generated XML report contains the suffix in both the test suite name and testcase classname

## Verification

- `mvn -pl maven-surefire-common -Dtest=WrappedReportEntryTest,StatelessXmlReporterTest test`
- `mvn -pl maven-surefire-common -DskipTests -Dinvoker.skip=true install`
- `mvn -pl surefire-its -P run-its -Dit.test=Surefire3210ReportNameSuffixIT -Dits.forkCount=1 -Dinvoker.skip=true verify`
- `mvn -pl surefire-its -am -DskipTests -Dinvoker.skip=true install`
- `mvn clean install`
- `mvn -Prun-its clean install`
- `git diff --check`

## Checklist

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).
 - [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004.