### PR TITLE
[SUREFIRE-2113] Honor java.io.tmpdir in forked JVMs

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/DefaultForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/DefaultForkConfiguration.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.apache.maven.plugin.surefire.JdkAttributes;
+import org.apache.maven.plugin.surefire.SurefireProperties;
 import org.apache.maven.plugin.surefire.booterclient.lazytestprovider.Commandline;
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.surefire.api.util.internal.ImmutableMap;
@@ -143,13 +144,17 @@ public abstract class DefaultForkConfiguration extends ForkConfiguration {
      * @param config       the startup configuration
      * @param forkNumber   index of forked JVM, to be the replacement in the argLine
      * @param dumpLogDirectory     directory for dump log file
+     * @param startupSystemProperties system properties which must be set when the forked JVM starts
      * @return CommandLine able to flush entire command going to be sent to forked JVM
      * @throws org.apache.maven.surefire.booter.SurefireBooterForkException when unable to perform the fork
      */
     @Nonnull
     @Override
     public Commandline createCommandLine(
-            @Nonnull StartupConfiguration config, int forkNumber, @Nonnull File dumpLogDirectory)
+            @Nonnull StartupConfiguration config,
+            int forkNumber,
+            @Nonnull File dumpLogDirectory,
+            @Nonnull SurefireProperties startupSystemProperties)
             throws SurefireBooterForkException {
         try {
             Commandline cli = new Commandline(getExcludedEnvironmentVariables());
@@ -165,6 +170,11 @@ public abstract class DefaultForkConfiguration extends ForkConfiguration {
             }
 
             cli.setExecutable(getJdkForTests().getJvmExecutable().getAbsolutePath());
+
+            for (Object key : startupSystemProperties.getStringKeySet()) {
+                String propertyName = (String) key;
+                cli.createArg().setValue("-D" + propertyName + "=" + startupSystemProperties.getProperty(propertyName));
+            }
 
             String jvmArgLine = newJvmArgLine(forkNumber);
             if (!jvmArgLine.isEmpty()) {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkConfiguration.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkConfiguration.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.maven.plugin.surefire.JdkAttributes;
+import org.apache.maven.plugin.surefire.SurefireProperties;
 import org.apache.maven.plugin.surefire.booterclient.lazytestprovider.Commandline;
 import org.apache.maven.surefire.booter.Classpath;
 import org.apache.maven.surefire.booter.ForkedBooter;
@@ -79,15 +80,19 @@ public abstract class ForkConfiguration {
     protected abstract Classpath getBooterClasspath();
 
     /**
-     * @param config               the startup configuration
-     * @param forkNumber           index of forked JVM, to be the replacement in the argLine
+     * @param config       the startup configuration
+     * @param forkNumber   index of forked JVM, to be the replacement in the argLine
      * @param dumpLogDirectory     directory for dump log file
+     * @param startupSystemProperties system properties which must be set when the forked JVM starts
      * @return CommandLine able to flush entire command going to be sent to forked JVM
      * @throws org.apache.maven.surefire.booter.SurefireBooterForkException
      *          when unable to perform the fork
      */
     @Nonnull
     public abstract Commandline createCommandLine(
-            @Nonnull StartupConfiguration config, int forkNumber, @Nonnull File dumpLogDirectory)
+            @Nonnull StartupConfiguration config,
+            int forkNumber,
+            @Nonnull File dumpLogDirectory,
+            @Nonnull SurefireProperties startupSystemProperties)
             throws SurefireBooterForkException;
 }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
@@ -485,6 +485,7 @@ public class ForkStarter {
         final File surefireProperties;
         final File systPropsFile;
         final ForkChannel forkChannel;
+        final SurefireProperties startupSystemProperties = new SurefireProperties();
         File dumpLogDir = replaceForkThreadsInPath(startupReportConfiguration.getReportsDirectory(), forkNumber);
         try {
             ForkNodeArguments forkNodeArguments = new ForkedNodeArg(
@@ -514,6 +515,12 @@ public class ForkStarter {
             if (effectiveSystemProperties != null) {
                 SurefireProperties filteredProperties =
                         createCopyAndReplaceForkNumPlaceholder(effectiveSystemProperties, forkNumber);
+                String javaIoTmpDir = filteredProperties.getProperty("java.io.tmpdir");
+                if (javaIoTmpDir != null) {
+                    // The JDK caches the default temporary directory before ForkedBooter can set system properties.
+                    startupSystemProperties.setProperty("java.io.tmpdir", javaIoTmpDir);
+                    filteredProperties.remove("java.io.tmpdir");
+                }
 
                 systPropsFile = writePropertiesFile(
                         filteredProperties,
@@ -527,7 +534,8 @@ public class ForkStarter {
             throw new SurefireBooterForkException("Error creating properties files for forking", e);
         }
 
-        Commandline cli = forkConfiguration.createCommandLine(startupConfiguration, forkNumber, dumpLogDir);
+        Commandline cli = forkConfiguration.createCommandLine(
+                startupConfiguration, forkNumber, dumpLogDir, startupSystemProperties);
 
         cli.createArg().setValue(tempDir);
         cli.createArg().setValue(DUMP_FILE_PREFIX + forkNumber);

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkConfigurationTest.java
@@ -34,7 +34,9 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.surefire.AbstractSurefireMojo;
 import org.apache.maven.plugin.surefire.JdkAttributes;
+import org.apache.maven.plugin.surefire.SurefireProperties;
 import org.apache.maven.plugin.surefire.booterclient.lazytestprovider.Commandline;
 import org.apache.maven.plugin.surefire.log.api.ConsoleLogger;
 import org.apache.maven.plugin.surefire.log.api.NullConsoleLogger;
@@ -141,7 +143,7 @@ public class ForkConfigurationTest {
         StartupConfiguration startup = new StartupConfiguration("cls", cpConfig, clc, ALL, providerJpmsArgs);
 
         org.apache.maven.surefire.shared.utils.cli.Commandline cli =
-                config.createCommandLine(startup, 1, getTempDirectory());
+                config.createCommandLine(startup, 1, getTempDirectory(), new SurefireProperties());
 
         assertThat(cli.getEnvironmentVariables())
                 .contains("key1=val1", "key2=val2", "key3=val3")
@@ -196,7 +198,7 @@ public class ForkConfigurationTest {
         StartupConfiguration startup = new StartupConfiguration("cls", cpConfig, clc, ALL, providerJpmsArgs);
 
         org.apache.maven.surefire.shared.utils.cli.Commandline cliFork1 =
-                config.createCommandLine(startup, 1, getTempDirectory());
+                config.createCommandLine(startup, 1, getTempDirectory(), new SurefireProperties());
 
         assertThat(cliFork1.getEnvironmentVariables())
                 .contains("FORK_ID=1")
@@ -204,7 +206,7 @@ public class ForkConfigurationTest {
                 .doesNotHaveDuplicates();
 
         org.apache.maven.surefire.shared.utils.cli.Commandline cliFork2 =
-                config.createCommandLine(startup, 2, getTempDirectory());
+                config.createCommandLine(startup, 2, getTempDirectory(), new SurefireProperties());
 
         assertThat(cliFork2.getEnvironmentVariables())
                 .contains("FORK_ID=2")
@@ -246,7 +248,7 @@ public class ForkConfigurationTest {
         StartupConfiguration startup = new StartupConfiguration("cls", cpConfig, clc, ALL, providerJpmsArgs);
 
         org.apache.maven.surefire.shared.utils.cli.Commandline cli =
-                config.createCommandLine(startup, 1, getTempDirectory());
+                config.createCommandLine(startup, 1, getTempDirectory(), new SurefireProperties());
         String cliAsString = cli.toString();
 
         assertThat(cliAsString).contains("arg1");
@@ -322,7 +324,7 @@ public class ForkConfigurationTest {
         assertThat(startup.isShadefire()).isFalse();
 
         org.apache.maven.surefire.shared.utils.cli.Commandline cli =
-                config.createCommandLine(startup, 1, getTempDirectory());
+                config.createCommandLine(startup, 1, getTempDirectory(), new SurefireProperties());
 
         assertThat(cli.toString()).contains("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005");
     }
@@ -342,10 +344,38 @@ public class ForkConfigurationTest {
                 new StartupConfiguration("", cpConfig, clc, ALL, Collections.<String[]>emptyList());
 
         org.apache.maven.surefire.shared.utils.cli.Commandline cli =
-                config.createCommandLine(startup, 1, getTempDirectory());
+                config.createCommandLine(startup, 1, getTempDirectory(), new SurefireProperties());
 
         String line = join(" ", cli.getCommandline());
         assertTrue(line.contains("-jar"));
+    }
+
+    @Test
+    public void testStartupSystemPropertyPrecedesArgLineAndMainClass() throws IOException, SurefireBooterForkException {
+        ForkConfiguration config = getForkConfiguration(basedir, "-Djava.io.tmpdir=from-arg-line");
+        File cpElement = getTempClasspathFile();
+
+        List<String> cp = singletonList(cpElement.getAbsolutePath());
+        ClasspathConfiguration cpConfig =
+                new ClasspathConfiguration(new Classpath(cp), emptyClasspath(), emptyClasspath(), true, true);
+        ClassLoaderConfiguration clc = new ClassLoaderConfiguration(true, true);
+        StartupConfiguration startup =
+                new StartupConfiguration("", cpConfig, clc, ALL, Collections.<String[]>emptyList());
+
+        String configuredTempDir = new File(basedir, "custom temp-${surefire.forkNumber}").getAbsolutePath();
+        SurefireProperties effectiveSystemProperties = new SurefireProperties();
+        effectiveSystemProperties.setProperty("java.io.tmpdir", configuredTempDir);
+        SurefireProperties startupSystemProperties =
+                AbstractSurefireMojo.createCopyAndReplaceForkNumPlaceholder(effectiveSystemProperties, 2);
+
+        org.apache.maven.surefire.shared.utils.cli.Commandline cli =
+                config.createCommandLine(startup, 2, getTempDirectory(), startupSystemProperties);
+
+        assertThat(cli.getArguments())
+                .containsSubsequence(
+                        "-Djava.io.tmpdir=" + configuredTempDir.replace("${surefire.forkNumber}", "2"),
+                        "-Djava.io.tmpdir=from-arg-line",
+                        "-jar");
     }
 
     @Test
@@ -362,7 +392,7 @@ public class ForkConfigurationTest {
                 new StartupConfiguration("", cpConfig, clc, ALL, Collections.<String[]>emptyList());
 
         org.apache.maven.surefire.shared.utils.cli.Commandline commandLine =
-                config.createCommandLine(startup, 1, getTempDirectory());
+                config.createCommandLine(startup, 1, getTempDirectory(), new SurefireProperties());
         assertThat(commandLine.toString()).contains(IS_OS_WINDOWS ? "abc def" : "'abc' 'def'");
     }
 
@@ -378,7 +408,7 @@ public class ForkConfigurationTest {
                 new StartupConfiguration("", cpConfig, clc, ALL, Collections.<String[]>emptyList());
         ForkConfiguration config = getForkConfiguration(cwd.getCanonicalFile());
         org.apache.maven.surefire.shared.utils.cli.Commandline commandLine =
-                config.createCommandLine(startup, 1, getTempDirectory());
+                config.createCommandLine(startup, 1, getTempDirectory(), new SurefireProperties());
 
         File forkDirectory = new File(basedir, "fork_1");
 
@@ -393,7 +423,7 @@ public class ForkConfigurationTest {
 
         try {
             ForkConfiguration config = getForkConfiguration(cwd.getCanonicalFile());
-            config.createCommandLine(STARTUP_CONFIG, 1, getTempDirectory());
+            config.createCommandLine(STARTUP_CONFIG, 1, getTempDirectory(), new SurefireProperties());
         } catch (SurefireBooterForkException e) {
             // To handle issue with ~ expansion on Windows
             String absolutePath = cwd.getCanonicalPath();
@@ -415,7 +445,7 @@ public class ForkConfigurationTest {
 
         try {
             ForkConfiguration config = getForkConfiguration(cwd.getAbsoluteFile());
-            config.createCommandLine(STARTUP_CONFIG, 1, getTempDirectory());
+            config.createCommandLine(STARTUP_CONFIG, 1, getTempDirectory(), new SurefireProperties());
         } catch (SurefireBooterForkException sbfe) {
             assertEquals("Cannot create workingDirectory " + cwd.getAbsolutePath(), sbfe.getMessage());
             return;
@@ -501,7 +531,7 @@ public class ForkConfigurationTest {
 
         ForkConfiguration config = getForkConfiguration(workingDir.getCanonicalFile());
         org.apache.maven.surefire.shared.utils.cli.Commandline cli =
-                config.createCommandLine(startup, 1, getTempDirectory());
+                config.createCommandLine(startup, 1, getTempDirectory(), new SurefireProperties());
 
         // The command line must use -jar (manifest-only JAR mode)
         String line = join(" ", cli.getCommandline());

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
@@ -65,6 +65,7 @@ import org.junit.jupiter.api.Test;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -138,7 +139,8 @@ public class ForkStarterTest {
         cli.createArg().setLine("-jar");
         cli.createArg().setLine("surefirebooter.jar");
         cli.createArg().setLine("fail");
-        when(forkConfiguration.createCommandLine(eq(startupConfiguration), eq(1), eq(tmp)))
+        when(forkConfiguration.createCommandLine(
+                        eq(startupConfiguration), eq(1), eq(tmp), any(SurefireProperties.class)))
                 .thenReturn(cli);
 
         SurefireStatelessTestsetInfoReporter statelessTestsetInfoReporter = new SurefireStatelessTestsetInfoReporter();
@@ -228,7 +230,8 @@ public class ForkStarterTest {
         cli.setExecutable(System.getProperty("java.home") + "/bin/java");
         cli.createArg().setLine("-jar");
         cli.createArg().setLine("surefirebooter.jar");
-        when(forkConfiguration.createCommandLine(eq(startupConfiguration), eq(1), eq(tmp)))
+        when(forkConfiguration.createCommandLine(
+                        eq(startupConfiguration), eq(1), eq(tmp), any(SurefireProperties.class)))
                 .thenReturn(cli);
 
         SurefireStatelessTestsetInfoReporter statelessTestsetInfoReporter = new SurefireStatelessTestsetInfoReporter();

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire2113TempDirIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire2113TempDirIT.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.jupiter.api.Test;
+
+import static java.nio.file.Files.createDirectories;
+
+public class Surefire2113TempDirIT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    public void tempDirUsesJavaIoTmpDir() throws IOException {
+        SurefireLauncher launcher = unpack("surefire-2113-temp-dir").setJUnitVersion("5.9.0");
+        File customTempDir = new File(launcher.getUnpackedAt(), "custom-temp");
+        createDirectories(customTempDir.toPath());
+
+        launcher.addGoal("-Djava.io.tmpdir=" + customTempDir.getAbsolutePath())
+                .executeTest()
+                .assertTestSuiteResults(1, 0, 0, 0);
+    }
+
+    @Test
+    public void argLineOverridesEffectiveJavaIoTmpDir() throws IOException {
+        SurefireLauncher launcher = unpack("surefire-2113-temp-dir").setJUnitVersion("5.9.0");
+        File effectiveTempDir = new File(launcher.getUnpackedAt(), "effective-temp");
+        File argLineTempDir = new File(launcher.getUnpackedAt(), "arg-line-temp");
+        createDirectories(effectiveTempDir.toPath());
+        createDirectories(argLineTempDir.toPath());
+
+        launcher.addGoal("-Djava.io.tmpdir=" + effectiveTempDir.getAbsolutePath())
+                .addGoal("-DargLine=-Djava.io.tmpdir=" + argLineTempDir.getAbsolutePath())
+                .addGoal("-Dexpected.java.io.tmpdir=" + argLineTempDir.getAbsolutePath())
+                .executeTest()
+                .assertTestSuiteResults(1, 0, 0, 0);
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2113-temp-dir/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2113-temp-dir/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-2113-temp-dir</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-2113-temp-dir/src/test/java/surefire2113/TempDirTest.java
+++ b/surefire-its/src/test/resources/surefire-2113-temp-dir/src/test/java/surefire2113/TempDirTest.java
@@ -1,0 +1,24 @@
+package surefire2113;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TempDirTest {
+    @Test
+    void tempDirUsesJavaIoTmpDir(@TempDir Path tempDir) throws IOException {
+        Path expected = Paths.get(
+                        System.getProperty("expected.java.io.tmpdir", System.getProperty("java.io.tmpdir")))
+                .toRealPath();
+        Path configured = Paths.get(System.getProperty("java.io.tmpdir")).toRealPath();
+        Path actual = tempDir.getParent().toRealPath();
+
+        assertEquals(expected, configured);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary

- pass the effective `java.io.tmpdir` to the forked JVM on its command line
- place generated startup system properties before `argLine`, allowing explicit user JVM arguments to override them
- omit the promoted `java.io.tmpdir` from the properties file that `ForkedBooter` loads later
- make startup system properties an explicit part of the `ForkConfiguration#createCommandLine` contract
- add unit coverage for JVM argument ordering and an integration test using JUnit Jupiter's `@TempDir`

## Why

Surefire normally transfers configured system properties to `ForkedBooter` through a properties file. On newer JDKs, NIO caches the default temporary directory during JVM initialization, before `ForkedBooter` can apply those properties. As a result, `System.getProperty("java.io.tmpdir")` reported the configured value while JUnit's `@TempDir` still used the JVM's original temporary directory.

Passing `java.io.tmpdir` as a JVM startup argument ensures that the JDK initializes its cached temporary-directory value correctly. Generated startup properties precede `argLine`, so a value explicitly supplied by the user in `argLine` wins. The promoted property is removed from the later properties file so `ForkedBooter` cannot overwrite that winning value after JVM initialization. The change is in the shared fork-launching code and therefore applies to both Surefire and Failsafe.

Fixes #2940

## Validation

- `mvn clean install` passed across all 17 reactor modules on JDK 17
- `mvn -Prun-its clean install` passed; `surefire-its` ran 762 tests with no failures or errors
- focused `ForkConfigurationTest` passed all 11 tests
- focused `Surefire2113TempDirIT` passed both cases, including an `argLine` override of the effective `java.io.tmpdir`
- full-reactor `mvn spotless:check` passed

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
