### PR TITLE
javadoc: clarify statelessTestsetReporter, consoleOutputReporter,

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -172,12 +172,60 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
 
     private final ClasspathCache classpathCache = new ClasspathCache();
 
+    /**
+     * Configures the XML report, i.e. the {@code TEST-*.xml} files written to the reports directory.
+     * The nested element {@code disable} turns the report off and {@code version} selects the XSD schema
+     * version of the generated files.
+     * <br>
+     * Note: the deprecated parameter <em>disableXmlReport</em> takes precedence over {@code disable}
+     * whenever it is explicitly set, no matter which value: {@code true} disables the report and
+     * {@code false} keeps it enabled even if {@code disable} is {@code true}.
+     * <br>
+     * The XML attribute {@code implementation} may select another extension, e.g.
+     * {@link org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter
+     * JUnit5Xml30StatelessReporter} which phrases names after the JUnit 5 annotation <em>DisplayName</em>.
+     * For the complete list of nested elements, including those added by the JUnit 5
+     * variants, see <a href="https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html#Surefire_Extensions_and_Reports_Configuration_for_.40DisplayName">Surefire Extensions and Reports Configuration for @DisplayName</a>.
+     *
+     * @see SurefireStatelessReporter
+     * @since 3.0.0-M4
+     */
     @Parameter
     private SurefireStatelessReporter statelessTestsetReporter;
 
+    /**
+     * Configures the reporter of the standard output and error streams captured from the tests. The streams
+     * are written to the {@code *-output.txt} files in the reports directory if
+     * {@code redirectTestOutputToFile} is enabled, and printed to the console otherwise. The nested element
+     * {@code disable} drops the captured output altogether and {@code encoding} selects the charset of the
+     * output files.
+     * <br>
+     * The XML attribute {@code implementation} may select another extension, e.g.
+     * {@link org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter
+     * JUnit5ConsoleOutputReporter} which phrases the file names after the JUnit 5 annotation
+     * <em>DisplayName</em>. For the complete list of nested elements, including those added by the JUnit 5
+     * variants, see <a href="https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html#Surefire_Extensions_and_Reports_Configuration_for_.40DisplayName">Surefire Extensions and Reports Configuration for @DisplayName</a>.
+     *
+     * @see SurefireConsoleOutputReporter
+     * @since 3.0.0-M4
+     */
     @Parameter
     private SurefireConsoleOutputReporter consoleOutputReporter;
 
+    /**
+     * Configures the reporter of the per test-set summary, i.e. the <em>Running</em> and <em>Tests run</em>
+     * lines printed to the console and written to the plain text {@code *.txt} files in the reports
+     * directory. The nested element {@code disable} turns off both the console and the file summary.
+     * <br>
+     * The XML attribute {@code implementation} may select another extension, e.g.
+     * {@link org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter
+     * JUnit5StatelessTestsetInfoReporter} which phrases names after the JUnit 5 annotation
+     * <em>DisplayName</em>. For the complete list of nested elements, including those added by the JUnit 5
+     * variants, see <a href="https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html#Surefire_Extensions_and_Reports_Configuration_for_.40DisplayName">Surefire Extensions and Reports Configuration for @DisplayName</a>.
+     *
+     * @see SurefireStatelessTestsetInfoReporter
+     * @since 3.0.0-M4
+     */
     @Parameter
     private SurefireStatelessTestsetInfoReporter statelessTestsetInfoReporter;
 


### PR DESCRIPTION
Adds Javadoc to the three undocumented @Parameter fields in
AbstractSurefireMojo, describing what each reporter controls and
linking to the JUnit 5 Platform example page for the full list of
nested configuration elements.

Closes #3386

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
