### PR TITLE
Enable Maven 4 build and fix IT failures

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -50,3 +50,7 @@ jobs:
         !surefire-its/target/ConsoleOutputIT_*/target/surefire-reports/*-jvmRun*-events.bin
       timeout-minutes: 600
       os-matrix: '[ "ubuntu-latest", "windows-latest", "macos-latest" ]'
+      maven4-enabled: true
+      matrix-exclude: '[
+        { "jdk": "11", "maven": "4.0.0-rc-5" }
+      ]'

--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/util/CountdownCloseable.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/util/CountdownCloseable.java
@@ -53,7 +53,7 @@ public final class CountdownCloseable implements Closeable {
      * @throws InterruptedException see {@link Object#wait()}
      */
     public synchronized void awaitClosed() throws InterruptedException {
-        if (countdown > 0) {
+        while (countdown > 0) {
             wait();
         }
     }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/MavenLauncher.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/MavenLauncher.java
@@ -76,8 +76,10 @@ public final class MavenLauncher {
         this.resourceName = resourceName;
         this.suffix = suffix != null ? suffix : "";
         this.cli = cli == null ? null : cli.clone();
-        // by default use embedded mode
-        this.forkJvm = false;
+        // Use forked mode for Maven 4+ because maven-verifier 2.0.0-M1's embedded mode
+        // uses reflection against MavenCling.doMain() with an incompatible method signature.
+        // Once surefire migrates from maven-verifier to maven-executor, this can be removed.
+        this.forkJvm = isMaven4();
         resetGoals();
         resetCliOptions();
     }
@@ -407,6 +409,32 @@ public final class MavenLauncher {
         return defaultCliOptions == null
                 ? new Verifier(basedir, settingsFile, false)
                 : new Verifier(basedir, settingsFile, false, defaultCliOptions);
+    }
+
+    /**
+     * Detects if the current Maven installation is version 4.x or later by checking for the
+     * presence of {@code maven-cling-*.jar} in the Maven home lib directory. Maven 4 introduced
+     * the {@code maven-cling} module which is not present in Maven 3.x installations.
+     *
+     * @return {@code true} if Maven 4+ is detected
+     */
+    private static boolean isMaven4() {
+        String mavenHome = System.getProperty("maven.home", "");
+        if (mavenHome.isEmpty()) {
+            return false;
+        }
+        File libDir = new File(mavenHome, "lib");
+        if (libDir.isDirectory()) {
+            String[] files = libDir.list();
+            if (files != null) {
+                for (String file : files) {
+                    if (file.startsWith("maven-cling-")) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private static File settingsXmlPath() {


### PR DESCRIPTION
## Summary

- Enable Maven 4 in the CI matrix (`maven4-enabled: true`) with proper JDK 11 exclusion
- Fix integration test failures caused by `maven-verifier:2.0.0-M1` API incompatibility with Maven 4
- Fix pre-existing race condition in `CountdownCloseable`

## Details

### Maven 4 CI matrix
The shared workflow's matrix uses the exact version string `4.0.0-rc-5`, so the exclude must match it exactly (not just `"4"`). JDK 8 is already auto-excluded by the shared workflow when `maven4-enabled=true`.

### IT failures — maven-verifier embedded mode
All integration tests fail with Maven 4 because `maven-verifier:2.0.0-M1` uses reflection to call `MavenCling.doMain(String[], String, PrintStream, PrintStream)` in embedded mode, but Maven 4 rc-5 changed this method signature. The fix detects Maven 4 by checking for `maven-cling-*.jar` in the Maven home lib directory and forces forked JVM mode, bypassing the broken reflection entirely.

This is a **short-term workaround**. The long-term fix is to migrate from `maven-verifier` (which is [being deprecated](https://github.com/apache/maven-verifier/issues/186)) to [maven-executor](https://github.com/apache/maven-executor) (`org.apache.maven.executor:maven-executor:1.0.0`), which natively supports both Maven 3.x and 4.x.

### CountdownCloseable race condition
`CountdownCloseable.awaitClosed()` used `if` instead of `while` to guard `Object.wait()`, making it vulnerable to spurious wakeups per the Java Language Specification. This is a pre-existing bug unrelated to Maven 4, but it could cause intermittent `CommandlineExecutorTest` failures under different JVM timing.

## Related
- Supersedes / addresses the same goals as #3352
- Upstream: [apache/maven-verifier#186](https://github.com/apache/maven-verifier/issues/186) (deprecation)
- Upstream: [apache/maven-executor](https://github.com/apache/maven-executor) (replacement)

## Test plan
- [x] `surefire-extensions-api` unit tests pass locally (including `CommandlineExecutorTest`)
- [x] Full project builds successfully (`mvn clean install -DskipTests`)
- [ ] CI: Maven 3.9.x cells should continue to pass (no behavior change)
- [ ] CI: Maven 4 + JDK 17/21 cells should now pass with forked mode
- [ ] CI: Maven 4 + JDK 8/11 cells should be excluded from the matrix


🤖 Generated with [Claude Code](https://claude.com/claude-code)