### PR TITLE
[Issue-3396] Support runOrder=balanced with forkCount>1

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/IntegrationTestMojo.java
@@ -328,8 +328,11 @@ public class IntegrationTestMojo extends AbstractSurefireMojo {
      * Failed first will run tests that failed on previous run first, as well as new tests for this run.
      * <br>
      * <br>
-     * Balanced is only relevant with parallel=classes, and will try to optimize the run-order of the tests reducing the
-     * overall execution time. Initially a statistics file is created and every next test run will reorder classes.
+     * Balanced will try to optimize the run-order of the tests reducing the overall execution time by distributing the
+     * classes across the concurrent test consumers based on their recorded run time. The number of consumers is
+     * {@code forkCount} multiplied by {@code threadCount} (when {@code parallel} is used), so balanced is effective
+     * with {@code forkCount > 1} even without {@code parallel=classes}. Initially a statistics file is created and
+     * every next test run will reorder classes.
      * <br>
      * <br>
      * Note that the statistics are stored in a file named <b>.surefire-XXXXXXXXX</b> beside <i>pom.xml</i> and

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -1825,6 +1825,10 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
 
         getProperties().setProperty(ProviderParameterNames.STACK_TRACE_MAX_FRAMES, String.valueOf(stackTraceMaxFrames));
 
+        getProperties()
+                .setProperty(
+                        ProviderParameterNames.FORKCOUNT_PROP, Integer.toString(Math.max(getEffectiveForkCount(), 1)));
+
         Map<String, String> providerProperties = toStringProperties(getProperties());
 
         return new ProviderConfiguration(

--- a/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefireMojo.java
+++ b/maven-surefire-plugin/src/main/java/org/apache/maven/plugin/surefire/SurefireMojo.java
@@ -308,8 +308,11 @@ public class SurefireMojo extends AbstractSurefireMojo implements SurefireReport
      * Failed first will run tests that failed on previous run first, as well as new tests for this run.
      * <br>
      * <br>
-     * Balanced is only relevant with parallel=classes, and will try to optimize the run-order of the tests reducing the
-     * overall execution time. Initially a statistics file is created and every next test run will reorder classes.
+     * Balanced will try to optimize the run-order of the tests reducing the overall execution time by distributing the
+     * classes across the concurrent test consumers based on their recorded run time. The number of consumers is
+     * {@code forkCount} multiplied by {@code threadCount} (when {@code parallel} is used), so balanced is effective
+     * with {@code forkCount > 1} even without {@code parallel=classes}. Initially a statistics file is created and
+     * every next test run will reorder classes.
      * <br>
      * <br>
      * Note that the statistics are stored in a file named <b>.surefire-XXXXXXXXX</b> beside <i>pom.xml</i> and

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/BaseProviderFactory.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/BaseProviderFactory.java
@@ -105,9 +105,14 @@ public class BaseProviderFactory implements ProviderParameters {
         return threadcount == null ? 1 : Math.max(Integer.parseInt(threadcount), 1);
     }
 
+    private int getForkCount() {
+        final String forkcount = providerProperties.get(ProviderParameterNames.FORKCOUNT_PROP);
+        return forkcount == null ? 1 : Math.max(Integer.parseInt(forkcount), 1);
+    }
+
     @Override
     public RunOrderCalculator getRunOrderCalculator() {
-        return new DefaultRunOrderCalculator(runOrderParameters, getThreadCount());
+        return new DefaultRunOrderCalculator(runOrderParameters, getThreadCount() * getForkCount());
     }
 
     public void setReporterFactory(ReporterFactory reporterFactory) {

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ProviderParameterNames.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ProviderParameterNames.java
@@ -32,6 +32,13 @@ public class ProviderParameterNames {
 
     public static final String THREADCOUNT_PROP = "threadcount";
 
+    /**
+     * Number of forked JVMs executing tests concurrently, used together with {@link #THREADCOUNT_PROP} to size the
+     * distribution of the {@code balanced} run order.
+     * @since 3.6.0
+     */
+    public static final String FORKCOUNT_PROP = "forkcount";
+
     public static final String PARALLEL_PROP = "parallel";
 
     public static final String THREADCOUNTSUITES_PROP = "threadcountsuites";

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/DefaultRunOrderCalculator.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/DefaultRunOrderCalculator.java
@@ -40,13 +40,13 @@ public class DefaultRunOrderCalculator implements RunOrderCalculator {
 
     private final RunOrderParameters runOrderParameters;
 
-    private final int threadCount;
+    private final int distributedParallelism;
 
     private final Random random;
 
-    public DefaultRunOrderCalculator(RunOrderParameters runOrderParameters, int threadCount) {
+    public DefaultRunOrderCalculator(RunOrderParameters runOrderParameters, int distributedParallelism) {
         this.runOrderParameters = runOrderParameters;
-        this.threadCount = threadCount;
+        this.distributedParallelism = distributedParallelism;
         this.runOrder = runOrderParameters.getRunOrder();
         this.sortOrder = this.runOrder.length > 0 ? getSortOrderComparator(this.runOrder[0]) : null;
         Long runOrderRandomSeed = runOrderParameters.getRunOrderRandomSeed();
@@ -77,7 +77,7 @@ public class DefaultRunOrderCalculator implements RunOrderCalculator {
 
         } else if (RunOrder.BALANCED.equals(runOrder)) {
             RunEntryStatisticsMap stat = RunEntryStatisticsMap.fromFile(runOrderParameters.getRunStatisticsFile());
-            List<Class<?>> prioritized = stat.getPrioritizedTestsClassRunTime(testClasses, threadCount);
+            List<Class<?>> prioritized = stat.getPrioritizedTestsClassRunTime(testClasses, distributedParallelism);
             testClasses.clear();
             testClasses.addAll(prioritized);
 

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/booter/BaseProviderFactoryTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/booter/BaseProviderFactoryTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.api.booter;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.maven.surefire.api.testset.RunOrderParameters;
+import org.apache.maven.surefire.api.util.DefaultRunOrderCalculator;
+import org.apache.maven.surefire.api.util.RunOrder;
+import org.apache.maven.surefire.api.util.RunOrderCalculator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the {@code balanced} run order distribution width is derived from both the parallel
+ * {@code threadcount} and the {@code forkcount}.
+ */
+public class BaseProviderFactoryTest {
+
+    @Test
+    public void distributionWidthDefaultsToForkCountWhenNoThreadCount() {
+        assertThat(distributedParallelism(properties(null, "3"))).isEqualTo(3);
+    }
+
+    @Test
+    public void distributionWidthEqualsThreadCountWhenSingleFork() {
+        assertThat(distributedParallelism(properties("4", "1"))).isEqualTo(4);
+    }
+
+    @Test
+    public void distributionWidthMultipliesThreadCountAndForkCount() {
+        assertThat(distributedParallelism(properties("4", "3"))).isEqualTo(12);
+    }
+
+    @Test
+    public void distributionWidthDefaultsToOneWhenNoPropertiesSet() {
+        assertThat(distributedParallelism(properties(null, null))).isEqualTo(1);
+    }
+
+    @Test
+    public void distributionWidthClampsZeroForkCountToOne() {
+        assertThat(distributedParallelism(properties("4", "0"))).isEqualTo(4);
+    }
+
+    private static Map<String, String> properties(String threadCount, String forkCount) {
+        Map<String, String> providerProperties = new HashMap<>();
+        if (threadCount != null) {
+            providerProperties.put(ProviderParameterNames.THREADCOUNT_PROP, threadCount);
+        }
+        if (forkCount != null) {
+            providerProperties.put(ProviderParameterNames.FORKCOUNT_PROP, forkCount);
+        }
+        return providerProperties;
+    }
+
+    private static int distributedParallelism(Map<String, String> providerProperties) {
+        BaseProviderFactory factory = new BaseProviderFactory(true);
+        factory.setProviderProperties(providerProperties);
+        factory.setRunOrderParameters(new RunOrderParameters(new RunOrder[] {RunOrder.BALANCED}, new File(".")));
+        RunOrderCalculator calculator = factory.getRunOrderCalculator();
+        assertThat(calculator).isInstanceOf(DefaultRunOrderCalculator.class);
+        return getInternalState(calculator, "distributedParallelism");
+    }
+
+    private static int getInternalState(Object target, String fieldName) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.getInt(target);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
@@ -89,6 +89,16 @@ public class RunOrderIT extends SurefireJUnit4IntegrationTestCase {
     }
 
     @Test
+    public void testBalancedWithMultipleForksWithoutParallel() {
+        executeBalancedWithForkCount(2);
+    }
+
+    @Test
+    public void testBalancedWithoutForkingClampsDistributionWidth() {
+        executeBalancedWithForkCount(0);
+    }
+
+    @Test
     public void testNonExistingRunOrderJUnit4() {
         unpack().forkCount(1)
                 .reuseForks(reuseForks())
@@ -137,6 +147,14 @@ public class RunOrderIT extends SurefireJUnit4IntegrationTestCase {
                 .forkCount(1)
                 .reuseForks(reuseForks())
                 .runOrder(runOrder)
+                .executeTest()
+                .verifyErrorFree(3);
+    }
+
+    private OutputValidator executeBalancedWithForkCount(int forkCount) {
+        return unpack().forkCount(forkCount)
+                .reuseForks(reuseForks())
+                .runOrder("balanced")
                 .executeTest()
                 .verifyErrorFree(3);
     }


### PR DESCRIPTION
Fixes #3396

### What

`runOrder=balanced` used only `threadCount` to sort the test classes. With `forkCount>1` and no `parallel=classes`, `threadCount` is `1`. So `balanced` only put the slowest classes first and did not use the number of forks.

This change makes `balanced` use `forkCount × threadCount` as the number of parallel test runners. Now `balanced` also helps when you use `forkCount>1` without `parallel=classes`.

### How

- New `forkcount` provider property (`ProviderParameterNames.FORKCOUNT_PROP`). The mojo sends it to the provider, the same way as the existing `threadcount`.
- `BaseProviderFactory.getRunOrderCalculator()` now uses `threadCount × forkCount`. `getForkCount()` uses the same default and clamp as `getThreadCount()`.
- Renamed the field `threadCount` to `distributedParallelism` in `DefaultRunOrderCalculator`, because it now means threads and forks together.
- Updated the docs in `SurefireMojo` and `IntegrationTestMojo`. Removed the old note that said "only relevant with parallel=classes".

### Tests

- Unit test `BaseProviderFactoryTest`: checks the width is `threadCount × forkCount`, plus the default and the clamp cases.
- IT `RunOrderIT` (and `RunOrderParallelForksIT`): run `balanced` with `forkCount>1` (both reuse modes) and with `forkCount=0`.

---
- [x] Each commit has a clear subject line and body.
- [x] The description explains what the change does, how, and why.
- [x] Ran `mvn clean install` on the changed modules. Basic checks pass.
- [x] Ran the related integration tests (`RunOrderIT`, `RunOrderParallelForksIT`) with `-Prun-its`. They pass.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).