### PR TITLE
Fix Windows flake in CommandChannelDecoderTest (#3400) Backport of #3400 in surefire-3.5.x branch

### DIFF
--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/CommandChannelDecoderTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/spi/CommandChannelDecoderTest.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.surefire.api.booter.Command;
 import org.apache.maven.surefire.api.booter.DumpErrorSingleton;
@@ -36,9 +37,7 @@ import org.apache.maven.surefire.api.fork.ForkNodeArguments;
 import org.apache.maven.surefire.booter.ForkedNodeArg;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import static java.nio.channels.Channels.newChannel;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -63,19 +62,22 @@ import static org.junit.Assert.fail;
 public class CommandChannelDecoderTest {
     private static final Random RND = new Random();
 
-    @Rule
-    public final TemporaryFolder tempFolder = new TemporaryFolder();
+    File reportsDir = new File("target", "decoder-dumps");
 
     @Before
     public void initTmpFile() {
-        File reportsDir = tempFolder.getRoot();
+        File reportsDir = new File("target", "decoder-dumps");
         String dumpFileName = "surefire-" + RND.nextLong();
         DumpErrorSingleton.getSingleton().init(reportsDir, dumpFileName);
     }
 
     @After
     public void deleteTmpFiles() {
-        tempFolder.delete();
+        try {
+            FileUtils.deleteDirectory(reportsDir);
+        } catch (IOException e) {
+            // ignore
+        }
     }
 
     @Test


### PR DESCRIPTION
The test initializes DumpErrorSingleton into the JUnit @TempDir;
several tests write .dumpstream files there. On Windows a freshly
written file can be transiently locked (antivirus, indexer) right when
the @TempDir cleanup runs, failing the whole class with
DirectoryNotEmptyException ('Failed to close extension context').
JUnit 5.14's resilient cleanup retries do not close the gap. Writing
the dumps under target/ needs no post-test cleanup at all.

Co-authored-by: Gerd Aschemann <ascheman@apache.org>
Co-authored-by: Claude Fable 5 <noreply@anthropic.com>

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
