### PR TITLE
[SUREFIRE-862, SUREFIRE-3178] Handle missing Failsafe summary files

### DIFF
--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
@@ -181,11 +181,13 @@ public class VerifyMojo extends AbstractMojo implements SurefireReportParameters
                     capitalizeFirstLetter(getPluginName()) + " report directory: " + getReportsDirectory());
 
             try {
-                RunResult summary = existsSummaryFile() ? readSummary(summaryFile) : noTestsRun();
+                RunResult summary = isSummaryFile(summaryFile) ? readSummary(summaryFile) : noTestsRun();
 
-                if (existsSummaryFiles()) {
+                if (summaryFiles != null) {
                     for (final File summaryFile : summaryFiles) {
-                        summary = summary.aggregate(readSummary(summaryFile));
+                        if (isSummaryFile(summaryFile)) {
+                            summary = summary.aggregate(readSummary(summaryFile));
+                        }
                     }
                 }
                 reportExecution(this, summary, getConsoleLogger(), getBooterForkException(summary));
@@ -368,11 +370,29 @@ public class VerifyMojo extends AbstractMojo implements SurefireReportParameters
     }
 
     private boolean existsSummaryFile() {
-        return summaryFile != null && summaryFile.isFile();
+        return existsSummaryFile(summaryFile);
     }
 
     private boolean existsSummaryFiles() {
-        return summaryFiles != null && summaryFiles.length != 0;
+        boolean exists = false;
+        if (summaryFiles != null) {
+            for (File summaryFile : summaryFiles) {
+                exists |= existsSummaryFile(summaryFile);
+            }
+        }
+        return exists;
+    }
+
+    private boolean existsSummaryFile(File summaryFile) {
+        boolean exists = isSummaryFile(summaryFile);
+        if (!exists && summaryFile != null) {
+            getConsoleLogger().debug("Failsafe summary file does not exist: " + summaryFile);
+        }
+        return exists;
+    }
+
+    private static boolean isSummaryFile(File summaryFile) {
+        return summaryFile != null && summaryFile.isFile();
     }
 
     private boolean existsSummary() {

--- a/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
+++ b/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/VerifyMojo.java
@@ -235,7 +235,7 @@ public class VerifyMojo extends AbstractMojo implements SurefireReportParameters
 
         if (!existsSummary()) {
             getConsoleLogger().info("No tests to run.");
-            return false;
+            return getFailIfNoTests();
         }
 
         if (failOnFlakeCount < 0) {

--- a/maven-failsafe-plugin/src/test/java/org/apache/maven/plugin/failsafe/VerifyMojoTest.java
+++ b/maven-failsafe-plugin/src/test/java/org/apache/maven/plugin/failsafe/VerifyMojoTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugin.failsafe;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLDecoder;
 
@@ -93,5 +94,29 @@ class VerifyMojoTest {
         setupExecuteMocks();
         mojo.setSummaryFile(new File(getTestBaseDir(), "failsafe-summary-success.xml"));
         mojo.execute();
+    }
+
+    @Test
+    void executeWithMissingAdditionalSummaryFiles() throws Exception {
+        setupExecuteMocks();
+        setSummaryFiles(new File(tempFolder, "missing-summary.xml"));
+
+        assertThatCode(mojo::execute).doesNotThrowAnyException();
+    }
+
+    @Test
+    void executeWithExistingAndMissingAdditionalSummaryFiles() throws Exception {
+        setupExecuteMocks();
+        setSummaryFiles(
+                new File(getTestBaseDir(), "failsafe-summary-success.xml"),
+                new File(tempFolder, "missing-summary.xml"));
+
+        assertThatCode(mojo::execute).doesNotThrowAnyException();
+    }
+
+    private void setSummaryFiles(File... summaryFiles) throws ReflectiveOperationException {
+        Field field = VerifyMojo.class.getDeclaredField("summaryFiles");
+        field.setAccessible(true);
+        field.set(mojo, summaryFiles);
     }
 }

--- a/maven-failsafe-plugin/src/test/java/org/apache/maven/plugin/failsafe/VerifyMojoTest.java
+++ b/maven-failsafe-plugin/src/test/java/org/apache/maven/plugin/failsafe/VerifyMojoTest.java
@@ -105,6 +105,16 @@ class VerifyMojoTest {
     }
 
     @Test
+    void executeWithMissingSummaryAndFailIfNoTests() {
+        setupExecuteMocks();
+        mojo.setFailIfNoTests(true);
+
+        assertThatCode(mojo::execute)
+                .isExactlyInstanceOf(MojoFailureException.class)
+                .hasMessage("No tests were executed!  (Set -DfailIfNoTests=false to ignore this error.)");
+    }
+
+    @Test
     void executeWithExistingAndMissingAdditionalSummaryFiles() throws Exception {
         setupExecuteMocks();
         setSummaryFiles(

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3178FailIfNoTestsIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3178FailIfNoTestsIT.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+public class Surefire3178FailIfNoTestsIT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void emptyTestClassFailsVerification() {
+        unpack("surefire-3178-fail-if-no-tests")
+                .maven()
+                .withFailure()
+                .executeVerify()
+                .verifyTextInLog("No tests were executed!");
+    }
+}

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire862MissingSummaryFilesIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire862MissingSummaryFilesIT.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+public class Surefire862MissingSummaryFilesIT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void missingSummaryFilesAreIgnored() {
+        unpack("surefire-862-missing-summary-files")
+                .debugLogging()
+                .executeVerify()
+                .verifyTextInLog("Failsafe summary file does not exist:");
+    }
+}

--- a/surefire-its/src/test/resources/surefire-3178-fail-if-no-tests/pom.xml
+++ b/surefire-its/src/test/resources/surefire-3178-fail-if-no-tests/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>surefire-3178-fail-if-no-tests</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-3178-fail-if-no-tests/src/test/java/EmptyIT.java
+++ b/surefire-its/src/test/resources/surefire-3178-fail-if-no-tests/src/test/java/EmptyIT.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+public class EmptyIT {}

--- a/surefire-its/src/test/resources/surefire-862-missing-summary-files/pom.xml
+++ b/surefire-its/src/test/resources/surefire-862-missing-summary-files/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>surefire-862-missing-summary-files</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <summaryFile>${project.build.directory}/failsafe-summary-itest.xml</summaryFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <summaryFiles>
+                <summaryFile>${project.build.directory}/failsafe-summary-itest.xml</summaryFile>
+              </summaryFiles>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Fixes #862.
Fixes #3178.

## Summary

Failsafe 3.3.1 stopped writing a summary file when an integration-test
execution runs no tests. This is intentional, but `VerifyMojo` still tried
to read every path configured through `summaryFiles`, causing verification
of POM modules to fail with `FileNotFoundException`.

The same missing summary also caused `verify` to return before the normal
`failIfNoTests` check, so an empty discovered test class incorrectly produced
a successful build even with `failIfNoTests=true`.

This change:

- filters configured summary files to those that actually exist;
- logs each missing summary file at DEBUG level;
- routes a missing-summary result through normal reporting when
  `failIfNoTests=true`;
- retains the normal failure when an existing summary reports test failures;
- adds unit coverage for missing, mixed, and fail-if-no-tests summary cases;
- adds integration tests reproducing #862 and #3178.

## Validation

- `mvn clean install` with JDK 17: passed (all 17 reactor modules).
- `mvn -Prun-its clean install` with JDK 17: passed (760 tests,
  0 failures, 0 errors, 153 skipped).
- Focused `VerifyMojoTest` unit tests: 6 tests passed.
- `Surefire862MissingSummaryFilesIT`: 1 integration test passed.
- `Surefire3178FailIfNoTestsIT`: 1 integration test passed through the
  `run-its` profile.
- The reproducer linked from #862 succeeds with the locally built snapshot.
- The reproducer from #3178 fails as configured with the locally built
  snapshot; its reported 3.3.0 failure and 3.3.1 success were also reproduced.

The JDK 8 build in this environment is blocked by the unrelated existing
`ProcessCheckerTest.shouldHavePidAtBegin` start-time assertion; the same test
and both complete builds pass with JDK 17.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
