### PR TITLE
[SUREFIRE-859] Make random test order reproducible

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java
@@ -141,6 +141,8 @@ import static org.apache.maven.plugin.surefire.util.DependencyScanner.filter;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.EXCLUDE_JUNIT5_ENGINES_PROP;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.INCLUDE_JUNIT5_ENGINES_PROP;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.JUNIT_VINTAGE_DETECTED;
+import static org.apache.maven.surefire.api.booter.ProviderParameterNames.RUN_ORDER_PROP;
+import static org.apache.maven.surefire.api.booter.ProviderParameterNames.RUN_ORDER_RANDOM_SEED_PROP;
 import static org.apache.maven.surefire.api.suite.RunResult.failure;
 import static org.apache.maven.surefire.api.suite.RunResult.noTestsRun;
 import static org.apache.maven.surefire.booter.Classpath.emptyClasspath;
@@ -1877,6 +1879,12 @@ public abstract class AbstractSurefireMojo extends AbstractMojo implements Suref
         getProperties().setProperty(ProviderParameterNames.STACK_TRACE_MAX_FRAMES, String.valueOf(stackTraceMaxFrames));
 
         Map<String, String> providerProperties = toStringProperties(getProperties());
+        providerProperties.put(RUN_ORDER_PROP, RunOrder.asString(runOrderParameters.getRunOrder()));
+        if (runOrderParameters.getRunOrderRandomSeed() != null) {
+            providerProperties.put(
+                    RUN_ORDER_RANDOM_SEED_PROP,
+                    runOrderParameters.getRunOrderRandomSeed().toString());
+        }
 
         return new ProviderConfiguration(
                 directoryScannerParameters,

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/AbstractSurefireMojoTest.java
@@ -55,11 +55,14 @@ import org.apache.maven.plugin.surefire.booterclient.Platform;
 import org.apache.maven.plugin.surefire.log.PluginConsoleLogger;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.surefire.api.suite.RunResult;
+import org.apache.maven.surefire.api.testset.RunOrderParameters;
 import org.apache.maven.surefire.api.util.DefaultScanResult;
+import org.apache.maven.surefire.api.util.RunOrder;
 import org.apache.maven.surefire.api.util.SureFireFileManager;
 import org.apache.maven.surefire.booter.ClassLoaderConfiguration;
 import org.apache.maven.surefire.booter.Classpath;
 import org.apache.maven.surefire.booter.ModularClasspathConfiguration;
+import org.apache.maven.surefire.booter.ProviderConfiguration;
 import org.apache.maven.surefire.booter.StartupConfiguration;
 import org.apache.maven.surefire.extensions.ForkNodeFactory;
 import org.apache.maven.surefire.providerapi.ProviderInfo;
@@ -155,6 +158,22 @@ public class AbstractSurefireMojoTest {
         plugin.setVersion(mojoArtifact.getVersion());
         when(pluginDescriptor.getPlugin()).thenReturn(plugin);
         mojo.setPluginDescriptor(pluginDescriptor);
+    }
+
+    @Test
+    public void shouldAddRunOrderParametersToProviderProperties() throws Exception {
+        MavenProject project = mock(MavenProject.class);
+        Artifact projectArtifact = mojo.getMojoArtifact();
+        when(project.getArtifact()).thenReturn(projectArtifact);
+        mojo.setProject(project);
+        RunOrderParameters runOrderParameters = new RunOrderParameters(new RunOrder[] {RunOrder.RANDOM}, null, 1234L);
+
+        ProviderConfiguration providerConfiguration =
+                invokeMethod(mojo, "createProviderConfiguration", runOrderParameters);
+
+        assertThat(providerConfiguration.getProviderProperties())
+                .containsEntry("runOrder", "random")
+                .containsEntry("runOrderRandomSeed", "1234");
     }
 
     @Test

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ProviderParameterNames.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/booter/ProviderParameterNames.java
@@ -54,6 +54,10 @@ public class ProviderParameterNames {
 
     public static final String EXCLUDES_SCAN_LIST = "junit.excludes.scan.list";
 
+    public static final String RUN_ORDER_PROP = "runOrder";
+
+    public static final String RUN_ORDER_RANDOM_SEED_PROP = "runOrderRandomSeed";
+
     /**
      * Additional package prefixes to filter from stack traces.
      * @since 3.6.0

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/DefaultRunOrderCalculator.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/DefaultRunOrderCalculator.java
@@ -68,6 +68,7 @@ public class DefaultRunOrderCalculator implements RunOrderCalculator {
 
     private void orderTestClasses(List<Class<?>> testClasses, RunOrder runOrder) {
         if (RunOrder.RANDOM.equals(runOrder)) {
+            testClasses.sort(getAlphabeticalComparator());
             Collections.shuffle(testClasses, random);
         } else if (RunOrder.FAILEDFIRST.equals(runOrder)) {
             RunEntryStatisticsMap stat = RunEntryStatisticsMap.fromFile(runOrderParameters.getRunStatisticsFile());

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/util/RunOrderCalculatorTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/util/RunOrderCalculatorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.surefire.api.util;
 
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -25,7 +26,9 @@ import org.apache.maven.surefire.api.testset.RunOrderParameters;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.maven.surefire.api.util.RunOrder.ALPHABETICAL;
+import static org.apache.maven.surefire.api.util.RunOrder.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 /**
  * @author Kristian Rosenvold
@@ -42,14 +45,33 @@ public class RunOrderCalculatorTest {
         assertEquals(A.class, testsToRun1.iterator().next());
     }
 
+    @Test
+    public void testRandomOrderIsIndependentOfDiscoveryOrder() {
+        long seed = 42L;
+        RunOrderParameters random = new RunOrderParameters(new RunOrder[] {RANDOM}, null, seed);
+
+        TestsToRun firstDiscoveryOrder = new TestsToRun(getClassesToRun(A.class, B.class, C.class, D.class));
+        TestsToRun secondDiscoveryOrder = new TestsToRun(getClassesToRun(D.class, B.class, A.class, C.class));
+
+        TestsToRun firstRandomOrder = new DefaultRunOrderCalculator(random, 1).orderTestClasses(firstDiscoveryOrder);
+        TestsToRun secondRandomOrder = new DefaultRunOrderCalculator(random, 1).orderTestClasses(secondDiscoveryOrder);
+
+        assertIterableEquals(firstRandomOrder, secondRandomOrder);
+    }
+
     private Set<Class<?>> getClassesToRun() {
-        Set<Class<?>> classesToRun = new LinkedHashSet<>();
-        classesToRun.add(B.class);
-        classesToRun.add(A.class);
-        return classesToRun;
+        return getClassesToRun(B.class, A.class);
+    }
+
+    private Set<Class<?>> getClassesToRun(Class<?>... classes) {
+        return new LinkedHashSet<>(Arrays.asList(classes));
     }
 
     static class A {}
 
     static class B {}
+
+    static class C {}
+
+    static class D {}
 }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/RunOrderIT.java
@@ -112,6 +112,21 @@ public class RunOrderIT extends SurefireJUnit4IntegrationTestCase {
     }
 
     @Test
+    public void testRandomSeedPassedToJUnit5() {
+        for (int forkCount : new int[] {0, 1}) {
+            unpack("runOrder-junitX", "-random-seed-fork-count-" + forkCount)
+                    .setJUnitVersion("5.14.1")
+                    .forkCount(forkCount)
+                    .reuseForks(reuseForks())
+                    .runOrder("random")
+                    .runOrderRandomSeed("1234")
+                    .sysProp("expected.junit.random.seed", "1234")
+                    .executeTest()
+                    .verifyErrorFree(3);
+        }
+    }
+
+    @Test
     public void testReverseAlphabeticalJUnit6() throws VerificationException {
         // JUnit 6.0.0 requires Java 17+
         assumeJavaVersion(17);

--- a/surefire-its/src/test/resources/runOrder-junitX/src/test/java/junit/runOrder/TestA.java
+++ b/surefire-its/src/test/resources/runOrder-junitX/src/test/java/junit/runOrder/TestA.java
@@ -1,12 +1,34 @@
 package junit.runOrder;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(TestA.RandomSeedVerifier.class)
 public class TestA
 {
     @Test
     public void testTwo()
     {
         System.out.println( "TA" );
+    }
+
+    public static class RandomSeedVerifier implements BeforeAllCallback
+    {
+        @Override
+        public void beforeAll( ExtensionContext context )
+        {
+            String expectedSeed = System.getProperty( "expected.junit.random.seed" );
+            if ( expectedSeed != null )
+            {
+                String actualSeed = context.getConfigurationParameter( "junit.jupiter.execution.order.random.seed" )
+                        .orElse( null );
+                if ( !expectedSeed.equals( actualSeed ) )
+                {
+                    throw new AssertionError( "Expected JUnit random seed " + expectedSeed + " but was " + actualSeed );
+                }
+            }
+        }
     }
 }

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -79,6 +79,8 @@ import static org.apache.maven.surefire.api.booter.ProviderParameterNames.EXCLUD
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.GROUPS_PROP;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.INCLUDE_JUNIT5_ENGINES_PROP;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.JUNIT_VINTAGE_DETECTED;
+import static org.apache.maven.surefire.api.booter.ProviderParameterNames.RUN_ORDER_PROP;
+import static org.apache.maven.surefire.api.booter.ProviderParameterNames.RUN_ORDER_RANDOM_SEED_PROP;
 import static org.apache.maven.surefire.api.report.ConsoleOutputCapture.startCapture;
 import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 import static org.apache.maven.surefire.api.report.RunMode.RERUN_TEST_AFTER_FAILURE;
@@ -98,6 +100,8 @@ import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.r
  */
 public class JUnitPlatformProvider extends AbstractProvider {
     static final String CONFIGURATION_PARAMETERS = "configurationParameters";
+
+    private static final String JUNIT_RANDOM_SEED = "junit.jupiter.execution.order.random.seed";
 
     private final ProviderParameters parameters;
 
@@ -157,13 +161,15 @@ public class JUnitPlatformProvider extends AbstractProvider {
     }
 
     private void setupRunOrder() {
-        String runOrder = parameters.getProviderProperties().get("runOrder");
+        String runOrder = parameters.getProviderProperties().get(RUN_ORDER_PROP);
         if (runOrder != null) {
             if (runOrder.equals("random")) {
                 getConfigurationParameters()
                         .put("junit.jupiter.testmethod.order.default", "org.junit.jupiter.api.MethodOrderer$Random");
                 getConfigurationParameters()
                         .put("junit.jupiter.testclass.order.default", "org.junit.jupiter.api.ClassOrderer$Random");
+                Optional.ofNullable(parameters.getProviderProperties().get(RUN_ORDER_RANDOM_SEED_PROP))
+                        .ifPresent(seed -> getConfigurationParameters().put(JUNIT_RANDOM_SEED, seed));
             } else if (runOrder.equals("alphabetical")) {
                 getConfigurationParameters()
                         .put(

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -74,6 +74,7 @@ import static org.apache.maven.surefire.api.booter.ProviderParameterNames.EXCLUD
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.GROUPS_PROP;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.INCLUDE_JUNIT5_ENGINES_PROP;
 import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
+import static org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.CONFIGURATION_PARAMETERS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -99,6 +100,35 @@ import static org.mockito.Mockito.withSettings;
  * @since 2.22.0
  */
 public class JUnitPlatformProviderTest {
+    @Test
+    public void shouldPassSurefireRandomSeedToJupiter() {
+        Map<String, String> providerProperties = new HashMap<>();
+        providerProperties.put("runOrder", "random");
+        providerProperties.put("runOrderRandomSeed", "1234");
+        ProviderParameters providerParameters = providerParametersMock();
+        when(providerParameters.getProviderProperties()).thenReturn(providerProperties);
+
+        JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
+
+        assertThat(provider.getConfigurationParameters())
+                .containsEntry("junit.jupiter.execution.order.random.seed", "1234");
+    }
+
+    @Test
+    public void shouldPreferExplicitJupiterRandomSeed() {
+        Map<String, String> providerProperties = new HashMap<>();
+        providerProperties.put("runOrder", "random");
+        providerProperties.put("runOrderRandomSeed", "1234");
+        providerProperties.put(CONFIGURATION_PARAMETERS, "junit.jupiter.execution.order.random.seed=5678");
+        ProviderParameters providerParameters = providerParametersMock();
+        when(providerParameters.getProviderProperties()).thenReturn(providerProperties);
+
+        JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
+
+        assertThat(provider.getConfigurationParameters())
+                .containsEntry("junit.jupiter.execution.order.random.seed", "5678");
+    }
+
     @Test
     public void shouldFailClassOnBeforeAll() throws Exception {
         TestReportListener<TestOutputReportEntry> listener = mock(TestReportListener.class);


### PR DESCRIPTION
## Summary

- sort discovered test classes before applying the seeded random shuffle
- pass Surefire's `runOrderRandomSeed` to JUnit Jupiter as `junit.jupiter.execution.order.random.seed`
- propagate run-order provider properties consistently in forked and in-process execution
- preserve an explicitly configured JUnit Jupiter random seed
- add unit and integration coverage for deterministic discovery order and JUnit seed propagation

## Why

`Collections.shuffle()` is deterministic only when both its input order and seed are deterministic. Test-class discovery can return classes in a different order across filesystems and machines, so the same Surefire seed previously produced different shuffled orders.

JUnit Jupiter also performs its own class and method ordering. Surefire selected Jupiter's random orderers for `runOrder=random`, but did not pass `runOrderRandomSeed` to JUnit. Jupiter therefore used an independent seed and could not reproduce the complete test order from the Surefire seed.

Sorting the discovered classes before shuffling provides a stable input. Forwarding the same seed through JUnit's configuration parameters makes Jupiter's random class and method ordering reproducible as well. An explicit `junit.jupiter.execution.order.random.seed` in Surefire's JUnit configuration parameters retains precedence.

Fixes #859

## Validation

- `mvn clean install` passed across all 17 reactor modules on JDK 17
- `mvn -Prun-its clean install` passed; `surefire-its` ran 764 tests with no failures or errors
- focused `RunOrderIT` passed all 11 tests, including JUnit seed propagation with `forkCount=0` and `forkCount=1`
- focused Surefire API, common, and JUnit Platform provider unit tests passed
- Spotless, Checkstyle, RAT, and `git diff --check` passed

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
