### PR TITLE
Migrate legacy plugin Javadoc annotations

### DIFF
--- a/surefire-its/src/test/resources/surefire-946-self-destruct-plugin/pom.xml
+++ b/surefire-its/src/test/resources/surefire-946-self-destruct-plugin/pom.xml
@@ -22,6 +22,12 @@
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.15.2</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/surefire-its/src/test/resources/surefire-946-self-destruct-plugin/src/main/java/org/apache/maven/plugins/surefire/selfdestruct/SelfDestructMojo.java
+++ b/surefire-its/src/test/resources/surefire-946-self-destruct-plugin/src/main/java/org/apache/maven/plugins/surefire/selfdestruct/SelfDestructMojo.java
@@ -25,6 +25,9 @@ import java.util.TimerTask;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -47,10 +50,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 
 /**
  * Goal which terminates the maven process it is executed in after a timeout.
- * 
- * @goal selfdestruct
- * @phase test
  */
+@Mojo(name = "selfdestruct", defaultPhase = LifecyclePhase.TEST)
 public class SelfDestructMojo
     extends AbstractMojo
 {
@@ -61,17 +62,15 @@ public class SelfDestructMojo
 
     /**
      * Timeout in milliseconds
-     * 
-     * @parameter
      */
+    @Parameter
     private long timeoutInMillis;
 
     /**
      * Method of self-destruction: 'exit' will use System.exit (default), 'halt' will use Runtime.halt, 'interrupt' will
      * try to call 'taskkill' (windows) or 'kill -INT' (others)
-     * 
-     * @parameter
      */
+    @Parameter
     private String method = "exit";
 
     public void execute()


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

## Summary

Replace the legacy Maven Plugin Tools Javadoc tags in the SUREFIRE-946 self-destruct helper plugin with `maven-plugin-annotations` metadata.

The conversion preserves the `selfdestruct` goal name, its `test` default phase, and the two mojo parameters. The annotation dependency is provided-scoped and uses an explicit version because this standalone IT fixture is copied without reactor property filtering.

This does not change Surefire runtime behavior; it keeps the test helper compatible with annotation-based plugin descriptor generation as Maven Plugin Tools moves away from QDox.

Related to https://github.com/apache/maven-plugin-tools/issues/718.

## Validation

With Maven 3.9.16 and JDK 21:

```
mvn -B -V clean install -nsu -P run-its
```

The complete 17-module reactor passed. The `Surefire946KillMainProcessInReusableForkIT` regression coverage passed all 6 cases; the complete `surefire-its` module ran 759 tests with 0 failures and 0 errors (153 skipped).
