### PR TITLE
[SUREFIRE-2239, SUREFIRE-2241, SUREFIRE-2260, SUREFIRE-2274, SUREFIRE-2300] Preserve JUnit Platform test identity across reruns

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
@@ -73,17 +73,17 @@ public class DefaultReporterFactory implements ReporterFactory, ReportsMerger {
 
     private RunStatistics globalStats = new RunStatistics();
 
-    // from "<testclass>.<testmethod>" -> statistics about all the runs for success tests
-    private Map<String, List<TestMethodStats>> successTests;
+    // from test identity -> statistics about all the runs for success tests
+    private Map<TestMethodKey, List<TestMethodStats>> successTests;
 
-    // from "<testclass>.<testmethod>" -> statistics about all the runs for flaky tests
-    private Map<String, List<TestMethodStats>> flakyTests;
+    // from test identity -> statistics about all the runs for flaky tests
+    private Map<TestMethodKey, List<TestMethodStats>> flakyTests;
 
-    // from "<testclass>.<testmethod>" -> statistics about all the runs for failed tests
-    private Map<String, List<TestMethodStats>> failedTests;
+    // from test identity -> statistics about all the runs for failed tests
+    private Map<TestMethodKey, List<TestMethodStats>> failedTests;
 
-    // from "<testclass>.<testmethod>" -> statistics about all the runs for error tests
-    private Map<String, List<TestMethodStats>> errorTests;
+    // from test identity -> statistics about all the runs for error tests
+    private Map<TestMethodKey, List<TestMethodStats>> errorTests;
 
     public DefaultReporterFactory(StartupReportConfiguration reportConfiguration, ConsoleLogger consoleLogger) {
         this(reportConfiguration, consoleLogger, null);
@@ -252,16 +252,16 @@ public class DefaultReporterFactory implements ReporterFactory, ReportsMerger {
         failedTests = new TreeMap<>();
         errorTests = new TreeMap<>();
 
-        Map<String, List<TestMethodStats>> mergedTestHistoryResult = new HashMap<>();
+        Map<TestMethodKey, List<TestMethodStats>> mergedTestHistoryResult = new HashMap<>();
         // Merge all the stats for tests from listeners
         for (TestSetRunListener listener : listeners) {
             for (TestMethodStats methodStats : listener.getTestMethodStats()) {
-                List<TestMethodStats> currentMethodStats =
-                        mergedTestHistoryResult.get(methodStats.getTestClassMethodName());
+                TestMethodKey testMethodKey = methodStats.getTestMethodKey();
+                List<TestMethodStats> currentMethodStats = mergedTestHistoryResult.get(testMethodKey);
                 if (currentMethodStats == null) {
                     currentMethodStats = new ArrayList<>();
                     currentMethodStats.add(methodStats);
-                    mergedTestHistoryResult.put(methodStats.getTestClassMethodName(), currentMethodStats);
+                    mergedTestHistoryResult.put(testMethodKey, currentMethodStats);
                 } else {
                     currentMethodStats.add(methodStats);
                 }
@@ -272,9 +272,10 @@ public class DefaultReporterFactory implements ReporterFactory, ReportsMerger {
         int completedCount = 0, skipped = 0;
         Map<String, List<TestMethodStats>> beforeAllFailures = new HashMap<>();
 
-        for (Map.Entry<String, List<TestMethodStats>> entry : mergedTestHistoryResult.entrySet()) {
+        for (Map.Entry<TestMethodKey, List<TestMethodStats>> entry : mergedTestHistoryResult.entrySet()) {
             List<TestMethodStats> testMethodStats = entry.getValue();
-            String testClassMethodName = entry.getKey();
+            TestMethodKey testMethodKey = entry.getKey();
+            String testClassMethodName = testMethodKey.getTestClassMethodName();
 
             // Handle @BeforeAll failures (null, empty, ends with ".null" or ".initializationError" method names).
             // Do NOT include ".executionError" (AfterAll/AfterClass) — those stay as real errors (#3412).
@@ -324,19 +325,19 @@ public class DefaultReporterFactory implements ReporterFactory, ReportsMerger {
                         }
                     }
                     completedCount += successCount - 1;
-                    successTests.put(testClassMethodName, testMethodStats);
+                    successTests.put(testMethodKey, testMethodStats);
                     break;
                 case SKIPPED:
                     skipped++;
                     break;
                 case FLAKE:
-                    flakyTests.put(testClassMethodName, testMethodStats);
+                    flakyTests.put(testMethodKey, testMethodStats);
                     break;
                 case FAILURE:
-                    failedTests.put(testClassMethodName, testMethodStats);
+                    failedTests.put(testMethodKey, testMethodStats);
                     break;
                 case ERROR:
-                    errorTests.put(testClassMethodName, testMethodStats);
+                    errorTests.put(testMethodKey, testMethodStats);
                     break;
                 default:
                     throw new IllegalStateException("Get unknown test result type");
@@ -344,9 +345,9 @@ public class DefaultReporterFactory implements ReporterFactory, ReportsMerger {
         }
 
         // Loop over all success tests and find those that are passed flakes for beforeAll failures
-        for (Map.Entry<String, List<TestMethodStats>> entry : successTests.entrySet()) {
+        for (Map.Entry<TestMethodKey, List<TestMethodStats>> entry : successTests.entrySet()) {
             List<TestMethodStats> testMethodStats = entry.getValue();
-            String testClassMethodName = entry.getKey();
+            String testClassMethodName = entry.getKey().getTestClassMethodName();
             // If current test belong to class that failed during beforeAll store that info to proper log info
             String className = extractClassNameFromMethodName(testClassMethodName);
             if (beforeAllFailures.containsKey(className)) {
@@ -360,7 +361,7 @@ public class DefaultReporterFactory implements ReporterFactory, ReportsMerger {
         for (Map.Entry<String, List<TestMethodStats>> entry : beforeAllFailures.entrySet()) {
             String className = entry.getKey();
             List<TestMethodStats> testMethodStats = entry.getValue();
-            String classNameKey = className + ".<beforeAll>";
+            TestMethodKey classNameKey = new TestMethodKey(className + ".<beforeAll>", null);
 
             if (reportConfiguration.getRerunFailingTestsCount() > 0
                     && testMethodStats.stream()
@@ -386,7 +387,7 @@ public class DefaultReporterFactory implements ReporterFactory, ReportsMerger {
      */
     // Use default visibility for testing
     boolean printTestFailures(TestResultType type) {
-        final Map<String, List<TestMethodStats>> testStats;
+        final Map<TestMethodKey, List<TestMethodStats>> testStats;
         final Level level;
         switch (type) {
             case FAILURE:
@@ -411,13 +412,13 @@ public class DefaultReporterFactory implements ReporterFactory, ReportsMerger {
             printed = true;
         }
 
-        for (Map.Entry<String, List<TestMethodStats>> entry : testStats.entrySet()) {
+        for (Map.Entry<TestMethodKey, List<TestMethodStats>> entry : testStats.entrySet()) {
             List<TestMethodStats> testMethodStats = entry.getValue();
             if (testMethodStats.size() == 1) {
                 // No rerun, follow the original output format
                 failure("  " + testMethodStats.get(0).getStackTraceWriter().smartTrimmedStackTrace());
             } else {
-                log(entry.getKey(), level);
+                log(entry.getKey().getTestClassMethodName(), level);
                 for (int i = 0; i < testMethodStats.size(); i++) {
                     StackTraceWriter failureStackTrace = testMethodStats.get(i).getStackTraceWriter();
                     if (failureStackTrace == null) {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -161,7 +161,7 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
 
     @Override
     public void testSetCompleted(WrappedReportEntry testSetReportEntry, TestSetStats testSetStats) {
-        Map<String, Map<String, List<WrappedReportEntry>>> classMethodStatistics =
+        Map<String, Map<TestMethodKey, List<WrappedReportEntry>>> classMethodStatistics =
                 arrangeMethodStatistics(testSetReportEntry, testSetStats);
 
         // The Java Language Spec:
@@ -176,7 +176,7 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
                 showProperties(ppw, testSetReportEntry.getSystemProperties());
             } else {
                 boolean hasNonSuccess = false;
-                for (Map<String, List<WrappedReportEntry>> statistics : classMethodStatistics.values()) {
+                for (Map<TestMethodKey, List<WrappedReportEntry>> statistics : classMethodStatistics.values()) {
                     for (List<WrappedReportEntry> thisMethodRuns : statistics.values()) {
                         if (thisMethodRuns.stream()
                                 .anyMatch(entry -> entry.getReportEntryType() != ReportEntryType.SUCCESS)) {
@@ -194,9 +194,10 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
                 }
             }
 
-            for (Entry<String, Map<String, List<WrappedReportEntry>>> statistics : classMethodStatistics.entrySet()) {
-                Map<String, List<WrappedReportEntry>> methodStatistics = statistics.getValue();
-                for (Entry<String, List<WrappedReportEntry>> thisMethodRuns : methodStatistics.entrySet()) {
+            for (Entry<String, Map<TestMethodKey, List<WrappedReportEntry>>> statistics :
+                    classMethodStatistics.entrySet()) {
+                Map<TestMethodKey, List<WrappedReportEntry>> methodStatistics = statistics.getValue();
+                for (Entry<TestMethodKey, List<WrappedReportEntry>> thisMethodRuns : methodStatistics.entrySet()) {
                     serializeTestClass(outputStream, fw, ppw, thisMethodRuns.getValue(), methodStatistics);
                 }
             }
@@ -210,15 +211,15 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
         }
     }
 
-    private Map<String, Map<String, List<WrappedReportEntry>>> arrangeMethodStatistics(
+    private Map<String, Map<TestMethodKey, List<WrappedReportEntry>>> arrangeMethodStatistics(
             WrappedReportEntry testSetReportEntry, TestSetStats testSetStats) {
-        Map<String, Map<String, List<WrappedReportEntry>>> classMethodStatistics = new LinkedHashMap<>();
+        Map<String, Map<TestMethodKey, List<WrappedReportEntry>>> classMethodStatistics = new LinkedHashMap<>();
         for (WrappedReportEntry methodEntry : aggregateCacheFromMultipleReruns(testSetReportEntry, testSetStats)) {
             String testClassName = methodEntry.getSourceName();
-            Map<String, List<WrappedReportEntry>> stats =
+            Map<TestMethodKey, List<WrappedReportEntry>> stats =
                     classMethodStatistics.computeIfAbsent(testClassName, k -> new LinkedHashMap<>());
-            String methodName = methodEntry.getName();
-            List<WrappedReportEntry> methodRuns = stats.computeIfAbsent(methodName, k -> new ArrayList<>());
+            TestMethodKey methodKey = new TestMethodKey(methodEntry.getClassMethodName(), methodEntry.getTestRunId());
+            List<WrappedReportEntry> methodRuns = stats.computeIfAbsent(methodKey, k -> new ArrayList<>());
             methodRuns.add(methodEntry);
         }
         return classMethodStatistics;
@@ -237,7 +238,7 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
             OutputStreamWriter fw,
             XMLWriter ppw,
             List<WrappedReportEntry> methodEntries,
-            Map<String, List<WrappedReportEntry>> methodStatistics)
+            Map<TestMethodKey, List<WrappedReportEntry>> methodStatistics)
             throws IOException {
         if (rerunFailingTestsCount > 0) {
             serializeTestClassWithRerun(outputStream, fw, ppw, methodEntries, methodStatistics);
@@ -275,7 +276,7 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
             OutputStreamWriter fw,
             XMLWriter ppw,
             List<WrappedReportEntry> methodEntries,
-            Map<String, List<WrappedReportEntry>> methodStatistics)
+            Map<TestMethodKey, List<WrappedReportEntry>> methodStatistics)
             throws IOException {
         WrappedReportEntry firstMethodEntry = methodEntries.get(0);
 
@@ -339,7 +340,9 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
                 WrappedReportEntry firstOrSuccessful = successful == null ? methodEntries.get(0) : successful;
                 startTestElement(ppw, firstOrSuccessful);
                 for (WrappedReportEntry singleRunEntry : methodEntries) {
-                    if (singleRunEntry.getReportEntryType() != SUCCESS) {
+                    if (singleRunEntry.getReportEntryType() == SKIPPED) {
+                        addCommentElementTestCase("a skipped test execution in re-run phase", fw, ppw, outputStream);
+                    } else if (singleRunEntry.getReportEntryType() != SUCCESS) {
                         getTestProblems(
                                 fw,
                                 ppw,
@@ -406,7 +409,7 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
     private TestResultType getTestResultTypeWithBeforeAllHandling(
             String methodName,
             List<WrappedReportEntry> methodRuns,
-            Map<String, List<WrappedReportEntry>> methodStatistics) {
+            Map<TestMethodKey, List<WrappedReportEntry>> methodStatistics) {
         TestResultType resultType = getTestResultType(methodRuns);
 
         // Special handling for @BeforeAll failures only (not @AfterAll "executionError" or null-named
@@ -416,10 +419,11 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
         if (("null".equals(methodName) || "initializationError".equals(methodName))
                 && (resultType == TestResultType.ERROR || resultType == TestResultType.FAILURE)) {
             // Check if any actual test methods succeeded (exclude synthetic class-level names)
-            boolean hasSuccessfulTestMethods = methodStatistics.entrySet().stream()
-                    .filter(entry -> isActualTestMethodName(entry.getKey()))
-                    .anyMatch(entry -> entry.getValue().stream()
-                            .anyMatch(reportEntry -> reportEntry.getReportEntryType() == SUCCESS));
+            boolean hasSuccessfulTestMethods = methodStatistics.values().stream()
+                    .filter(entries -> !entries.isEmpty()
+                            && isActualTestMethodName(entries.get(0).getName()))
+                    .anyMatch(entries ->
+                            entries.stream().anyMatch(reportEntry -> reportEntry.getReportEntryType() == SUCCESS));
 
             if (hasSuccessfulTestMethods) {
                 resultType = TestResultType.FLAKE;
@@ -497,7 +501,7 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
     private void createTestSuiteElement(
             XMLWriter ppw,
             WrappedReportEntry report,
-            Map<String, Map<String, List<WrappedReportEntry>>> classMethodStatistics)
+            Map<String, Map<TestMethodKey, List<WrappedReportEntry>>> classMethodStatistics)
             throws IOException {
         ppw.startElement("testsuite");
 
@@ -531,11 +535,11 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
         int skipped = 0;
         int flakes = 0;
 
-        for (Map<String, List<WrappedReportEntry>> methodStats : classMethodStatistics.values()) {
+        for (Map<TestMethodKey, List<WrappedReportEntry>> methodStats : classMethodStatistics.values()) {
             actualTestCount += methodStats.size();
-            for (Map.Entry<String, List<WrappedReportEntry>> methodEntry : methodStats.entrySet()) {
-                String methodName = methodEntry.getKey();
+            for (Map.Entry<TestMethodKey, List<WrappedReportEntry>> methodEntry : methodStats.entrySet()) {
                 List<WrappedReportEntry> methodRuns = methodEntry.getValue();
+                String methodName = methodRuns.get(0).getName();
                 TestResultType resultType = getTestResultTypeWithBeforeAllHandling(methodName, methodRuns, methodStats);
 
                 switch (resultType) {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestMethodKey.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestMethodKey.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.surefire.report;
+
+import java.util.Objects;
+
+/**
+ * Identity used to aggregate the executions of one test across reruns. Providers
+ * without a test run ID retain the legacy class-and-method-name grouping.
+ */
+final class TestMethodKey implements Comparable<TestMethodKey> {
+    private final String testClassMethodName;
+
+    private final Long testRunId;
+
+    TestMethodKey(String testClassMethodName, Long testRunId) {
+        this.testClassMethodName = testClassMethodName;
+        this.testRunId = testRunId;
+    }
+
+    String getTestClassMethodName() {
+        return testClassMethodName;
+    }
+
+    @Override
+    public int compareTo(TestMethodKey other) {
+        int byName = compare(testClassMethodName, other.testClassMethodName);
+        return byName == 0 ? compare(testRunId, other.testRunId) : byName;
+    }
+
+    private static <T extends Comparable<T>> int compare(T left, T right) {
+        if (left == null) {
+            return right == null ? 0 : -1;
+        }
+        return right == null ? 1 : left.compareTo(right);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof TestMethodKey)) {
+            return false;
+        }
+        TestMethodKey that = (TestMethodKey) other;
+        return Objects.equals(testClassMethodName, that.testClassMethodName)
+                && Objects.equals(testRunId, that.testRunId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(testClassMethodName, testRunId);
+    }
+}

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestMethodStats.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestMethodStats.java
@@ -28,18 +28,30 @@ import org.apache.maven.surefire.api.report.StackTraceWriter;
 public class TestMethodStats {
     private final String testClassMethodName;
 
+    private final Long testRunId;
+
     private final ReportEntryType resultType;
 
     private final StackTraceWriter stackTraceWriter;
 
     public TestMethodStats(String testClassMethodName, ReportEntryType resultType, StackTraceWriter stackTraceWriter) {
+        this(testClassMethodName, null, resultType, stackTraceWriter);
+    }
+
+    public TestMethodStats(
+            String testClassMethodName, Long testRunId, ReportEntryType resultType, StackTraceWriter stackTraceWriter) {
         this.testClassMethodName = testClassMethodName;
+        this.testRunId = testRunId;
         this.resultType = resultType;
         this.stackTraceWriter = stackTraceWriter;
     }
 
     public String getTestClassMethodName() {
         return testClassMethodName;
+    }
+
+    TestMethodKey getTestMethodKey() {
+        return new TestMethodKey(testClassMethodName, testRunId);
     }
 
     public ReportEntryType getResultType() {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/TestSetRunListener.java
@@ -321,6 +321,7 @@ public class TestSetRunListener implements TestReportListener<TestOutputReportEn
         for (WrappedReportEntry reportEntry : getTestSetStats(report).getReportEntries()) {
             TestMethodStats methodStats = new TestMethodStats(
                     reportEntry.getClassMethodName(),
+                    reportEntry.getTestRunId(),
                     reportEntry.getReportEntryType(),
                     reportEntry.getStackTraceWriter());
             testMethodStats.add(methodStats);

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
@@ -283,6 +283,53 @@ public class DefaultReporterFactoryTest {
         assertEquals(emptyList(), reporter.getMessages());
     }
 
+    @Test
+    public void testIdenticalNamesWithDistinctIdsRemainSeparate() {
+        File reportsDirectory = new File(new File(System.getProperty("user.dir"), "target"), "tmpIdentity");
+        StartupReportConfiguration reportConfig = new StartupReportConfiguration(
+                true,
+                true,
+                "PLAIN",
+                false,
+                reportsDirectory,
+                false,
+                null,
+                new File(reportsDirectory, "TESTHASH"),
+                false,
+                1,
+                null,
+                null,
+                false,
+                true,
+                true,
+                false,
+                new SurefireStatelessReporter(),
+                new SurefireConsoleOutputReporter(),
+                new SurefireStatelessTestsetInfoReporter(),
+                new ReporterFactoryOptions());
+        DefaultReporterFactory factory = new DefaultReporterFactory(reportConfig, new DummyTestReporter());
+
+        String identicalName = "com.example.Test.identical name";
+        Queue<TestMethodStats> runStats = new ArrayDeque<>();
+        runStats.add(new TestMethodStats(identicalName, 1L, ReportEntryType.SKIPPED, null));
+        runStats.add(new TestMethodStats(
+                identicalName, 2L, ReportEntryType.FAILURE, new DummyStackTraceWriter(ASSERTION_FAIL)));
+        runStats.add(new TestMethodStats(identicalName, 3L, ReportEntryType.SUCCESS, null));
+        runStats.add(new TestMethodStats(
+                identicalName, 2L, ReportEntryType.FAILURE, new DummyStackTraceWriter(ASSERTION_FAIL)));
+
+        TestSetRunListener runListener = mock(TestSetRunListener.class);
+        when(runListener.getTestMethodStats()).thenReturn(runStats);
+        factory.addListener(runListener);
+
+        RunStatistics mergedStatistics = factory.getGlobalRunStatistics();
+        assertEquals(3, mergedStatistics.getCompletedCount());
+        assertEquals(0, mergedStatistics.getErrors());
+        assertEquals(1, mergedStatistics.getFailures());
+        assertEquals(0, mergedStatistics.getFlakes());
+        assertEquals(1, mergedStatistics.getSkipped());
+    }
+
     static final class DummyTestReporter implements ConsoleLogger {
         private final List<String> messages = new ArrayList<>();
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporterTest.java
@@ -308,7 +308,7 @@ public class StatelessXmlReporterTest {
                 createStdOutput(firstRunErr));
 
         WrappedReportEntry testTwoSecondError = new WrappedReportEntry(
-                new SimpleReportEntry(RERUN_TEST_AFTER_FAILURE, 1L, cls, null, TEST_TWO, null, stackTraceWriterTwo, 13),
+                new SimpleReportEntry(RERUN_TEST_AFTER_FAILURE, 0L, cls, null, TEST_TWO, null, stackTraceWriterTwo, 13),
                 ReportEntryType.ERROR,
                 1771085631L,
                 13,
@@ -325,7 +325,7 @@ public class StatelessXmlReporterTest {
 
         WrappedReportEntry testThreeSecondRun = new WrappedReportEntry(
                 new SimpleReportEntry(
-                        RERUN_TEST_AFTER_FAILURE, 3L, cls, null, TEST_THREE, null, stackTraceWriterTwo, 2),
+                        RERUN_TEST_AFTER_FAILURE, 2L, cls, null, TEST_THREE, null, stackTraceWriterTwo, 2),
                 ReportEntryType.SUCCESS,
                 1771085631L,
                 2,
@@ -506,6 +506,148 @@ public class StatelessXmlReporterTest {
                 .filter(line -> line.contains("<!-- a skipped test execution in re-run phase -->"))
                 .count();
         assertEquals(1, linesWithComments);
+    }
+
+    @Test
+    public void testIdenticalNamesWithDistinctIdsRemainSeparate() throws IOException {
+        expectedReportFile = new File(reportDir, "TEST-" + getClass().getName() + ".xml");
+        StackTraceWriter failure = new DeserializedStacktraceWriter("failure", "trimmed", "failed");
+
+        WrappedReportEntry skipped = new WrappedReportEntry(
+                new SimpleReportEntry(NORMAL_RUN, 1L, getClass().getName(), null, TEST_ONE, null, 1),
+                SKIPPED,
+                1771085631L,
+                1,
+                null,
+                null);
+        WrappedReportEntry failed = new WrappedReportEntry(
+                new SimpleReportEntry(NORMAL_RUN, 2L, getClass().getName(), null, TEST_ONE, null, failure, 2),
+                ReportEntryType.FAILURE,
+                1771085631L,
+                2,
+                null,
+                null);
+        WrappedReportEntry succeeded = new WrappedReportEntry(
+                new SimpleReportEntry(NORMAL_RUN, 3L, getClass().getName(), null, TEST_ONE, null, 3),
+                SUCCESS,
+                1771085631L,
+                3,
+                null,
+                null);
+        WrappedReportEntry failedAgain = new WrappedReportEntry(
+                new SimpleReportEntry(
+                        RERUN_TEST_AFTER_FAILURE, 2L, getClass().getName(), null, TEST_ONE, null, failure, 4),
+                ReportEntryType.FAILURE,
+                1771085631L,
+                4,
+                null,
+                null);
+        stats.testSucceeded(skipped);
+        stats.testSucceeded(failed);
+        stats.testSucceeded(succeeded);
+        rerunStats.testSucceeded(failedAgain);
+
+        WrappedReportEntry testSet = new WrappedReportEntry(
+                new SimpleReportEntry(NORMAL_RUN, 0L, getClass().getName(), null, null, null, 10),
+                SUCCESS,
+                1771085631L,
+                10,
+                null,
+                null,
+                systemProps());
+        StatelessXmlReporter reporter = new StatelessXmlReporter(
+                reportDir,
+                null,
+                false,
+                1,
+                new HashMap<>(),
+                XSD,
+                "3.0.2",
+                false,
+                false,
+                false,
+                false,
+                true,
+                true,
+                false);
+
+        reporter.testSetCompleted(testSet, stats);
+        reporter.testSetCompleted(testSet, rerunStats);
+
+        Xpp3Dom testSuite;
+        try (FileInputStream fileInputStream = new FileInputStream(expectedReportFile);
+                InputStreamReader reader = new InputStreamReader(fileInputStream, UTF_8)) {
+            testSuite = Xpp3DomBuilder.build(reader);
+        }
+        assertEquals("3", testSuite.getAttribute("tests"));
+        assertEquals("1", testSuite.getAttribute("failures"));
+        assertEquals("1", testSuite.getAttribute("skipped"));
+        assertEquals("0", testSuite.getAttribute("flakes"));
+        assertEquals(3, testSuite.getChildren("testcase").length);
+    }
+
+    @Test
+    public void testSkippedExecutionInFlakeDoesNotCreateEmptyElement() throws IOException {
+        expectedReportFile = new File(reportDir, "TEST-" + getClass().getName() + ".xml");
+        StackTraceWriter failure = new DeserializedStacktraceWriter("failure", "trimmed", "failed");
+
+        stats.testSucceeded(new WrappedReportEntry(
+                new SimpleReportEntry(NORMAL_RUN, 1L, getClass().getName(), null, TEST_ONE, null, failure, 1),
+                ReportEntryType.FAILURE,
+                1771085631L,
+                1,
+                null,
+                null));
+        stats.testSucceeded(new WrappedReportEntry(
+                new SimpleReportEntry(NORMAL_RUN, 1L, getClass().getName(), null, TEST_ONE, null, 1),
+                SKIPPED,
+                1771085631L,
+                1,
+                null,
+                null));
+        rerunStats.testSucceeded(new WrappedReportEntry(
+                new SimpleReportEntry(RERUN_TEST_AFTER_FAILURE, 1L, getClass().getName(), null, TEST_ONE, null, 1),
+                SUCCESS,
+                1771085631L,
+                1,
+                null,
+                null));
+
+        WrappedReportEntry testSet = new WrappedReportEntry(
+                new SimpleReportEntry(NORMAL_RUN, 0L, getClass().getName(), null, null, null, 3),
+                SUCCESS,
+                1771085631L,
+                3,
+                null,
+                null,
+                systemProps());
+        StatelessXmlReporter reporter = new StatelessXmlReporter(
+                reportDir,
+                null,
+                false,
+                1,
+                new HashMap<>(),
+                XSD,
+                "3.0.2",
+                false,
+                false,
+                false,
+                false,
+                true,
+                true,
+                false);
+
+        reporter.testSetCompleted(testSet, stats);
+        reporter.testSetCompleted(testSet, rerunStats);
+
+        try (FileInputStream fileInputStream = new FileInputStream(expectedReportFile);
+                InputStreamReader reader = new InputStreamReader(fileInputStream, UTF_8)) {
+            Xpp3Dom testSuite = Xpp3DomBuilder.build(reader);
+            assertEquals("1", testSuite.getAttribute("flakes"));
+            assertNotNull(testSuite.getChild("testcase").getChild("flakyFailure"));
+        }
+        assertThat(readAllLines(expectedReportFile.toPath(), UTF_8))
+                .anyMatch(line -> line.contains("<!-- a skipped test execution in re-run phase -->"));
     }
 
     @Test

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2239TestNgRerunIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2239TestNgRerunIT.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Integration test for SUREFIRE-2239.
+ */
+public class Surefire2239TestNgRerunIT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void rerunsTestNgTestsWithSurefireAndFailsafe() throws VerificationException {
+        OutputValidator validator = unpack("surefire-2239-testng-rerun")
+                .executeVerify()
+                .assertTestSuiteResults(1, 0, 0, 0, 1)
+                .assertIntegrationTestSuiteResults(1, 0, 0, 0)
+                .assertThatLogLine(
+                        containsString(
+                                "Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider"),
+                        is(2));
+
+        validator
+                .getSurefireReportsXmlFile("TEST-example.FlakyTest.xml")
+                .assertContainsText("flakes=\"1\"")
+                .assertContainsText("<flakyFailure");
+        validator
+                .getTargetFile("failsafe-reports/TEST-example.FlakyIT.xml")
+                .assertContainsText("flakes=\"1\"")
+                .assertContainsText("<flakyFailure");
+    }
+}

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2241JUnitParamsRerunIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2241JUnitParamsRerunIT.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for SUREFIRE-2241 / GitHub issue #2686.
+ */
+public class Surefire2241JUnitParamsRerunIT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void identicallyReportedJUnitParamsTestsRemainDistinctDuringRerun() throws VerificationException {
+        OutputValidator validator = unpack("surefire-2241-junitparams-rerun")
+                .maven()
+                .executeTest()
+                .verifyTextNotInLog("Element name cannot be empty");
+
+        validator.assertTestSuiteResults(7, 0, 0, 2, 2);
+
+        validator
+                .getSurefireReportsXmlFile("TEST-org.apache.druid.sql.calcite.CalciteJoinQueryTest.xml")
+                .assertContainsText("errors=\"0\"")
+                .assertContainsText("failures=\"0\"")
+                .assertContainsText("skipped=\"2\"")
+                .assertContainsText("name=\"testJoinWithNonEquiCondition({}) [0]\"")
+                .assertContainsText("name=\"testJoinWithNonEquiCondition({}) [1]\"")
+                .assertContainsText("name=\"ensureDecoupledTestConfigAnnotationWorks({}) [0]\"")
+                .assertContainsText("name=\"ensureDecoupledTestConfigAnnotationWorks({}) [1]\"")
+                .assertContainsText("name=\"testTopNOnStringWithNonSortedOrUniqueDictionary({}) [0]\"")
+                .assertContainsText("name=\"testTopNOnStringWithNonSortedOrUniqueDictionary({}) [1]\"")
+                .assertContainsText("<flakyFailure");
+        validator
+                .getSurefireReportsXmlFile("TEST-org.apache.druid.sql.calcite.CalciteQueryTest.xml")
+                .assertContainsText("name=\"testInnocent\"");
+    }
+}

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2260NonUniqueScenariosIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2260NonUniqueScenariosIT.java
@@ -16,26 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.surefire.its.jiras;
+package org.apache.maven.surefire.its;
 
+import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
-import org.apache.maven.surefire.its.fixture.SurefireLauncher;
 import org.junit.jupiter.api.Test;
 
 /**
- * SUREFIRE-1152 Assert rerunFailingTestsCount works with test suites
- *
- * @author Sean Flanigan
+ * Integration test for SUREFIRE-2260 / GitHub issue #2670.
  */
-public class Surefire1152RerunFailingTestsInSuiteIT extends SurefireJUnit4IntegrationTestCase {
-
+public class Surefire2260NonUniqueScenariosIT extends SurefireJUnit4IntegrationTestCase {
     @Test
-    public void testJUnit48Provider4() {
-        SurefireLauncher launcher = unpack("surefire-1152-rerunFailingTestsCount-suite");
-        OutputValidator outputValidator =
-                launcher.showErrorStackTraces().debugLogging().executeVerify();
-        outputValidator.assertTestSuiteResults(2, 0, 0, 0, 2);
-        outputValidator.assertIntegrationTestSuiteResults(1, 0, 0, 0);
+    public void identicallyNamedCucumberScenariosRemainDistinctDuringRerun() throws VerificationException {
+        OutputValidator validator = unpack("surefire-2260-non-unique-scenarios")
+                .maven()
+                .withFailure()
+                .executeTest()
+                .verifyTextNotInLog("Element name cannot be empty");
+
+        validator.assertTestSuiteResults(3, 0, 1, 1, 0);
     }
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2274FailsafeFlakeCountIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2274FailsafeFlakeCountIT.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for SUREFIRE-2274 / GitHub issue #2656.
+ */
+public class Surefire2274FailsafeFlakeCountIT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void failsafeVerifyFailsWhenFlakeCountExceedsLimit() {
+        OutputValidator validator = unpack("surefire-2274-failsafe-flake-count")
+                .maven()
+                .withFailure()
+                .executeVerify()
+                .assertIntegrationTestSuiteResults(3, 0, 0, 0)
+                .verifyTextInLog("There are 2 flakes and failOnFlakeCount is set to 1");
+
+        validator.getTargetFile("failsafe-reports/failsafe-summary.xml").assertContainsText("<flakes>2</flakes>");
+        validator
+                .getTargetFile("failsafe-reports/TEST-example.ReproducerIT.xml")
+                .assertContainsText("flakes=\"2\"")
+                .assertContainsText("<flakyFailure");
+    }
+}

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2300BeforeAllAssumptionIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/Surefire2300BeforeAllAssumptionIT.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for SUREFIRE-2300 / GitHub issue #2602.
+ */
+public class Surefire2300BeforeAllAssumptionIT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void reportsTestsAbortedByBeforeAllAssumptionAsSkipped() {
+        OutputValidator validator = unpack("surefire-2300-before-all-assumption")
+                .executeTest()
+                .assertTestSuiteResults(2, 0, 0, 2)
+                .verifyTextInLog("Tests run: 2, Failures: 0, Errors: 0, Skipped: 2");
+
+        validator
+                .getSurefireReportsXmlFile("TEST-example.TestAssume.xml")
+                .assertContainsText("tests=\"2\" errors=\"0\" skipped=\"2\" failures=\"0\"")
+                .assertContainsText("name=\"testOne\"")
+                .assertContainsText("name=\"testTwo\"")
+                .assertContainsText("<skipped type=\"org.opentest4j.TestAbortedException\">")
+                .assertContainsText("Assumption failed: assumption is not true");
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2239-testng-rerun/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2239-testng-rerun/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-2239-testng-rerun</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <rerunFailingTestsCount>1</rerunFailingTestsCount>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rerunFailingTestsCount>1</rerunFailingTestsCount>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-2239-testng-rerun/src/test/java/example/FlakyIT.java
+++ b/surefire-its/src/test/resources/surefire-2239-testng-rerun/src/test/java/example/FlakyIT.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package example;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class FlakyIT {
+    private static int runs;
+
+    @Test
+    public void passesOnSecondRun() {
+        Assert.assertTrue(++runs >= 2, "first run intentionally fails");
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2239-testng-rerun/src/test/java/example/FlakyTest.java
+++ b/surefire-its/src/test/resources/surefire-2239-testng-rerun/src/test/java/example/FlakyTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package example;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class FlakyTest {
+    private static int runs;
+
+    @Test
+    public void passesOnSecondRun() {
+        Assert.assertTrue(++runs >= 2, "first run intentionally fails");
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2241-junitparams-rerun/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2241-junitparams-rerun/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-2241-junitparams-rerun</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <surefire.rerunFailingTestsCount>1</surefire.rerunFailingTestsCount>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-2241-junitparams-rerun/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
+++ b/surefire-its/src/test/resources/surefire-2241-junitparams-rerun/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.druid.sql.calcite;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnitParamsRunner.class)
+public class CalciteJoinQueryTest {
+    private static final AtomicInteger FAILURES_REMAINING = new AtomicInteger(2);
+
+    @Test
+    @Parameters(source = QueryContextForJoinProvider1.class)
+    public void ensureDecoupledTestConfigAnnotationWorks(Map<String, Object> queryContext) {
+        assertTrue("fails only on the first invocation", FAILURES_REMAINING.getAndDecrement() <= 0);
+    }
+
+    @Test
+    @Parameters(source = QueryContextForJoinProvider1.class)
+    public void testJoinWithNonEquiCondition(Map<String, Object> queryContext) {
+        Assume.assumeFalse(true);
+    }
+
+    @Test
+    @Parameters(source = QueryContextForJoinProvider1.class)
+    public void testTopNOnStringWithNonSortedOrUniqueDictionary(Map<String, Object> queryContext) {}
+
+    public static class QueryContextForJoinProvider1 {
+        public static Object[] provideQueryContexts() {
+            return new Object[] {new HashMap<>(), new HashMap<>()};
+        }
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2241-junitparams-rerun/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/surefire-its/src/test/resources/surefire-2241-junitparams-rerun/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.druid.sql.calcite;
+
+import org.junit.Test;
+
+public class CalciteQueryTest {
+    @Test
+    public void testInnocent() {}
+}

--- a/surefire-its/src/test/resources/surefire-2260-non-unique-scenarios/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2260-non-unique-scenarios/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-2260-non-unique-scenarios</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.11.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-bom</artifactId>
+                <version>7.18.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                    <configuration>
+                        <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-2260-non-unique-scenarios/src/test/java/io/cucumber/skeleton/CucumberReproducerTest.java
+++ b/surefire-its/src/test/resources/surefire-2260-non-unique-scenarios/src/test/java/io/cucumber/skeleton/CucumberReproducerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.cucumber.skeleton;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectPackages("io.cucumber.skeleton")
+@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.skeleton")
+public class CucumberReproducerTest {}

--- a/surefire-its/src/test/resources/surefire-2260-non-unique-scenarios/src/test/java/io/cucumber/skeleton/StepDefinitions.java
+++ b/surefire-its/src/test/resources/surefire-2260-non-unique-scenarios/src/test/java/io/cucumber/skeleton/StepDefinitions.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.cucumber.skeleton;
+
+import io.cucumber.java.en.Given;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+
+public class StepDefinitions {
+    @Given("this scenario is aborted")
+    public void thisScenarioIsSkipped() {
+        Assumptions.assumeTrue(false);
+    }
+
+    @Given("this scenario fails")
+    public void thisScenarioFails() {
+        Assertions.assertTrue(false);
+    }
+
+    @Given("this scenario passes")
+    public void thisScenarioPasses() {}
+}

--- a/surefire-its/src/test/resources/surefire-2260-non-unique-scenarios/src/test/resources/io/cucumber/skeleton/reproducer.feature
+++ b/surefire-its/src/test/resources/surefire-2260-non-unique-scenarios/src/test/resources/io/cucumber/skeleton/reproducer.feature
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+Feature: Reproducer
+
+  Scenario: identical name
+    Given this scenario is aborted
+
+  Scenario: identical name
+    Given this scenario fails
+
+  Scenario: identical name
+    Given this scenario passes

--- a/surefire-its/src/test/resources/surefire-2274-failsafe-flake-count/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2274-failsafe-flake-count/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-2274-failsafe-flake-count</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <junit.version>5.11.1</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                    <failOnFlakeCount>1</failOnFlakeCount>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-2274-failsafe-flake-count/src/test/java/example/ReproducerIT.java
+++ b/surefire-its/src/test/resources/surefire-2274-failsafe-flake-count/src/test/java/example/ReproducerIT.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package example;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ReproducerIT {
+    private static final AtomicInteger TEST_ONE_RUNS = new AtomicInteger();
+
+    private static final AtomicInteger TEST_TWO_RUNS = new AtomicInteger();
+
+    @Test
+    public void testOne() {
+        failFirstTwoRuns(TEST_ONE_RUNS);
+    }
+
+    @Test
+    public void testTwo() {
+        failFirstTwoRuns(TEST_TWO_RUNS);
+    }
+
+    @Test
+    public void testThree() {}
+
+    private static void failFirstTwoRuns(AtomicInteger runs) {
+        int currentRun = runs.incrementAndGet();
+        assertTrue(currentRun >= 3, "Run " + currentRun + " intentionally fails");
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2300-before-all-assumption/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2300-before-all-assumption/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-2300-before-all-assumption</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <junit.version>5.12.1</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-2300-before-all-assumption/src/test/java/example/TestAssume.java
+++ b/surefire-its/src/test/resources/surefire-2300-before-all-assumption/src/test/java/example/TestAssume.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package example;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+public class TestAssume {
+    @BeforeAll
+    public static void beforeAll() {
+        Assumptions.assumeTrue(false, "assumption is not true");
+    }
+
+    @Test
+    public void testOne() {}
+
+    @Test
+    public void testTwo() {}
+}

--- a/surefire-its/src/test/resources/testng-multiple-method-patterns/pom.xml
+++ b/surefire-its/src/test/resources/testng-multiple-method-patterns/pom.xml
@@ -41,7 +41,10 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.14.3</version>
+      <!-- Avoid a suspected TestNG 6.14.3 race that may lose class lifecycle callbacks
+           during parallel execution; fixed by https://github.com/testng-team/testng/issues/2000.
+           Version 7.5.1 is the latest release that supports Java 8. -->
+      <version>7.5.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/ClassMethodIndexer.java
+++ b/surefire-providers/common-java5/src/main/java/org/apache/maven/surefire/report/ClassMethodIndexer.java
@@ -38,14 +38,14 @@ public final class ClassMethodIndexer {
 
     public long indexClassMethod(String clazz, String method) {
         ClassMethod key = new ClassMethod(requireNonNull(clazz), method);
-        return testIdMapping.computeIfAbsent(key, cm -> {
+        long id = testIdMapping.computeIfAbsent(key, cm -> {
             Long classId = testIdMapping.get(new ClassMethod(requireNonNull(clazz), null));
             long c = classId == null ? (((long) classIndex.getAndIncrement()) << 32) : classId;
             int m = method == null ? 0 : methodIndex.getAndIncrement();
-            long id = c | m;
-            testLocalMapping.set(id);
-            return id;
+            return c | m;
         });
+        testLocalMapping.set(id);
+        return id;
     }
 
     public long indexClass(String clazz) {

--- a/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/ClassMethodIndexerTest.java
+++ b/surefire-providers/common-java5/src/test/java/org/apache/maven/surefire/report/ClassMethodIndexerTest.java
@@ -62,4 +62,15 @@ public class ClassMethodIndexerTest {
         index = indexer.indexClassMethod(getClass().getName(), "methodName");
         assertThat(index).isEqualTo(0x0000000100000001L);
     }
+
+    @Test
+    public void testExistingIndexRestoresThreadLocal() {
+        ClassMethodIndexer indexer = new ClassMethodIndexer();
+        long first = indexer.indexClassMethod(getClass().getName(), "first");
+        long second = indexer.indexClassMethod(getClass().getName(), "second");
+
+        assertThat(indexer.getLocalIndex()).isEqualTo(second);
+        assertThat(indexer.indexClassMethod(getClass().getName(), "first")).isEqualTo(first);
+        assertThat(indexer.getLocalIndex()).isEqualTo(first);
+    }
 }

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -58,6 +58,7 @@ import org.apache.maven.surefire.shared.utils.io.SelectorUtils;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
@@ -316,12 +317,41 @@ public class JUnitPlatformProvider extends AbstractProvider {
         return null;
     }
 
-    private LauncherDiscoveryRequest buildLauncherDiscoveryRequestForRerunFailures(RunListenerAdapter adapter) {
+    LauncherDiscoveryRequest buildLauncherDiscoveryRequestForRerunFailures(RunListenerAdapter adapter) {
         LauncherDiscoveryRequestBuilder builder = newRequest();
-        // Iterate over recorded failures
-        for (TestIdentifier identifier :
-                new LinkedHashSet<>(adapter.getFailures().keySet())) {
-            builder.selectors(selectUniqueId(identifier.getUniqueId()));
+        LinkedHashSet<TestIdentifier> failures =
+                new LinkedHashSet<>(adapter.getFailures().keySet());
+        LinkedHashSet<UniqueId> failureIds = failures.stream()
+                .map(TestIdentifier::getUniqueId)
+                .map(UniqueId::parse)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        adapter.setRerunTestIds(failureIds);
+        LinkedHashSet<String> classNames = new LinkedHashSet<>();
+
+        for (TestIdentifier identifier : failures) {
+            // Runner-backed Vintage tests may expose only a ClassSource and may not
+            // support rediscovery from a leaf UniqueId. Rediscover their owning class
+            // and retain the failed branch with a post-discovery filter instead.
+            Optional<ClassSource> classSource =
+                    identifier.getSource().filter(ClassSource.class::isInstance).map(ClassSource.class::cast);
+            if (classSource.isPresent()) {
+                classNames.add(classSource.get().getClassName());
+            } else {
+                builder.selectors(selectUniqueId(identifier.getUniqueId()));
+            }
+        }
+
+        if (!classNames.isEmpty()) {
+            classNames.forEach(className -> builder.selectors(selectClass(className)));
+            builder.filters((PostDiscoveryFilter) testDescriptor -> {
+                UniqueId candidateId = testDescriptor.getUniqueId();
+                boolean isFailureOrRelatedContainer = failureIds.stream()
+                        .anyMatch(failureId -> candidateId.hasPrefix(failureId) || failureId.hasPrefix(candidateId));
+                return FilterResult.includedIf(
+                        isFailureOrRelatedContainer,
+                        () -> "Failed test or related container",
+                        () -> "Not a failed test");
+            });
         }
         return builder.build();
     }

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -21,6 +21,7 @@ package org.apache.maven.surefire.junitplatform;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -50,10 +51,13 @@ import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableSet;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 import static org.apache.maven.surefire.api.report.RunMode.RERUN_TEST_AFTER_FAILURE;
 import static org.apache.maven.surefire.api.util.internal.ObjectUtils.systemProps;
 import static org.apache.maven.surefire.shared.lang3.StringUtils.isNotBlank;
@@ -87,6 +91,8 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     private final ThreadLocal<Boolean> suppressOutput = new ThreadLocal<>();
     /** Class names that had at least one successful test method in the current adapter cycle. */
     private final Set<String> classesWithSuccessfulTests = ConcurrentHashMap.newKeySet();
+    /** Unique IDs of class containers that had at least one descendant test start in the current adapter cycle. */
+    private final Set<String> classContainersWithStartedTests = ConcurrentHashMap.newKeySet();
 
     private volatile Set<UniqueId> rerunTestIds = emptySet();
 
@@ -127,16 +133,13 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
         runningTestIdentifiersByUniqueId.put(testIdentifier.getUniqueId(), testIdentifier);
 
-        if (testIdentifier.isContainer()
-                && testIdentifier
-                        .getSource()
-                        .filter(ClassSource.class::isInstance)
-                        .isPresent()) {
+        if (isClassContainer(testIdentifier)) {
             testStartTime.put(testIdentifier, System.currentTimeMillis());
             runListener.testSetStarting(createReportEntry(testIdentifier));
         } else if (testIdentifier.isTest()) {
             testStartTime.put(testIdentifier, System.currentTimeMillis());
             runListener.testStarting(createReportEntry(testIdentifier));
+            recordStartedTest(testIdentifier);
         }
     }
 
@@ -147,11 +150,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         }
         suppressOutput.remove();
 
-        boolean isClass = testIdentifier.isContainer()
-                && testIdentifier
-                        .getSource()
-                        .filter(ClassSource.class::isInstance)
-                        .isPresent();
+        boolean isClass = isClassContainer(testIdentifier);
 
         boolean isTest = testIdentifier.isTest();
 
@@ -172,6 +171,8 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                     if (isTest) {
                         runListener.testAssumptionFailure(
                                 createReportEntry(testIdentifier, testExecutionResult, elapsed));
+                    } else if (isClass) {
+                        reportAbortedClass(testIdentifier, testExecutionResult, elapsed);
                     } else {
                         runListener.testSetCompleted(
                                 createReportEntry(testIdentifier, testExecutionResult, systemProps(), null, elapsed));
@@ -216,6 +217,58 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         runningTestIdentifiersByUniqueId.remove(testIdentifier.getUniqueId());
     }
 
+    private void reportAbortedClass(
+            TestIdentifier testIdentifier, TestExecutionResult testExecutionResult, Integer elapsed) {
+        if (classContainersWithStartedTests.contains(testIdentifier.getUniqueId())) {
+            runListener.testSetCompleted(
+                    createReportEntry(testIdentifier, testExecutionResult, systemProps(), null, elapsed));
+            return;
+        }
+
+        List<TestIdentifier> discoveredTests = testPlan == null
+                ? emptyList()
+                : testPlan.getDescendants(testIdentifier).stream()
+                        .filter(TestIdentifier::isTest)
+                        .sorted(comparing(TestIdentifier::getUniqueId))
+                        .collect(toList());
+        List<TestIdentifier> targetedTests =
+                discoveredTests.stream().filter(this::isRerunTarget).collect(toList());
+
+        if (discoveredTests.isEmpty()) {
+            runListener.testAssumptionFailure(createReportEntry(testIdentifier, testExecutionResult, elapsed));
+        } else {
+            for (TestIdentifier test : targetedTests) {
+                runListener.testAssumptionFailure(createReportEntry(test, testExecutionResult, null));
+            }
+        }
+
+        runListener.testSetCompleted(createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
+    }
+
+    private void recordStartedTest(TestIdentifier testIdentifier) {
+        TestPlan currentTestPlan = testPlan;
+        if (currentTestPlan == null) {
+            return;
+        }
+
+        Optional<TestIdentifier> parent = currentTestPlan.getParent(testIdentifier);
+        while (parent.isPresent()) {
+            TestIdentifier ancestor = parent.get();
+            if (isClassContainer(ancestor)) {
+                classContainersWithStartedTests.add(ancestor.getUniqueId());
+            }
+            parent = currentTestPlan.getParent(ancestor);
+        }
+    }
+
+    private static boolean isClassContainer(TestIdentifier testIdentifier) {
+        return testIdentifier.isContainer()
+                && testIdentifier
+                        .getSource()
+                        .filter(ClassSource.class::isInstance)
+                        .isPresent();
+    }
+
     private Integer computeElapsedTime(TestIdentifier testIdentifier) {
         Long startTime = testStartTime.remove(testIdentifier);
         long endTime = System.currentTimeMillis();
@@ -248,11 +301,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         }
         suppressOutput.remove();
 
-        boolean isClass = testIdentifier.isContainer()
-                && testIdentifier
-                        .getSource()
-                        .filter(ClassSource.class::isInstance)
-                        .isPresent();
+        boolean isClass = isClassContainer(testIdentifier);
 
         testStartTime.remove(testIdentifier);
 
@@ -666,6 +715,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         getFailures().clear();
         testPlan = null;
         classesWithSuccessfulTests.clear();
+        classContainersWithStartedTests.clear();
     }
 
     @Override

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -20,6 +20,7 @@ package org.apache.maven.surefire.junitplatform;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -50,7 +51,10 @@ import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.joining;
+import static org.apache.maven.surefire.api.report.RunMode.RERUN_TEST_AFTER_FAILURE;
 import static org.apache.maven.surefire.api.util.internal.ObjectUtils.systemProps;
 import static org.apache.maven.surefire.shared.lang3.StringUtils.isNotBlank;
 import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
@@ -78,8 +82,13 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     private final ConcurrentMap<TestIdentifier, Long> testStartTime = new ConcurrentHashMap<>();
     private final ConcurrentMap<TestIdentifier, TestExecutionResult> failures = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, TestIdentifier> runningTestIdentifiersByUniqueId = new ConcurrentHashMap<>();
+    // Some custom runners execute tests removed by post-discovery filtering. Do not
+    // report those executions or associate their output with a targeted rerun.
+    private final ThreadLocal<Boolean> suppressOutput = new ThreadLocal<>();
     /** Class names that had at least one successful test method in the current adapter cycle. */
     private final Set<String> classesWithSuccessfulTests = ConcurrentHashMap.newKeySet();
+
+    private volatile Set<UniqueId> rerunTestIds = emptySet();
 
     private final TestReportListener<TestOutputReportEntry> runListener;
     private final Stoppable stoppable;
@@ -105,10 +114,17 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     public void testPlanExecutionFinished(TestPlan testPlan) {
         this.testPlan = null;
         testStartTime.clear();
+        suppressOutput.remove();
     }
 
     @Override
     public void executionStarted(TestIdentifier testIdentifier) {
+        if (!isRerunTarget(testIdentifier)) {
+            suppressOutput.set(true);
+            return;
+        }
+        suppressOutput.remove();
+
         runningTestIdentifiersByUniqueId.put(testIdentifier.getUniqueId(), testIdentifier);
 
         if (testIdentifier.isContainer()
@@ -126,6 +142,11 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
     @Override
     public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+        if (!isRerunTarget(testIdentifier)) {
+            return;
+        }
+        suppressOutput.remove();
+
         boolean isClass = testIdentifier.isContainer()
                 && testIdentifier
                         .getSource()
@@ -221,6 +242,12 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
     @Override
     public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+        if (!isRerunTarget(testIdentifier)) {
+            suppressOutput.set(true);
+            return;
+        }
+        suppressOutput.remove();
+
         boolean isClass = testIdentifier.isContainer()
                 && testIdentifier
                         .getSource()
@@ -266,6 +293,19 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         String methodName = failed || testIdentifier.isTest() ? classMethodName.getMethodSignature() : null;
         String methodText = failed || testIdentifier.isTest() ? classMethodName.getMethodDisplayName() : null;
 
+        // Some engines, notably JUnit Vintage with JUnitParams, attach ClassSource to
+        // individual tests. They are tests nevertheless and need a test name rather
+        // than being reported as an unnamed class-level event.
+        if (testIdentifier.isTest()
+                && methodName == null
+                && testIdentifier
+                        .getSource()
+                        .filter(ClassSource.class::isInstance)
+                        .isPresent()) {
+            methodName = testIdentifier.getLegacyReportingName();
+            methodText = testIdentifier.getDisplayName();
+        }
+
         if (testExecutionResult != null
                 && testExecutionResult.getStatus() != org.junit.platform.engine.TestExecutionResult.Status.SUCCESSFUL
                 && testIdentifier.isContainer()
@@ -287,9 +327,10 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         }
         StackTraceWriter stw =
                 testExecutionResult == null ? null : toStackTraceWriter(className, methodName, testExecutionResult);
+        String testId = testIdentifier.isTest() ? testIdentifier.getUniqueId() : methodName;
         return new SimpleReportEntry(
                 runMode,
-                classMethodIndexer.indexClassMethod(className, methodName),
+                classMethodIndexer.indexClassMethod(className, testId),
                 className,
                 classText,
                 qualifiedClassName,
@@ -603,6 +644,20 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         return failures;
     }
 
+    void setRerunTestIds(Set<UniqueId> rerunTestIds) {
+        this.rerunTestIds = unmodifiableSet(new LinkedHashSet<>(rerunTestIds));
+    }
+
+    private boolean isRerunTarget(TestIdentifier testIdentifier) {
+        if (runMode != RERUN_TEST_AFTER_FAILURE || rerunTestIds.isEmpty()) {
+            return true;
+        }
+
+        UniqueId candidateId = UniqueId.parse(testIdentifier.getUniqueId());
+        return rerunTestIds.stream()
+                .anyMatch(failureId -> candidateId.hasPrefix(failureId) || failureId.hasPrefix(candidateId));
+    }
+
     boolean hasFailingTests() {
         return !getFailures().isEmpty();
     }
@@ -615,6 +670,9 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
     @Override
     public void writeTestOutput(OutputReportEntry reportEntry) {
+        if (Boolean.TRUE.equals(suppressOutput.get())) {
+            return;
+        }
         Long testRunId = classMethodIndexer.getLocalIndex();
         runListener.writeTestOutput(new TestOutputReportEntry(reportEntry, runMode, testRunId));
     }

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -52,9 +52,18 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.ClassSelector;
+import org.junit.platform.engine.discovery.UniqueIdSelector;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.EngineFilter;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.LauncherSessionListener;
+import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
@@ -127,6 +136,41 @@ public class JUnitPlatformProviderTest {
 
         assertThat(provider.getConfigurationParameters())
                 .containsEntry("junit.jupiter.execution.order.random.seed", "5678");
+    }
+
+    @Test
+    public void rerunsClassSourceTestByClassWithUniqueIdFilter() {
+        RunListenerAdapter adapter = new RunListenerAdapter(runListenerMock(), Stoppable.NOOP);
+        UniqueId parentId = UniqueId.forEngine("junit-vintage")
+                .append("runner", TestClass1.class.getName())
+                .append("test", "parameterized");
+        UniqueId failedId = parentId.append("test", "[0]");
+        TestDescriptor failedTest = testDescriptor(failedId, ClassSource.from(TestClass1.class));
+        adapter.getFailures().put(TestIdentifier.from(failedTest), TestExecutionResult.failed(new AssertionError()));
+
+        JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParametersMock());
+        LauncherDiscoveryRequest request = provider.buildLauncherDiscoveryRequestForRerunFailures(adapter);
+
+        assertThat(request.getSelectorsByType(ClassSelector.class))
+                .extracting(ClassSelector::getClassName)
+                .containsExactly(TestClass1.class.getName());
+        assertThat(request.getSelectorsByType(UniqueIdSelector.class)).isEmpty();
+
+        PostDiscoveryFilter filter = request.getPostDiscoveryFilters().get(0);
+        TestDescriptor parent = testDescriptor(parentId, ClassSource.from(TestClass1.class));
+        TestDescriptor sibling = testDescriptor(parentId.append("test", "[1]"), ClassSource.from(TestClass1.class));
+        assertThat(filter.apply(parent).included()).isTrue();
+        assertThat(filter.apply(failedTest).included()).isTrue();
+        assertThat(filter.apply(sibling).included()).isFalse();
+    }
+
+    private static TestDescriptor testDescriptor(UniqueId uniqueId, ClassSource source) {
+        return new AbstractTestDescriptor(uniqueId, uniqueId.toString(), source) {
+            @Override
+            public Type getType() {
+                return Type.TEST;
+            }
+        };
     }
 
     @Test

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -59,6 +59,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
+import static org.apache.maven.surefire.api.report.RunMode.RERUN_TEST_AFTER_FAILURE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -72,6 +73,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -100,6 +102,30 @@ public class RunListenerAdapterTest {
     }
 
     @Test
+    public void ignoresNonTargetTestsExecutedByRunnerDuringRerun() throws Exception {
+        UniqueId parentId = UniqueId.forEngine("junit-vintage").append("runner", MyTestClass.class.getName());
+        UniqueId failedId = parentId.append("test", "failed");
+        TestIdentifier failed = TestIdentifier.from(new TestMethodTestDescriptorWithDisplayName(
+                failedId, MyTestClass.class, MyTestClass.class.getDeclaredMethod("myTestMethod"), "failed"));
+        TestIdentifier passing = TestIdentifier.from(new TestMethodTestDescriptorWithDisplayName(
+                parentId.append("test", "passing"),
+                MyTestClass.class,
+                MyTestClass.class.getDeclaredMethod("myNamedTestMethod"),
+                "passing"));
+
+        adapter.setRunMode(RERUN_TEST_AFTER_FAILURE);
+        adapter.setRerunTestIds(singleton(failedId));
+        adapter.executionStarted(passing);
+        adapter.executionFinished(passing, successful());
+        adapter.executionStarted(failed);
+        adapter.executionFinished(failed, successful());
+
+        verify(listener).testStarting(any());
+        verify(listener).testSucceeded(any());
+        verifyNoMoreInteractions(listener);
+    }
+
+    @Test
     public void notifiedWithCorrectNamesWhenMethodExecutionStarted() throws Exception {
         ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
 
@@ -117,6 +143,77 @@ public class RunListenerAdapterTest {
         assertEquals(MY_TEST_METHOD_NAME, entry.getName());
         assertEquals(MyTestClass.class.getName(), entry.getSourceName());
         assertNull(entry.getStackTraceWriter());
+    }
+
+    @Test
+    public void uniqueIdsDistinguishTestsWithIdenticalReportedNames() {
+        EngineDescriptor engine = newEngineDescriptor();
+        TestDescriptor testClass = newClassDescriptor();
+        engine.addChild(testClass);
+
+        TestDescriptor first =
+                new AbstractTestDescriptor(testClass.getUniqueId().append("scenario", "1"), "identical name") {
+                    @Override
+                    public Type getType() {
+                        return TEST;
+                    }
+                };
+        TestDescriptor second =
+                new AbstractTestDescriptor(testClass.getUniqueId().append("scenario", "2"), "identical name") {
+                    @Override
+                    public Type getType() {
+                        return TEST;
+                    }
+                };
+        testClass.addChild(first);
+        testClass.addChild(second);
+
+        TestPlan plan = TestPlan.from(false, singletonList(engine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(first));
+        adapter.executionStarted(TestIdentifier.from(second));
+
+        ArgumentCaptor<ReportEntry> started = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener, times(2)).testStarting(started.capture());
+        ReportEntry firstStart = started.getAllValues().get(0);
+        ReportEntry secondStart = started.getAllValues().get(1);
+        assertEquals("identical name", firstStart.getName());
+        assertEquals("identical name", secondStart.getName());
+        assertThat(firstStart.getTestRunId()).isNotEqualTo(secondStart.getTestRunId());
+
+        adapter.executionFinished(TestIdentifier.from(first), successful());
+        ArgumentCaptor<ReportEntry> finished = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener).testSucceeded(finished.capture());
+        assertEquals(firstStart.getTestRunId(), finished.getValue().getTestRunId());
+    }
+
+    @Test
+    public void testIdentifierWithClassSourceHasTestName() {
+        EngineDescriptor engine = newEngineDescriptor();
+        TestDescriptor testClass = newClassDescriptor();
+        engine.addChild(testClass);
+
+        TestDescriptor parameterizedTest =
+                new AbstractTestDescriptor(
+                        testClass.getUniqueId().append("test", "parameterized-1"),
+                        "parameterized [1]",
+                        ClassSource.from(MyTestClass.class)) {
+                    @Override
+                    public Type getType() {
+                        return TEST;
+                    }
+                };
+        testClass.addChild(parameterizedTest);
+
+        TestPlan plan = TestPlan.from(false, singletonList(engine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+        adapter.executionStarted(TestIdentifier.from(parameterizedTest));
+
+        ArgumentCaptor<ReportEntry> started = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener).testStarting(started.capture());
+        assertEquals(MyTestClass.class.getName(), started.getValue().getSourceName());
+        assertEquals("parameterized [1]", started.getValue().getName());
     }
 
     @Test

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -487,15 +487,91 @@ public class RunListenerAdapterTest {
     }
 
     @Test
-    public void notifiedWhenClassExecutionAborted() {
+    public void notifiedForAllDescendantTestsWhenClassExecutionAborted() throws Exception {
+        TestDescriptor classDescriptor = newClassDescriptor();
+        UniqueId classId = classDescriptor.getUniqueId();
+        TestDescriptor directMethod =
+                newMethodDescriptor(classId.append("method", MY_TEST_METHOD_NAME), MY_TEST_METHOD_NAME);
+        TestDescriptor nestedContainer =
+                new EngineDescriptor(classId.append("nested", "container"), "nested container");
+        TestDescriptor nestedMethod = newMethodDescriptor(
+                nestedContainer.getUniqueId().append("method", MY_NAMED_TEST_METHOD_NAME), MY_NAMED_TEST_METHOD_NAME);
+        classDescriptor.addChild(directMethod);
+        classDescriptor.addChild(nestedContainer);
+        nestedContainer.addChild(nestedMethod);
+
+        TestPlan testPlan = TestPlan.from(false, singletonList(classDescriptor), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(testPlan);
+
+        TestIdentifier classIdentifier = TestIdentifier.from(classDescriptor);
+        TestSkippedException assumption = new TestSkippedException("skipped");
+        adapter.executionStarted(classIdentifier);
+        adapter.executionFinished(classIdentifier, aborted(assumption));
+
+        ArgumentCaptor<ReportEntry> skippedTests = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener, times(2)).testAssumptionFailure(skippedTests.capture());
+        verify(listener).testSetStarting(any());
+        verify(listener).testSetCompleted(any());
+
+        assertThat(skippedTests.getAllValues())
+                .extracting(ReportEntry::getName)
+                .containsExactlyInAnyOrder(MY_TEST_METHOD_NAME, MY_NAMED_TEST_METHOD_NAME);
+        assertThat(skippedTests.getAllValues()).allSatisfy(report -> {
+            assertThat(report.getSourceName()).isEqualTo(MyTestClass.class.getName());
+            assertThat(report.getStackTraceWriter()).isNotNull();
+            assertThat(report.getStackTraceWriter().getThrowable().getTarget()).isSameAs(assumption);
+        });
+    }
+
+    @Test
+    public void notifiedWithSyntheticSkipWhenAbortedClassHasNoDescendantTests() {
+        TestDescriptor classDescriptor = newClassDescriptor();
+        TestPlan testPlan = TestPlan.from(false, singletonList(classDescriptor), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(testPlan);
+
         TestSkippedException t = new TestSkippedException("skipped");
-        adapter.executionFinished(newClassIdentifier(), aborted(t));
+        adapter.executionFinished(TestIdentifier.from(classDescriptor), aborted(t));
         String source = MyTestClass.class.getName();
         StackTraceWriter stw = new DefaultStackTraceWriter(source, "initializationError", t);
         ArgumentCaptor<SimpleReportEntry> report = ArgumentCaptor.forClass(SimpleReportEntry.class);
+        verify(listener).testAssumptionFailure(report.capture());
+        assertThat(report.getValue().getSourceName()).isEqualTo(source);
+        assertThat(report.getValue().getName()).isEqualTo("initializationError");
+        assertThat(report.getValue().getStackTraceWriter()).isEqualTo(stw);
+
+        report = ArgumentCaptor.forClass(SimpleReportEntry.class);
         verify(listener).testSetCompleted(report.capture());
         assertThat(report.getValue().getSourceName()).isEqualTo(source);
-        assertThat(report.getValue().getStackTraceWriter()).isEqualTo(stw);
+        assertThat(report.getValue().getName()).isNull();
+        assertThat(report.getValue().getStackTraceWriter()).isNull();
+    }
+
+    @Test
+    public void doesNotSkipDescendantsWhenClassAbortsAfterTestStarted() throws Exception {
+        TestDescriptor classDescriptor = newClassDescriptor();
+        TestDescriptor nestedContainer =
+                new EngineDescriptor(classDescriptor.getUniqueId().append("nested-class", "Nested"), "Nested");
+        TestDescriptor methodDescriptor = newMethodDescriptor(
+                nestedContainer.getUniqueId().append("method", MY_TEST_METHOD_NAME), MY_TEST_METHOD_NAME);
+        classDescriptor.addChild(nestedContainer);
+        nestedContainer.addChild(methodDescriptor);
+        TestPlan testPlan = TestPlan.from(false, singletonList(classDescriptor), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(testPlan);
+
+        TestIdentifier classIdentifier = TestIdentifier.from(classDescriptor);
+        TestIdentifier methodIdentifier = TestIdentifier.from(methodDescriptor);
+        TestSkippedException assumption = new TestSkippedException("after all skipped");
+        adapter.executionStarted(classIdentifier);
+        adapter.executionStarted(methodIdentifier);
+        adapter.executionFinished(methodIdentifier, successful());
+        adapter.executionFinished(classIdentifier, aborted(assumption));
+
+        verify(listener).testSucceeded(any());
+        verify(listener, never()).testAssumptionFailure(any());
+        ArgumentCaptor<SimpleReportEntry> report = ArgumentCaptor.forClass(SimpleReportEntry.class);
+        verify(listener).testSetCompleted(report.capture());
+        assertThat(report.getValue().getStackTraceWriter().getThrowable().getTarget())
+                .isSameAs(assumption);
     }
 
     @Test
@@ -852,10 +928,15 @@ public class RunListenerAdapterTest {
     }
 
     private static TestDescriptor newMethodDescriptor(Class<?>... parameterTypes) throws Exception {
+        return newMethodDescriptor(UniqueId.forEngine("method"), MY_TEST_METHOD_NAME, parameterTypes);
+    }
+
+    private static TestDescriptor newMethodDescriptor(UniqueId uniqueId, String methodName, Class<?>... parameterTypes)
+            throws Exception {
         return new TestMethodTestDescriptor(
-                UniqueId.forEngine("method"),
+                uniqueId,
                 MyTestClass.class,
-                MyTestClass.class.getDeclaredMethod(MY_TEST_METHOD_NAME, parameterTypes),
+                MyTestClass.class.getDeclaredMethod(methodName, parameterTypes),
                 Collections::emptyList,
                 new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
     }


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

## Summary

Fixes #2686.
Fixes #2670.
Fixes #2626.
Fixes #2656.
Fixes #2602.

JUnit Platform tests were aggregated by their human-readable class and method names. Engines can legitimately report multiple logical tests with the same names, and JUnitParams on the Vintage engine reports actual tests with a `ClassSource` but no method source. During reruns this collapsed skipped, failing, and successful executions into one apparent flake, could generate an empty XML element name, and could hide real failures.

This change:

- uses the JUnit Platform unique ID as the internal test-run identity while retaining readable report names;
- propagates that identity into XML and global result aggregation;
- restores cached IDs to the output association;
- gives `ClassSource`-backed tests a readable test name;
- rediscovers `ClassSource`-backed failures by class while filtering and reporting only the failed unique-ID branches, allowing runner-backed Vintage tests such as JUnitParams to rerun without parsing engine-specific unique-ID segments;
- serializes skipped executions defensively in a flake history;
- adds exact JUnitParams and Cucumber regression projects;
- recovers the SUREFIRE-2239 fail-first/pass-second TestNG reproducer as an integration test for both Surefire and Failsafe;
- adapts the SUREFIRE-2274 Failsafe reproducer into an integration test that verifies rerun flakes reach `failsafe-summary.xml` and are enforced by `verify`; and
- reports every discovered test below a class aborted by a JUnit 5 `@BeforeAll` assumption as skipped, while preserving completed test results when a class aborts later in its lifecycle.

An existing integration fixture containing two distinct tests with the same method name now correctly expects both tests in its report.

## User impact

Identically named tests and scenarios remain distinct. The JUnitParams reproducer fails both parameterized cases on their first invocation, reruns those two cases successfully, records two flakes in valid XML, and continues to the following test class. The Cucumber reproducer reports three scenarios as one skipped, one failed, and one passed test. TestNG tests are also verified to rerun through the JUnit Platform provider in both Surefire and Failsafe, with one flake recorded by each plugin. Failsafe is additionally protected end to end against losing the flake count between `integration-test` and `verify`: two fail-twice/pass-third tests produce `<flakes>2</flakes>`, and `failOnFlakeCount=1` fails the build during `verify`. A two-test class aborted by a `@BeforeAll` assumption now reports two tests and two skips, including both XML test cases and the original assumption cause, instead of reporting zero tests and zero skips.

## Tests

- `mvn clean install`
- `nice -n 10 env JAVA_HOME=/opt/jdks/latest-17 /opt/maven/latest/bin/mvn -Prun-its clean install` (761 integration tests, 0 failures, 0 errors)
- `nice -n 10 /opt/maven/latest/bin/mvn clean test -pl surefire-providers/common-java5,surefire-providers/surefire-junit-platform` (passed; 85 JUnit Platform provider tests)
- focused rerun-related integration tests (83 tests, 0 failures, 0 errors)
- exact fail-first/pass-second JUnitParams integration test (7 final tests, 2 flakes, no `initializationError`)
- Java 8 TestNG/JUnitParams/Cucumber related integration-test set (12 tests, 0 failures, 0 errors)
- exact fail-first/pass-second TestNG integration test through Surefire and Failsafe (1 flake in each report)
- `nice -n 10 /opt/maven/latest/bin/mvn clean verify -pl surefire-its -Prun-its -Dit.test=Surefire2274FailsafeFlakeCountIT -Dmaven.build.cache.enabled=false` (passed on Java 8; nested Failsafe build failed at `verify` as expected with 2 flakes)
- `nice -n 10 /opt/maven/latest/bin/mvn clean test -pl maven-failsafe-plugin -Dtest=RunResultTest -Dmaven.build.cache.enabled=false` (7 tests, 0 failures, 0 errors)
- `nice -n 10 /opt/maven/latest/bin/mvn clean test -pl surefire-providers/surefire-junit-platform -Dmaven.build.cache.enabled=false` (87 tests, 0 failures, 0 errors)
- `nice -n 10 /opt/maven/latest/bin/mvn clean verify -pl surefire-its -Prun-its -Dit.test=Surefire2300BeforeAllAssumptionIT,JUnit5BeforeAllContainerFailureIT,JUnit4PlatformFailingBeforeAllRerunIT -Dmaven.build.cache.enabled=false` (3 tests, 0 failures, 0 errors)
