### PR TITLE
Fix Windows flake in CommandChannelDecoderTest

### DIFF
--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/CommandChannelDecoderTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/CommandChannelDecoderTest.java
@@ -25,7 +25,6 @@ import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Path;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -37,7 +36,6 @@ import org.apache.maven.surefire.api.fork.ForkNodeArguments;
 import org.apache.maven.surefire.booter.ForkedNodeArg;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import static java.nio.channels.Channels.newChannel;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -63,12 +61,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class CommandChannelDecoderTest {
     private static final Random RND = new Random();
 
-    @TempDir
-    Path tempFolder;
-
     @BeforeEach
     public void initTmpFile() {
-        File reportsDir = tempFolder.toFile();
+        // Not a JUnit @TempDir: the decoder writes .dumpstream files into this directory,
+        // and on Windows a freshly written file can be transiently locked (antivirus,
+        // indexer) right when the @TempDir cleanup runs, failing the whole test class
+        // with DirectoryNotEmptyException. target/ needs no post-test cleanup.
+        File reportsDir = new File("target", "decoder-dumps");
         String dumpFileName = "surefire-" + RND.nextLong();
         DumpErrorSingleton.getSingleton().init(reportsDir, dumpFileName);
     }


### PR DESCRIPTION
`Verify / windows-latest jdk-8` intermittently fails whole `CommandChannelDecoderTest` runs with:

```
org.junit.platform.commons.JUnitException: Failed to close extension context
Caused by: java.io.IOException: Failed to delete temp directory C:\...\Temp\junit-...
  Suppressed: java.nio.file.DirectoryNotEmptyException
```

Observed three times within a week on unrelated PRs (#3392, #3395 — e.g. https://github.com/apache/maven-surefire/actions/runs/30089175667/job/89469589427 and run 30089211662); every re-run is green.

Root cause: the test class initializes `DumpErrorSingleton` into the JUnit `@TempDir`, and several tests write `.dumpstream` files there. On Windows a freshly written file can be transiently locked (antivirus/indexer) exactly when the `@TempDir` cleanup runs — the cleanup throws and fails the whole class. Surefire's own I/O is fine (all dump writes use try-with-resources), and JUnit 5.14's resilient cleanup retries evidently do not close the gap.

Fix: write the dumps under `target/decoder-dumps/` instead — no post-test cleanup needed at all, `mvn clean` removes them, and the files remain inspectable after CI runs. `CommandChannelDecoderTest` is the only test class using this pattern.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
