### PR TITLE
[SUREFIRE-2148] Verify recovered BeforeAll does not fail build

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit4PlatformFailingBeforeAllRerunIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit4PlatformFailingBeforeAllRerunIT.java
@@ -32,6 +32,22 @@ public class JUnit4PlatformFailingBeforeAllRerunIT extends SurefireJUnit4Integra
     private static final String TEST_PROJECT_BASE = "junit-platform-rerun-failing-before-all";
 
     @Test
+    public void testRecoveredBeforeAllDoesNotFailBuild() {
+        OutputValidator outputValidator = unpack(TEST_PROJECT_BASE)
+                .setJUnitVersion(VERSION)
+                .maven()
+                .debugLogging()
+                .addGoal("-Dtest=FlakyBeforeAllTest")
+                .addGoal("-Dsurefire.rerunFailingTestsCount=1")
+                .executeTest()
+                .assertTestSuiteResults(2, 0, 0, 0, 1);
+
+        outputValidator.verifyTextInLog("junitplatform.FlakyBeforeAllTest.<beforeAll>");
+        outputValidator.verifyTextInLog("Run 1: FlakyBeforeAllTest.setup");
+        outputValidator.verifyTextInLog("Run 2: PASS");
+    }
+
+    @Test
     public void testBeforeAllFailures() {
         // Test that @BeforeAll failures are properly handled when they succeed on rerun
         OutputValidator outputValidator = unpack(TEST_PROJECT_BASE)

--- a/surefire-its/src/test/resources/junit-platform-rerun-failing-before-all/pom.xml
+++ b/surefire-its/src/test/resources/junit-platform-rerun-failing-before-all/pom.xml
@@ -65,6 +65,7 @@
                 <configuration>
                     <excludes>
                         <exclude>**/ParametersTest.java</exclude>
+                        <exclude>**/FlakyBeforeAllTest.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/surefire-its/src/test/resources/junit-platform-rerun-failing-before-all/src/test/java/junitplatform/FlakyBeforeAllTest.java
+++ b/surefire-its/src/test/resources/junit-platform-rerun-failing-before-all/src/test/java/junitplatform/FlakyBeforeAllTest.java
@@ -1,0 +1,19 @@
+package junitplatform;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class FlakyBeforeAllTest {
+    private static boolean firstRun = true;
+
+    @BeforeAll
+    static void setup() {
+        if (firstRun) {
+            firstRun = false;
+            throw new IllegalStateException("BeforeAll fails once");
+        }
+    }
+
+    @Test
+    public void testPasses() {}
+}


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

## Summary

Fixes #2749.

The production behavior was corrected by #3200 and released in Surefire 3.5.5, but its integration test combines a recovered `@BeforeAll` failure with a class that always fails. Because that test expects the overall Maven invocation to fail, it does not protect the original SUREFIRE-2148 requirement: a build must succeed when the only setup failure passes on rerun.

This adds a focused JUnit Platform fixture whose `@BeforeAll` fails once and succeeds on the only retry. The integration test requires a successful Maven exit, verifies the lifecycle failure is reported as a flake followed by `Run 2: PASS`, and asserts the final report contains no errors or failures.

## User impact

There is no production-code change. The existing fix is now covered against regressions that would incorrectly fail a build after a recovered `@BeforeAll` error.

## Tests

- `nice -n 10 env JAVA_HOME=/opt/jdks/latest-17 /opt/maven/latest/bin/mvn clean install -Dmaven.build.cache.enabled=false` (17 modules, build success)
- `nice -n 10 env JAVA_HOME=/opt/jdks/latest-17 /opt/maven/latest/bin/mvn -Prun-its clean install -Dmaven.build.cache.enabled=false` (762 integration tests, 0 failures, 0 errors, 153 skipped)
- exact standalone SUREFIRE-2148 reproducer against `3.6.0-M2-SNAPSHOT` (first `@BeforeAll` run errors, retry passes, one flake, build success)
