### PR TITLE
Pin maven-jar-plugin 3.5.1 in modular IT fixtures

### DIFF
--- a/surefire-its/src/test/resources/surefire-1733-junit4/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1733-junit4/pom.xml
@@ -96,6 +96,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <!-- explicit 3.5.1: the Maven 3.10.0(-rc-1) super-POM pins 3.5.0, which
+                     breaks modular JARs on Windows with JDK < 14 (plexus-archiver 4.10.4
+                     NPE), see https://github.com/apache/maven-jar-plugin/issues/555 -->
+                <version>3.5.1</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/surefire-its/src/test/resources/surefire-1733-testng/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1733-testng/pom.xml
@@ -96,6 +96,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <!-- explicit 3.5.1: the Maven 3.10.0(-rc-1) super-POM pins 3.5.0, which
+                     breaks modular JARs on Windows with JDK < 14 (plexus-archiver 4.10.4
+                     NPE), see https://github.com/apache/maven-jar-plugin/issues/555 -->
+                <version>3.5.1</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/pom.xml
+++ b/surefire-its/src/test/resources/surefire-1993-jpms-providing-modules/pom.xml
@@ -93,6 +93,14 @@
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${surefire.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <!-- explicit 3.5.1: the Maven 3.10.0(-rc-1) super-POM pins 3.5.0, which
+                         breaks modular JARs on Windows with JDK < 14 (plexus-archiver 4.10.4
+                         NPE), see https://github.com/apache/maven-jar-plugin/issues/555 -->
+                    <version>3.5.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/surefire-its/src/test/resources/surefire-2190/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2190/pom.xml
@@ -63,6 +63,14 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <!-- explicit 3.5.1: the Maven 3.10.0(-rc-1) super-POM pins 3.5.0, which
+                     breaks modular JARs on Windows with JDK < 14 (plexus-archiver 4.10.4
+                     NPE), see https://github.com/apache/maven-jar-plugin/issues/555 -->
+                <version>3.5.1</version>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The windows-latest jdk-11 CI cell fails for every PR since Maven 3.10.0-rc-1 became the IT baseline: its super-POM pins maven-jar-plugin 3.5.0, whose plexus-archiver 4.10.4 throws an NPE (`JarToolModularJarArchiver.fixLastModifiedTimeZipEntries`) when packaging modular JARs on Windows with JDK < 14 (no `jar --date`; POSIX attribute view is null on Windows). Details, reproducer and windows-runner validation: https://github.com/apache/maven-jar-plugin/issues/555

maven-jar-plugin 3.5.1 (released 2026-07-22) ships plexus-archiver 4.12.0 with the fix. This pins 3.5.1 explicitly in the four affected modular fixtures (`surefire-1733-junit4`, `surefire-1733-testng`, `surefire-2190`, `surefire-1993-jpms-providing-modules`) so the fixtures stop depending on the super-POM's jar-plugin version.

Verified locally under Maven 3.10.0-rc-1: `Surefire1733JUnit4IT`, `Surefire1733TestngIT`, `Surefire2190JUnit4IT`, `Surefire1993JpmsProvidingModulesIT` all green, fixture logs confirm `maven-jar-plugin:3.5.1:jar` executed. The windows-latest jdk-11 cell (currently red on #3392/#3395 for this unrelated reason) should turn green with this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
