### PR TITLE
Use the resolver's own HTTP transport in the report plugin tests

### DIFF
--- a/maven-surefire-report-plugin/pom.xml
+++ b/maven-surefire-report-plugin/pom.xml
@@ -179,14 +179,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-wagon</artifactId>
+      <artifactId>maven-resolver-transport-http</artifactId>
       <version>${resolverVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http-lightweight</artifactId>
-      <version>3.5.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
`maven-surefire-report-plugin`'s test classpath carried two artifacts to give Resolver a way of speaking HTTP:

```xml
<artifactId>maven-resolver-transport-wagon</artifactId>
<artifactId>wagon-http-lightweight</artifactId>
```

Resolver has had its own HTTP transport since 1.0, so `maven-resolver-transport-http` at the same `${resolverVersion}` (1.9.27 here) does the same job on its own. `maven-resolver-connector-basic` is untouched — that is the connector, not the transport.

`wagon-http-lightweight` is additionally marked for removal in Wagon 4.0.0, and nothing in these tests needs a Wagon provider in particular; it was only ever the thing on the other side of the wagon transport.

**Verified:** `mvn -pl maven-surefire-report-plugin test` gives 13 tests, 0 failures, both before and after.

This came out of a survey of how Maven projects actually depend on Wagon. The identical pattern is being changed in apache/maven-project-info-reports-plugin#648 and apache/maven-checkstyle-plugin#681. It deliberately is **not** being changed in maven-doap-plugin: its tests resolve through the legacy `maven-compat` `WagonManager`, which looks up a Wagon by protocol, so a resolver transport cannot stand in — swapping it there fails with `Cannot find wagon which supports the requested protocol: https`.
