### PR TITLE
[surefire-3.5.x] Use the resolver's own HTTP transport in the report plugin tests

### DIFF
--- a/maven-surefire-report-plugin/pom.xml
+++ b/maven-surefire-report-plugin/pom.xml
@@ -184,14 +184,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-wagon</artifactId>
+      <artifactId>maven-resolver-transport-http</artifactId>
       <version>${resolverVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http-lightweight</artifactId>
-      <version>3.5.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Backport of #3414 to `surefire-3.5.x`. The cherry-pick was clean.

`maven-surefire-report-plugin`'s test classpath carries two artifacts so that Resolver has some way of speaking HTTP:

```xml
<artifactId>maven-resolver-transport-wagon</artifactId>
<artifactId>wagon-http-lightweight</artifactId>
```

Resolver has had its own HTTP transport since 1.0, so `maven-resolver-transport-http` at the same `${resolverVersion}` does the job on its own. `maven-resolver-connector-basic` is untouched — that is the connector, not the transport.

`wagon-http-lightweight` is additionally marked for removal in Wagon 4.0.0, so this also stops a shipping branch depending on something slated to disappear.

Note this branch is on resolver **1.4.1** rather than master's 1.9.27; `maven-resolver-transport-http` is published at 1.4.1, which I checked against Central before proposing this.

**Verified on this branch:** `mvn -pl maven-surefire-report-plugin test` gives 13 tests, 0 failures both before and after the change.

### Why on a maintenance branch

3.5.x is active — it had a commit on 2026-08-02 — and this is a test-scope dependency only, so it changes nothing about what the plugin ships to users. Happy for it to be declined if you would rather 3.5.x took fixes only.
