### PR TITLE
Restore the table borders lost in the APT conversion

### DIFF
--- a/maven-surefire-plugin/src/site/markdown/examples/toolchains.md.vm
+++ b/maven-surefire-plugin/src/site/markdown/examples/toolchains.md.vm
@@ -53,11 +53,12 @@ Minimum Java Version for Toolchains
 
 The minimum version of Java that can be used as a toolchain is limited by the Surefire Booter requirement.
 
-|Surefire Version|Minimum Java Version|Class File Version|
-|:---|:---|:---|
-|3\.0.0-M6 or higher|Java 8|52|
-|3\.0.0-M5 and lower|Java 7|51|
-|lower than 3.0.0-M1|Java 6|50|
+<table class="table table-bordered table-striped">
+<tr><th>Surefire Version</th><th>Minimum Java Version</th><th>Class File Version</th></tr>
+<tr><td style="text-align: left;">3.0.0-M6 or higher</td><td style="text-align: left;">Java 8</td><td style="text-align: left;">52</td></tr>
+<tr><td style="text-align: left;">3.0.0-M5 and lower</td><td style="text-align: left;">Java 7</td><td style="text-align: left;">51</td></tr>
+<tr><td style="text-align: left;">lower than 3.0.0-M1</td><td style="text-align: left;">Java 6</td><td style="text-align: left;">50</td></tr>
+</table>
 
 If you try to use a version older than the minimum supported version, you should face something like:
 

--- a/surefire-api/src/site/markdown/index.md
+++ b/surefire-api/src/site/markdown/index.md
@@ -28,12 +28,13 @@ under the License.
 
 ## Definitions
 
-|Term|Definition|
-|:---|:---|
-|test method|Individual test method within a class|
-|test|1..N test methods in 1 or more classes.|
-|suite|1..N tests.|
-|group|A named subset of test methods within a test.|
+<table class="table table-bordered table-striped">
+<tr><th>Term</th><th>Definition</th></tr>
+<tr><td style="text-align: left;">test method</td><td style="text-align: left;">Individual test method within a class</td></tr>
+<tr><td style="text-align: left;">test</td><td style="text-align: left;">1..N test methods in 1 or more classes.</td></tr>
+<tr><td style="text-align: left;">suite</td><td style="text-align: left;">1..N tests.</td></tr>
+<tr><td style="text-align: left;">group</td><td style="text-align: left;">A named subset of test methods within a test.</td></tr>
+</table>
 
 How each definition is applied depends on the provider, and the test suite being used.
 


### PR DESCRIPTION
Follow-up to #3422, which merged before this fix could be included.

## The problem

A Markdown pipe table renders as `class="table table-striped"`. The APT tables these two pages came from rendered as `class="table table-bordered table-striped"`, so the conversion quietly dropped the cell borders on:

* `maven-surefire-plugin/src/site/markdown/examples/toolchains.md.vm`
* `surefire-api/src/site/markdown/index.md`

I reported this in #3422 as a limitation of the Markdown sink that could not be controlled from the source document. **That was wrong** — it is true of a pipe table, but not of the source in general.

## The fix

Doxia parses a raw HTML `<table>` back into the same table it built from APT: the class and the per-cell `style` survive verbatim, and it still applies the alternating `tr class="a"`/`"b"` itself. Writing these two tables out as HTML restores the original rendering exactly.

## Verification

Compared against the pre-conversion site, on the same three axes used for #3422 — document title, author and date metadata plus visible text and link targets; block structure including `<pre>` and `<table>` classes; and heading anchors:

* **`examples/toolchains.html`** drops out of **all three** axes entirely. It is now an exact match for the APT baseline, `table-bordered` and `style="text-align: left;"` and all.
* **`surefire-api/index.html`**'s only remaining difference is the two `Term`/`Definition` header cells, which were added deliberately in #3422 because a Markdown table cannot express a headerless one.

## What is deliberately left alone

`maven-surefire-plugin/src/site/markdown/history.md.vm` keeps its Markdown table. It carries 24 links and 38 line breaks across nine rows, and it is the changelog that gains a row every release — handing maintainers hand-written HTML in the file they edit most often, to gain a border, is the wrong trade. That page keeps `table table-striped`.

Generated-by: Claude Opus 5 (1M context)