### PR TITLE
[Issue-3380] Send sourceQualifiedName to forked clients (#3380)

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClient.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/output/ForkClient.java
@@ -133,6 +133,7 @@ public final class ForkClient implements EventHandler<Event> {
                     reportEntry.getTestRunId(),
                     reportEntry.getSourceName(),
                     reportEntry.getSourceText(),
+                    reportEntry.getSourceQualifiedName(),
                     reportEntry.getName(),
                     reportEntry.getNameText(),
                     reportEntry.getGroup(),

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/WrappedReportEntry.java
@@ -126,6 +126,11 @@ public class WrappedReportEntry implements TestSetReportEntry {
     }
 
     @Override
+    public String getSourceQualifiedName() {
+        return getSourceQualifiedName(null);
+    }
+
+    @Override
     public String getName() {
         return original.getName();
     }

--- a/maven-surefire-common/src/main/java/org/apache/maven/surefire/stream/EventDecoder.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/surefire/stream/EventDecoder.java
@@ -104,6 +104,7 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
         DATA_STRING,
         DATA_STRING,
         DATA_STRING,
+        DATA_STRING,
         DATA_INTEGER,
         DATA_STRING,
         DATA_STRING,
@@ -272,28 +273,28 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
                 return new SystemPropertyEvent(
                         memento.ofDataAt(0), memento.ofDataAt(1), memento.ofDataAt(2), memento.ofDataAt(3));
             case BOOTERCODE_TESTSET_STARTING:
-                checkArguments(memento, 12);
+                checkArguments(memento, 13);
                 return new TestsetStartingEvent(toReportEntry(memento.getData()));
             case BOOTERCODE_TESTSET_COMPLETED:
-                checkArguments(memento, 12);
+                checkArguments(memento, 13);
                 return new TestsetCompletedEvent(toReportEntry(memento.getData()));
             case BOOTERCODE_TEST_STARTING:
-                checkArguments(memento, 12);
+                checkArguments(memento, 13);
                 return new TestStartingEvent(toReportEntry(memento.getData()));
             case BOOTERCODE_TEST_SUCCEEDED:
-                checkArguments(memento, 12);
+                checkArguments(memento, 13);
                 return new TestSucceededEvent(toReportEntry(memento.getData()));
             case BOOTERCODE_TEST_FAILED:
-                checkArguments(memento, 12);
+                checkArguments(memento, 13);
                 return new TestFailedEvent(toReportEntry(memento.getData()));
             case BOOTERCODE_TEST_SKIPPED:
-                checkArguments(memento, 12);
+                checkArguments(memento, 13);
                 return new TestSkippedEvent(toReportEntry(memento.getData()));
             case BOOTERCODE_TEST_ERROR:
-                checkArguments(memento, 12);
+                checkArguments(memento, 13);
                 return new TestErrorEvent(toReportEntry(memento.getData()));
             case BOOTERCODE_TEST_ASSUMPTIONFAILURE:
-                checkArguments(memento, 12);
+                checkArguments(memento, 13);
                 return new TestAssumptionFailureEvent(toReportEntry(memento.getData()));
             default:
                 throw new IllegalArgumentException("Missing a branch for the event type " + eventType);
@@ -307,20 +308,22 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
         // ReportEntry:
         String source = (String) args.get(2);
         String sourceText = (String) args.get(3);
-        String name = (String) args.get(4);
-        String nameText = (String) args.get(5);
-        String group = (String) args.get(6);
-        String message = (String) args.get(7);
-        Integer timeElapsed = (Integer) args.get(8);
+        String sourceQualifiedName = (String) args.get(4);
+        String name = (String) args.get(5);
+        String nameText = (String) args.get(6);
+        String group = (String) args.get(7);
+        String message = (String) args.get(8);
+        Integer timeElapsed = (Integer) args.get(9);
         // StackTraceWriter:
-        String traceMessage = (String) args.get(9);
-        String smartTrimmedStackTrace = (String) args.get(10);
-        String stackTrace = (String) args.get(11);
+        String traceMessage = (String) args.get(10);
+        String smartTrimmedStackTrace = (String) args.get(11);
+        String stackTrace = (String) args.get(12);
         return newReportEntry(
                 runMode,
                 testRunId,
                 source,
                 sourceText,
+                sourceQualifiedName,
                 name,
                 nameText,
                 group,
@@ -348,6 +351,7 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
             long testRunId,
             String source,
             String sourceText,
+            String sourceQualifiedName,
             String name,
             String nameText,
             String group,
@@ -364,6 +368,7 @@ public class EventDecoder extends AbstractStreamDecoder<Event, ForkedProcessEven
                 testRunId,
                 source,
                 sourceText,
+                sourceQualifiedName,
                 name,
                 nameText,
                 group,

--- a/maven-surefire-common/src/test/java/org/apache/maven/surefire/stream/EventDecoderTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/surefire/stream/EventDecoderTest.java
@@ -183,10 +183,11 @@ public class EventDecoderTest {
         });
 
         segmentTypes = decoder.nextSegmentType(BOOTERCODE_TESTSET_STARTING);
-        assertThat(segmentTypes).hasSize(14).isEqualTo(new SegmentType[] {
+        assertThat(segmentTypes).hasSize(15).isEqualTo(new SegmentType[] {
             RUN_MODE,
             TEST_RUN_ID,
             STRING_ENCODING,
+            DATA_STRING,
             DATA_STRING,
             DATA_STRING,
             DATA_STRING,
@@ -201,10 +202,11 @@ public class EventDecoderTest {
         });
 
         segmentTypes = decoder.nextSegmentType(ForkedProcessEventType.BOOTERCODE_TESTSET_COMPLETED);
-        assertThat(segmentTypes).hasSize(14).isEqualTo(new SegmentType[] {
+        assertThat(segmentTypes).hasSize(15).isEqualTo(new SegmentType[] {
             RUN_MODE,
             TEST_RUN_ID,
             STRING_ENCODING,
+            DATA_STRING,
             DATA_STRING,
             DATA_STRING,
             DATA_STRING,
@@ -219,10 +221,11 @@ public class EventDecoderTest {
         });
 
         segmentTypes = decoder.nextSegmentType(ForkedProcessEventType.BOOTERCODE_TEST_STARTING);
-        assertThat(segmentTypes).hasSize(14).isEqualTo(new SegmentType[] {
+        assertThat(segmentTypes).hasSize(15).isEqualTo(new SegmentType[] {
             RUN_MODE,
             TEST_RUN_ID,
             STRING_ENCODING,
+            DATA_STRING,
             DATA_STRING,
             DATA_STRING,
             DATA_STRING,
@@ -237,10 +240,11 @@ public class EventDecoderTest {
         });
 
         segmentTypes = decoder.nextSegmentType(BOOTERCODE_TEST_SUCCEEDED);
-        assertThat(segmentTypes).hasSize(14).isEqualTo(new SegmentType[] {
+        assertThat(segmentTypes).hasSize(15).isEqualTo(new SegmentType[] {
             RUN_MODE,
             TEST_RUN_ID,
             STRING_ENCODING,
+            DATA_STRING,
             DATA_STRING,
             DATA_STRING,
             DATA_STRING,
@@ -255,10 +259,11 @@ public class EventDecoderTest {
         });
 
         segmentTypes = decoder.nextSegmentType(BOOTERCODE_TEST_FAILED);
-        assertThat(segmentTypes).hasSize(14).isEqualTo(new SegmentType[] {
+        assertThat(segmentTypes).hasSize(15).isEqualTo(new SegmentType[] {
             RUN_MODE,
             TEST_RUN_ID,
             STRING_ENCODING,
+            DATA_STRING,
             DATA_STRING,
             DATA_STRING,
             DATA_STRING,
@@ -273,10 +278,11 @@ public class EventDecoderTest {
         });
 
         segmentTypes = decoder.nextSegmentType(ForkedProcessEventType.BOOTERCODE_TEST_SKIPPED);
-        assertThat(segmentTypes).hasSize(14).isEqualTo(new SegmentType[] {
+        assertThat(segmentTypes).hasSize(15).isEqualTo(new SegmentType[] {
             RUN_MODE,
             TEST_RUN_ID,
             STRING_ENCODING,
+            DATA_STRING,
             DATA_STRING,
             DATA_STRING,
             DATA_STRING,
@@ -291,10 +297,11 @@ public class EventDecoderTest {
         });
 
         segmentTypes = decoder.nextSegmentType(ForkedProcessEventType.BOOTERCODE_TEST_ERROR);
-        assertThat(segmentTypes).hasSize(14).isEqualTo(new SegmentType[] {
+        assertThat(segmentTypes).hasSize(15).isEqualTo(new SegmentType[] {
             RUN_MODE,
             TEST_RUN_ID,
             STRING_ENCODING,
+            DATA_STRING,
             DATA_STRING,
             DATA_STRING,
             DATA_STRING,
@@ -309,10 +316,11 @@ public class EventDecoderTest {
         });
 
         segmentTypes = decoder.nextSegmentType(ForkedProcessEventType.BOOTERCODE_TEST_ASSUMPTIONFAILURE);
-        assertThat(segmentTypes).hasSize(14).isEqualTo(new SegmentType[] {
+        assertThat(segmentTypes).hasSize(15).isEqualTo(new SegmentType[] {
             RUN_MODE,
             TEST_RUN_ID,
             STRING_ENCODING,
+            DATA_STRING,
             DATA_STRING,
             DATA_STRING,
             DATA_STRING,
@@ -448,6 +456,7 @@ public class EventDecoderTest {
                         1L,
                         "source",
                         "sourceText",
+                        "sourceQualifiedName",
                         "name",
                         "nameText",
                         "group",
@@ -465,6 +474,8 @@ public class EventDecoderTest {
                 .isEqualTo("source");
         assertThat(((TestsetStartingEvent) event).getReportEntry().getSourceText())
                 .isEqualTo("sourceText");
+        assertThat(((TestsetStartingEvent) event).getReportEntry().getSourceQualifiedName())
+                .isEqualTo("sourceQualifiedName");
         assertThat(((TestsetStartingEvent) event).getReportEntry().getName()).isEqualTo("name");
         assertThat(((TestsetStartingEvent) event).getReportEntry().getNameText())
                 .isEqualTo("nameText");
@@ -495,6 +506,7 @@ public class EventDecoderTest {
                         1L,
                         "source",
                         "sourceText",
+                        "sourceQualifiedName",
                         "name",
                         "nameText",
                         "group",
@@ -513,6 +525,8 @@ public class EventDecoderTest {
                 .isEqualTo("source");
         assertThat(((TestsetCompletedEvent) event).getReportEntry().getSourceText())
                 .isEqualTo("sourceText");
+        assertThat(((TestsetCompletedEvent) event).getReportEntry().getSourceQualifiedName())
+                .isEqualTo("sourceQualifiedName");
         assertThat(((TestsetCompletedEvent) event).getReportEntry().getName()).isEqualTo("name");
         assertThat(((TestsetCompletedEvent) event).getReportEntry().getNameText())
                 .isEqualTo("nameText");
@@ -545,6 +559,7 @@ public class EventDecoderTest {
                         1L,
                         "source",
                         "sourceText",
+                        "sourceQualifiedName",
                         "name",
                         "nameText",
                         "group",
@@ -559,6 +574,8 @@ public class EventDecoderTest {
         assertThat(((TestStartingEvent) event).getReportEntry().getTestRunId()).isEqualTo(1L);
         assertThat(((TestStartingEvent) event).getReportEntry().getSourceName()).isEqualTo("source");
         assertThat(((TestStartingEvent) event).getReportEntry().getSourceText()).isEqualTo("sourceText");
+        assertThat(((TestStartingEvent) event).getReportEntry().getSourceQualifiedName())
+                .isEqualTo("sourceQualifiedName");
         assertThat(((TestStartingEvent) event).getReportEntry().getName()).isEqualTo("name");
         assertThat(((TestStartingEvent) event).getReportEntry().getNameText()).isEqualTo("nameText");
         assertThat(((TestStartingEvent) event).getReportEntry().getGroup()).isEqualTo("group");
@@ -588,6 +605,7 @@ public class EventDecoderTest {
                         1L,
                         "source",
                         "sourceText",
+                        "sourceQualifiedName",
                         "name",
                         "nameText",
                         "group",
@@ -604,6 +622,8 @@ public class EventDecoderTest {
                 .isEqualTo("source");
         assertThat(((TestSucceededEvent) event).getReportEntry().getSourceText())
                 .isEqualTo("sourceText");
+        assertThat(((TestSucceededEvent) event).getReportEntry().getSourceQualifiedName())
+                .isEqualTo("sourceQualifiedName");
         assertThat(((TestSucceededEvent) event).getReportEntry().getName()).isEqualTo("name");
         assertThat(((TestSucceededEvent) event).getReportEntry().getNameText()).isEqualTo("nameText");
         assertThat(((TestSucceededEvent) event).getReportEntry().getGroup()).isEqualTo("group");
@@ -619,6 +639,7 @@ public class EventDecoderTest {
                         1L,
                         "source",
                         null,
+                        null,
                         "name",
                         null,
                         "group",
@@ -633,6 +654,8 @@ public class EventDecoderTest {
         assertThat(((TestFailedEvent) event).getReportEntry().getTestRunId()).isEqualTo(1L);
         assertThat(((TestFailedEvent) event).getReportEntry().getSourceName()).isEqualTo("source");
         assertThat(((TestFailedEvent) event).getReportEntry().getSourceText()).isNull();
+        assertThat(((TestFailedEvent) event).getReportEntry().getSourceQualifiedName())
+                .isNull();
         assertThat(((TestFailedEvent) event).getReportEntry().getName()).isEqualTo("name");
         assertThat(((TestFailedEvent) event).getReportEntry().getNameText()).isNull();
         assertThat(((TestFailedEvent) event).getReportEntry().getGroup()).isEqualTo("group");
@@ -657,13 +680,16 @@ public class EventDecoderTest {
 
         memento = decoder.new Memento();
         memento.getData()
-                .addAll(asList(NORMAL_RUN, 1L, "source", null, "name", null, null, null, 5, null, null, "stackTrace"));
+                .addAll(asList(
+                        NORMAL_RUN, 1L, "source", null, null, "name", null, null, null, 5, null, null, "stackTrace"));
         event = decoder.toMessage(BOOTERCODE_TEST_SKIPPED, memento);
         assertThat(event).isInstanceOf(TestSkippedEvent.class);
         assertThat(((TestSkippedEvent) event).getReportEntry().getRunMode()).isEqualTo(NORMAL_RUN);
         assertThat(((TestSkippedEvent) event).getReportEntry().getTestRunId()).isEqualTo(1L);
         assertThat(((TestSkippedEvent) event).getReportEntry().getSourceName()).isEqualTo("source");
         assertThat(((TestSkippedEvent) event).getReportEntry().getSourceText()).isNull();
+        assertThat(((TestSkippedEvent) event).getReportEntry().getSourceQualifiedName())
+                .isNull();
         assertThat(((TestSkippedEvent) event).getReportEntry().getName()).isEqualTo("name");
         assertThat(((TestSkippedEvent) event).getReportEntry().getNameText()).isNull();
         assertThat(((TestSkippedEvent) event).getReportEntry().getGroup()).isNull();
@@ -689,13 +715,27 @@ public class EventDecoderTest {
         memento = decoder.new Memento();
         memento.getData()
                 .addAll(asList(
-                        NORMAL_RUN, 1L, "source", null, "name", "nameText", null, null, 0, null, null, "stackTrace"));
+                        NORMAL_RUN,
+                        1L,
+                        "source",
+                        null,
+                        null,
+                        "name",
+                        "nameText",
+                        null,
+                        null,
+                        0,
+                        null,
+                        null,
+                        "stackTrace"));
         event = decoder.toMessage(BOOTERCODE_TEST_ERROR, memento);
         assertThat(event).isInstanceOf(TestErrorEvent.class);
         assertThat(((TestErrorEvent) event).getReportEntry().getRunMode()).isEqualTo(NORMAL_RUN);
         assertThat(((TestErrorEvent) event).getReportEntry().getTestRunId()).isEqualTo(1L);
         assertThat(((TestErrorEvent) event).getReportEntry().getSourceName()).isEqualTo("source");
         assertThat(((TestErrorEvent) event).getReportEntry().getSourceText()).isNull();
+        assertThat(((TestErrorEvent) event).getReportEntry().getSourceQualifiedName())
+                .isNull();
         assertThat(((TestErrorEvent) event).getReportEntry().getName()).isEqualTo("name");
         assertThat(((TestErrorEvent) event).getReportEntry().getNameText()).isEqualTo("nameText");
         assertThat(((TestErrorEvent) event).getReportEntry().getGroup()).isNull();
@@ -721,7 +761,19 @@ public class EventDecoderTest {
         memento = decoder.new Memento();
         memento.getData()
                 .addAll(asList(
-                        NORMAL_RUN, 1L, "source", null, "name", null, "group", null, 5, null, null, "stackTrace"));
+                        NORMAL_RUN,
+                        1L,
+                        "source",
+                        null,
+                        null,
+                        "name",
+                        null,
+                        "group",
+                        null,
+                        5,
+                        null,
+                        null,
+                        "stackTrace"));
         event = decoder.toMessage(BOOTERCODE_TEST_ASSUMPTIONFAILURE, memento);
         assertThat(event).isInstanceOf(TestAssumptionFailureEvent.class);
         assertThat(((TestAssumptionFailureEvent) event).getReportEntry().getRunMode())
@@ -731,6 +783,8 @@ public class EventDecoderTest {
         assertThat(((TestAssumptionFailureEvent) event).getReportEntry().getSourceName())
                 .isEqualTo("source");
         assertThat(((TestAssumptionFailureEvent) event).getReportEntry().getSourceText())
+                .isNull();
+        assertThat(((TestAssumptionFailureEvent) event).getReportEntry().getSourceQualifiedName())
                 .isNull();
         assertThat(((TestAssumptionFailureEvent) event).getReportEntry().getName())
                 .isEqualTo("name");
@@ -762,7 +816,7 @@ public class EventDecoderTest {
 
     @Test
     public void shouldRecognizeEmptyStream4ReportEntry() {
-        ReportEntry reportEntry = newReportEntry(NORMAL_RUN, 1L, "", "", "", "", "", "", null, "", "", "");
+        ReportEntry reportEntry = newReportEntry(NORMAL_RUN, 1L, "", "", "", "", "", "", "", null, "", "", "");
         assertThat(reportEntry).isNotNull();
         assertThat(reportEntry.getRunMode()).isEqualTo(NORMAL_RUN);
         assertThat(reportEntry.getTestRunId()).isEqualTo(1L);
@@ -773,6 +827,7 @@ public class EventDecoderTest {
                 .isEmpty();
         assertThat(reportEntry.getSourceName()).isEmpty();
         assertThat(reportEntry.getSourceText()).isEmpty();
+        assertThat(reportEntry.getSourceQualifiedName()).isEmpty();
         assertThat(reportEntry.getName()).isEmpty();
         assertThat(reportEntry.getNameText()).isEmpty();
         assertThat(reportEntry.getGroup()).isEmpty();
@@ -805,6 +860,7 @@ public class EventDecoderTest {
         when(reportEntry.getNameWithGroup()).thenReturn("name with group");
         when(reportEntry.getSourceName()).thenReturn("pkg.MyTest");
         when(reportEntry.getSourceText()).thenReturn("test class display name");
+        when(reportEntry.getSourceQualifiedName()).thenReturn("pkg.MyTest$innerClass");
         when(reportEntry.getStackTraceWriter()).thenReturn(stackTraceWriter);
 
         ReportEntry decodedReportEntry = newReportEntry(
@@ -812,6 +868,7 @@ public class EventDecoderTest {
                 1L,
                 reportEntry.getSourceName(),
                 reportEntry.getSourceText(),
+                reportEntry.getSourceQualifiedName(),
                 reportEntry.getName(),
                 reportEntry.getNameText(),
                 reportEntry.getGroup(),
@@ -824,6 +881,7 @@ public class EventDecoderTest {
         assertThat(decodedReportEntry).isNotNull();
         assertThat(decodedReportEntry.getSourceName()).isEqualTo(reportEntry.getSourceName());
         assertThat(decodedReportEntry.getSourceText()).isEqualTo(reportEntry.getSourceText());
+        assertThat(decodedReportEntry.getSourceQualifiedName()).isEqualTo(reportEntry.getSourceQualifiedName());
         assertThat(decodedReportEntry.getName()).isEqualTo(reportEntry.getName());
         assertThat(decodedReportEntry.getNameText()).isEqualTo(reportEntry.getNameText());
         assertThat(decodedReportEntry.getGroup()).isEqualTo(reportEntry.getGroup());
@@ -835,6 +893,7 @@ public class EventDecoderTest {
                 1L,
                 reportEntry.getSourceName(),
                 reportEntry.getSourceText(),
+                reportEntry.getSourceQualifiedName(),
                 reportEntry.getName(),
                 reportEntry.getNameText(),
                 reportEntry.getGroup(),
@@ -847,6 +906,7 @@ public class EventDecoderTest {
         assertThat(decodedReportEntry).isNotNull();
         assertThat(decodedReportEntry.getSourceName()).isEqualTo(reportEntry.getSourceName());
         assertThat(decodedReportEntry.getSourceText()).isEqualTo(reportEntry.getSourceText());
+        assertThat(decodedReportEntry.getSourceQualifiedName()).isEqualTo(reportEntry.getSourceQualifiedName());
         assertThat(decodedReportEntry.getName()).isEqualTo(reportEntry.getName());
         assertThat(decodedReportEntry.getNameText()).isEqualTo(reportEntry.getNameText());
         assertThat(decodedReportEntry.getGroup()).isEqualTo(reportEntry.getGroup());
@@ -865,6 +925,7 @@ public class EventDecoderTest {
                 1L,
                 reportEntry.getSourceName(),
                 reportEntry.getSourceText(),
+                reportEntry.getSourceQualifiedName(),
                 reportEntry.getName(),
                 reportEntry.getNameText(),
                 reportEntry.getGroup(),
@@ -877,6 +938,7 @@ public class EventDecoderTest {
         assertThat(decodedReportEntry).isNotNull();
         assertThat(decodedReportEntry.getSourceName()).isEqualTo(reportEntry.getSourceName());
         assertThat(decodedReportEntry.getSourceText()).isEqualTo(reportEntry.getSourceText());
+        assertThat(decodedReportEntry.getSourceQualifiedName()).isEqualTo(reportEntry.getSourceQualifiedName());
         assertThat(decodedReportEntry.getName()).isEqualTo(reportEntry.getName());
         assertThat(decodedReportEntry.getNameText()).isEqualTo(reportEntry.getNameText());
         assertThat(decodedReportEntry.getGroup()).isEqualTo(reportEntry.getGroup());
@@ -895,6 +957,7 @@ public class EventDecoderTest {
                 1L,
                 reportEntry.getSourceName(),
                 reportEntry.getSourceText(),
+                reportEntry.getSourceQualifiedName(),
                 reportEntry.getName(),
                 reportEntry.getNameText(),
                 reportEntry.getGroup(),
@@ -907,6 +970,7 @@ public class EventDecoderTest {
         assertThat(decodedReportEntry).isNotNull();
         assertThat(decodedReportEntry.getSourceName()).isEqualTo(reportEntry.getSourceName());
         assertThat(decodedReportEntry.getSourceText()).isEqualTo(reportEntry.getSourceText());
+        assertThat(decodedReportEntry.getSourceQualifiedName()).isEqualTo(reportEntry.getSourceQualifiedName());
         assertThat(decodedReportEntry.getName()).isEqualTo(reportEntry.getName());
         assertThat(decodedReportEntry.getNameText()).isEqualTo(reportEntry.getNameText());
         assertThat(decodedReportEntry.getGroup()).isEqualTo(reportEntry.getGroup());
@@ -929,6 +993,7 @@ public class EventDecoderTest {
                 1L,
                 reportEntry.getSourceName(),
                 reportEntry.getSourceText(),
+                reportEntry.getSourceQualifiedName(),
                 reportEntry.getName(),
                 reportEntry.getNameText(),
                 reportEntry.getGroup(),
@@ -941,6 +1006,7 @@ public class EventDecoderTest {
         assertThat(decodedReportEntry).isNotNull();
         assertThat(decodedReportEntry.getSourceName()).isEqualTo(reportEntry.getSourceName());
         assertThat(decodedReportEntry.getSourceText()).isEqualTo(reportEntry.getSourceText());
+        assertThat(decodedReportEntry.getSourceQualifiedName()).isEqualTo(reportEntry.getSourceQualifiedName());
         assertThat(decodedReportEntry.getName()).isEqualTo(reportEntry.getName());
         assertThat(decodedReportEntry.getNameText()).isEqualTo(reportEntry.getNameText());
         assertThat(decodedReportEntry.getGroup()).isEqualTo(reportEntry.getGroup());

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/CategorizedReportEntry.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/CategorizedReportEntry.java
@@ -103,11 +103,40 @@ public class CategorizedReportEntry extends SimpleReportEntry {
         this.group = group;
     }
 
+    public CategorizedReportEntry(
+            @Nonnull RunMode runMode,
+            @Nonnegative Long testRunId,
+            String source,
+            String sourceText,
+            String sourceQualifiedName,
+            String name,
+            String nameText,
+            String group,
+            StackTraceWriter stackTraceWriter,
+            Integer elapsed,
+            String message,
+            Map<String, String> systemProperties) {
+        super(
+                runMode,
+                testRunId,
+                source,
+                sourceText,
+                sourceQualifiedName,
+                name,
+                nameText,
+                stackTraceWriter,
+                elapsed,
+                message,
+                systemProperties);
+        this.group = group;
+    }
+
     public static TestSetReportEntry reportEntry(
             @Nonnull RunMode runMode,
             @Nonnegative Long testRunId,
             String source,
             String sourceText,
+            String sourceQualifiedName,
             String name,
             String nameText,
             String group,
@@ -121,6 +150,7 @@ public class CategorizedReportEntry extends SimpleReportEntry {
                         testRunId,
                         source,
                         sourceText,
+                        sourceQualifiedName,
                         name,
                         nameText,
                         group,
@@ -133,6 +163,7 @@ public class CategorizedReportEntry extends SimpleReportEntry {
                         testRunId,
                         source,
                         sourceText,
+                        sourceQualifiedName,
                         name,
                         nameText,
                         stackTraceWriter,

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/EventChannelEncoder.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/spi/EventChannelEncoder.java
@@ -346,6 +346,7 @@ public class EventChannelEncoder extends EventEncoder implements MasterProcessCh
                 1,
                 reportEntry.getSourceName(),
                 reportEntry.getSourceText(),
+                reportEntry.getSourceQualifiedName(),
                 reportEntry.getName(),
                 reportEntry.getNameText(),
                 reportEntry.getGroup(),
@@ -361,6 +362,7 @@ public class EventChannelEncoder extends EventEncoder implements MasterProcessCh
 
         encodeString(encoder, result, reportEntry.getSourceName());
         encodeString(encoder, result, reportEntry.getSourceText());
+        encodeString(encoder, result, reportEntry.getSourceQualifiedName());
         encodeString(encoder, result, reportEntry.getName());
         encodeString(encoder, result, reportEntry.getNameText());
         encodeString(encoder, result, reportEntry.getGroup());

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/EventChannelEncoderTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/EventChannelEncoderTest.java
@@ -84,6 +84,7 @@ public class EventChannelEncoderTest {
         when(reportEntry.getName()).thenReturn("my test");
         when(reportEntry.getNameWithGroup()).thenReturn("name with group");
         when(reportEntry.getSourceName()).thenReturn("pkg.MyTest");
+        when(reportEntry.getSourceQualifiedName()).thenReturn("pkg.MyTest$innerClass");
         when(reportEntry.getStackTraceWriter()).thenReturn(stackTraceWriter);
 
         Stream out = Stream.newStream();
@@ -106,6 +107,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(new byte[] {0, 0, 0, 1});
         expectedFrame.write(':');
         expectedFrame.write(0);
+        expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
         expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
@@ -164,6 +169,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(':');
         expectedFrame.write(0);
         expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
+        expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
         expectedFrame.write(reportEntry.getName().getBytes(UTF_8));
@@ -221,6 +230,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(':');
         expectedFrame.write(0);
         expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
+        expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
         expectedFrame.write(reportEntry.getName().getBytes(UTF_8));
@@ -276,6 +289,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(new byte[] {0, 0, 0, 1});
         expectedFrame.write(':');
         expectedFrame.write(0);
+        expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
         expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
@@ -337,6 +354,7 @@ public class EventChannelEncoderTest {
         when(reportEntry.getName()).thenReturn("my test");
         when(reportEntry.getNameWithGroup()).thenReturn("name with group");
         when(reportEntry.getSourceName()).thenReturn("pkg.MyTest");
+        when(reportEntry.getSourceQualifiedName()).thenReturn("pkg.MyTest$innerClass");
         when(reportEntry.getStackTraceWriter()).thenReturn(stackTraceWriter);
         when(reportEntry.getSystemProperties()).thenReturn(props);
 
@@ -390,6 +408,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(new byte[] {0, 0, 0, 1});
         expectedFrame.write(':');
         expectedFrame.write(0);
+        expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
         expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
@@ -450,6 +472,7 @@ public class EventChannelEncoderTest {
         when(reportEntry.getName()).thenReturn("my test");
         when(reportEntry.getNameWithGroup()).thenReturn("name with group");
         when(reportEntry.getSourceName()).thenReturn("pkg.MyTest");
+        when(reportEntry.getSourceQualifiedName()).thenReturn("pkg.MyTest$innerClass");
         when(reportEntry.getStackTraceWriter()).thenReturn(stackTraceWriter);
 
         Stream out = Stream.newStream();
@@ -474,6 +497,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(new byte[] {0, 0, 0, 1});
         expectedFrame.write(':');
         expectedFrame.write(0);
+        expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
         expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
@@ -533,6 +560,7 @@ public class EventChannelEncoderTest {
         when(reportEntry.getName()).thenReturn("my test");
         when(reportEntry.getNameWithGroup()).thenReturn("name with group");
         when(reportEntry.getSourceName()).thenReturn("pkg.MyTest");
+        when(reportEntry.getSourceQualifiedName()).thenReturn("pkg.MyTest$innerClass");
         when(reportEntry.getStackTraceWriter()).thenReturn(stackTraceWriter);
 
         Stream out = Stream.newStream();
@@ -556,6 +584,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(new byte[] {0, 0, 0, 1});
         expectedFrame.write(':');
         expectedFrame.write(0);
+        expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
         expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
@@ -615,6 +647,7 @@ public class EventChannelEncoderTest {
         when(reportEntry.getName()).thenReturn("my test");
         when(reportEntry.getNameWithGroup()).thenReturn("name with group");
         when(reportEntry.getSourceName()).thenReturn("pkg.MyTest");
+        when(reportEntry.getSourceQualifiedName()).thenReturn("pkg.MyTest$innerClass");
         when(reportEntry.getStackTraceWriter()).thenReturn(stackTraceWriter);
 
         Stream out = Stream.newStream();
@@ -638,6 +671,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(new byte[] {0, 0, 0, 1});
         expectedFrame.write(':');
         expectedFrame.write(0);
+        expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
         expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
@@ -696,6 +733,7 @@ public class EventChannelEncoderTest {
         when(reportEntry.getName()).thenReturn("my test");
         when(reportEntry.getNameWithGroup()).thenReturn("name with group");
         when(reportEntry.getSourceName()).thenReturn("pkg.MyTest");
+        when(reportEntry.getSourceQualifiedName()).thenReturn("pkg.MyTest$innerClass");
         when(reportEntry.getStackTraceWriter()).thenReturn(stackTraceWriter);
 
         Stream out = Stream.newStream();
@@ -719,6 +757,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(new byte[] {0, 0, 0, 1});
         expectedFrame.write(':');
         expectedFrame.write(0);
+        expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
         expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
@@ -777,6 +819,7 @@ public class EventChannelEncoderTest {
         when(reportEntry.getName()).thenReturn("my test");
         when(reportEntry.getNameWithGroup()).thenReturn("name with group");
         when(reportEntry.getSourceName()).thenReturn("pkg.MyTest");
+        when(reportEntry.getSourceQualifiedName()).thenReturn("pkg.MyTest$innerClass");
         when(reportEntry.getStackTraceWriter()).thenReturn(stackTraceWriter);
 
         Stream out = Stream.newStream();
@@ -799,6 +842,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(new byte[] {0, 0, 0, 1});
         expectedFrame.write(':');
         expectedFrame.write(0);
+        expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
         expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');
@@ -856,6 +903,7 @@ public class EventChannelEncoderTest {
         when(reportEntry.getName()).thenReturn("my test");
         when(reportEntry.getNameWithGroup()).thenReturn("name with group");
         when(reportEntry.getSourceName()).thenReturn("pkg.MyTest");
+        when(reportEntry.getSourceQualifiedName()).thenReturn("pkg.MyTest$innerClass");
         when(reportEntry.getStackTraceWriter()).thenReturn(stackTraceWriter);
 
         Stream out = Stream.newStream();
@@ -879,6 +927,10 @@ public class EventChannelEncoderTest {
         expectedFrame.write(new byte[] {0, 0, 0, 1});
         expectedFrame.write(':');
         expectedFrame.write(0);
+        expectedFrame.write(':');
+        expectedFrame.write(new byte[] {0, 0, 0, 21});
+        expectedFrame.write(':');
+        expectedFrame.write(reportEntry.getSourceQualifiedName().getBytes(UTF_8));
         expectedFrame.write(':');
         expectedFrame.write(new byte[] {0, 0, 0, 7});
         expectedFrame.write(':');

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3380ForkedSourceQualifiedNameIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3380ForkedSourceQualifiedNameIT.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import java.util.Arrays;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Integration Test for #3380
+ */
+@SuppressWarnings("checkstyle:magicnumber")
+public class Surefire3380ForkedSourceQualifiedNameIT extends SurefireJUnit4IntegrationTestCase {
+    static Iterable<?> junitJupiterVersions() {
+        return Arrays.asList("5.8.2", "5.9.1", "5.13.4");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("junitJupiterVersions")
+    void testXmlReport(String jupiterVersion) {
+        OutputValidator validator = unpack("surefire-3380-forked-source-qualified-name", "-" + jupiterVersion)
+                .setForkJvm()
+                .sysProp("junit5.version", jupiterVersion)
+                .executeTest()
+                .verifyErrorFree(9);
+
+        validator
+                .getSurefireReportsFile("TEST-issue3380.NestedJupiterTest.xml", UTF_8)
+                .assertContainsText("<testcase name=\"level1_test\" " + "classname=\"issue3380.NestedJupiterTest$A\"");
+
+        validator
+                .getSurefireReportsFile("TEST-issue3380.NestedJupiterTest.xml", UTF_8)
+                .assertContainsText("<testcase name=\"level2_test_nonparameterized\" "
+                        + "classname=\"issue3380.NestedJupiterTest$B$C\"")
+                .assertContainsText("<testcase name=\"level2_test_parameterized(String)[1]\" "
+                        + "classname=\"issue3380.NestedJupiterTest$B$C\"")
+                .assertContainsText("<testcase name=\"level2_test_parameterized(String)[2]\" "
+                        + "classname=\"issue3380.NestedJupiterTest$B$C\"");
+
+        String expectedDisplayNameForNestedClassA = "issue3380.NestedDisplayNameTest$A";
+
+        validator
+                .getSurefireReportsFile("TEST-issue3380.NestedDisplayNameTest.xml", UTF_8)
+                .assertContainsText("<testcase name=\"level1_test_without_display_name\" " + "classname=\""
+                        + expectedDisplayNameForNestedClassA + "\"")
+                .assertContainsText("<testcase name=\"level1_test_with_display_name\" " + "classname=\""
+                        + expectedDisplayNameForNestedClassA + "\"");
+
+        String expectedDisplayNameForNestedClassC = "issue3380.NestedDisplayNameTest$B$C";
+
+        validator
+                .getSurefireReportsFile("TEST-issue3380.NestedDisplayNameTest.xml", UTF_8)
+                .assertContainsText("<testcase name=\"level2_test_nonparameterized\" " + "classname=\""
+                        + expectedDisplayNameForNestedClassC + "\"")
+                .assertContainsText("<testcase name=\"level2_test_parameterized(String)[1]\" " + "classname=\""
+                        + expectedDisplayNameForNestedClassC + "\"")
+                .assertContainsText("<testcase name=\"level2_test_parameterized(String)[2]\" " + "classname=\""
+                        + expectedDisplayNameForNestedClassC + "\"");
+    }
+}

--- a/surefire-its/src/test/resources/surefire-3380-forked-source-qualified-name/pom.xml
+++ b/surefire-its/src/test/resources/surefire-3380-forked-source-qualified-name/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-3380-forked-source-qualified-name</artifactId>
+    <version>1.0</version>
+    <name>Test for: Sending sourceQualifiedName for forkedClients</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <!--
+        Declare "junit-jupiter-engine" dependency because the
+        Jupiter Engine is needed at test runtime. Artifacts
+        needed for test compilation, like "junit-jupiter-api",
+        are pulled-in via transitive dependency resolution.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <forkCount>1.0C</forkCount>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                        <disable>false</disable>
+                        <version>3.0</version>
+                        <usePhrasedTestCaseClassName>false</usePhrasedTestCaseClassName>
+                    </statelessTestsetReporter>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-3380-forked-source-qualified-name/src/test/java/issue3380/NestedDisplayNameTest.java
+++ b/surefire-its/src/test/resources/surefire-3380-forked-source-qualified-name/src/test/java/issue3380/NestedDisplayNameTest.java
@@ -1,0 +1,50 @@
+package issue3380;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName( "Display name of the main test class" )
+class NestedDisplayNameTest
+{
+    @Nested
+    @DisplayName( "Display name of level 1 nested class A" )
+    class A
+    {
+        @Test
+        void level1_test_without_display_name()
+        {
+        }
+
+        @Test
+        @DisplayName( "Display name of level 1 test method" )
+        void level1_test_with_display_name()
+        {
+        }
+    }
+
+    @Nested
+    @DisplayName( "Display name of level 1 nested class B" )
+    class B
+    {
+        @Nested
+        @DisplayName( "Display name of level 2 nested class C" )
+        class C
+        {
+            @Test
+            @DisplayName( "Display name of non-parameterized level 2 test method" )
+            void level2_test_nonparameterized()
+            {
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"paramValue1", "paramValue2"})
+            @DisplayName( "Display name of parameterized level 2 test method" )
+            void level2_test_parameterized(String paramValue)
+            {
+            }
+        }
+    }
+}

--- a/surefire-its/src/test/resources/surefire-3380-forked-source-qualified-name/src/test/java/issue3380/NestedJupiterTest.java
+++ b/surefire-its/src/test/resources/surefire-3380-forked-source-qualified-name/src/test/java/issue3380/NestedJupiterTest.java
@@ -1,0 +1,56 @@
+package issue3380;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class NestedJupiterTest
+{
+    @Nested
+    class A
+    {
+        @Test
+        void level1_test()
+        {
+        }
+    }
+
+    @Nested
+    class B
+    {
+        @Nested
+        class C
+        {
+            @Test
+            void level2_test_nonparameterized()
+            {
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"paramValue1", "paramValue2"})
+            void level2_test_parameterized(String paramValue)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
The sourceQualifiedName should also be sent to forked clients, so it's added on ForkClient, the EventChannelEncoder and EventDecoder.

It should also be used in the CategorizedReportEntry and implemented properly in WrappedReportEntry.

Check #3380 and #3203

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
