### PR TITLE
Restore the straight quotes the FAQ conversion turned typographic

### DIFF
--- a/maven-surefire-plugin/src/site/markdown/faq.md
+++ b/maven-surefire-plugin/src/site/markdown/faq.md
@@ -21,13 +21,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<a name="top"></a>
+<a id="top"></a>
 
 # Frequently Asked Questions
 
 1. [What is the difference between maven-failsafe-plugin and maven-surefire-plugin?](#surefire-v-failsafe)
 2. [How can I reuse my test code in other modules?](#reuse-test-code)
-3. [Surefire fails with the message "The forked VM terminated without properly saying goodbye".](#vm-termination)
+3. [Surefire fails with the message &quot;The forked VM terminated without properly saying goodbye&quot;.](#vm-termination)
 4. [Crashed Surefire or Failsafe plugin must indicate crashed tests](#crashed-forks)
 5. [How can I run GWT tests?](#GWT)
 6. [How do I use properties set by other plugins in `argLine`?](#late-property-evaluation)
@@ -36,7 +36,7 @@ under the License.
 9. [Corrupted channel by directly writing to native stream in forked JVM](#corruptedstream)
 10. [The files cannot be deleted when Jenkins CI killed Maven process and the tests still continue running.](#kill-jvm)
 
-<a name="surefire-v-failsafe"></a>
+<a id="surefire-v-failsafe"></a>
 
 ### What is the difference between maven-failsafe-plugin and maven-surefire-plugin?
 
@@ -46,7 +46,7 @@ tests and if any of the tests fail then it will fail the build immediately.
 [maven-failsafe-plugin](http://maven.apache.org/plugins/maven-failsafe-plugin/) is designed for running
 integration tests, and decouples failing the build if there are test failures from actually running the tests.
 
-<a name="reuse-test-code"></a>
+<a id="reuse-test-code"></a>
 
 ### How can I reuse my test code in other modules?
 
@@ -54,22 +54,22 @@ Visit this link for your reference,
 [Attaching tests](http://maven.apache.org/guides/mini/guide-attached-tests.html). Also see the examples for
 [Inclusions and Exclusions of Tests](examples/inclusion-exclusion.html).
 
-<a name="vm-termination"></a>
+<a id="vm-termination"></a>
 
-### Surefire fails with the message "The forked VM terminated without properly saying goodbye".
+### Surefire fails with the message &quot;The forked VM terminated without properly saying goodbye&quot;.
 
 Surefire does not support tests or any referenced libraries calling `System.exit()` at any time. If they do so,
 they are incompatible with Surefire and you should probably file an issue with the library/vendor.
 
 Alternatively the forked VM could also have crashed for a number of reasons. Look for the classical
 `hs_err*` files indicating VM crashes or examine the Maven log output when the tests execute. Some
-"extraordinary" output from crashing processes may be dumped to the console/log.
+&quot;extraordinary&quot; output from crashing processes may be dumped to the console/log.
 
 If this happens on a CI environment and only after it runs for some time, there is a fair chance your test
 suite is leaking some kind of OS-level resource that makes things worse at every run. Regular OS-level
 monitoring tools may give you some indication.
 
-<a name="crashed-forks"></a>
+<a id="crashed-forks"></a>
 
 ### Crashed Surefire or Failsafe plugin must indicate crashed tests
 
@@ -77,7 +77,7 @@ After a forked JVM has crashed the console of forked JVM prints *Crashed tests:*
 has crashed. In the console log you can find the message *The forked VM terminated without properly saying
 goodbye*.
 
-<a name="GWT"></a>
+<a id="GWT"></a>
 
 ### How can I run GWT tests?
 
@@ -92,7 +92,7 @@ to run with Surefire, you need the following settings:
 
 Try `reuseForks=true` and if it doesn't work, fall back to `reuseForks=false`
 
-<a name="late-property-evaluation"></a>
+<a id="late-property-evaluation"></a>
 
 ### How do I use properties set by other plugins in `argLine`?
 
@@ -107,16 +107,16 @@ also available with a different value at initialization of the POM model. Otherw
 replacement kicks in properly directly before this goal is being executed (instead of when the POM model is
 being resolved)*.
 
-<a name="failsafe-jar"></a>
+<a id="failsafe-jar"></a>
 
 ### How maven-failsafe-plugin allows me to configure the jar file or classes to use?
 
-By default maven-failsafe-plugin uses project artifact file in test classpath if packaging is set to "jar" in
+By default maven-failsafe-plugin uses project artifact file in test classpath if packaging is set to &quot;jar&quot; in
 pom.xml. This can be modified and for instance set to main project classes if you use configuration parameter
-"classesDirectory". This would mean that you set value "${project.build.outputDirectory}" for the parameter
-"classesDirectory" in the configuration of plugin.
+&quot;classesDirectory&quot;. This would mean that you set value &quot;${project.build.outputDirectory}&quot; for the parameter
+&quot;classesDirectory&quot; in the configuration of plugin.
 
-<a name="dumpfiles"></a>
+<a id="dumpfiles"></a>
 
 ### How to dump fatal errors and stack trace of plugin runtime if it fails?
 
@@ -134,7 +134,7 @@ follows:
 Forked JVM process and plugin process communicate via std/out. If this channel is corrupted, for a whatever
 reason, the dump of the corrupted stream appears in *\*.dumpstream*.
 
-<a name="corruptedstream"></a>
+<a id="corruptedstream"></a>
 
 ### Corrupted channel by directly writing to native stream in forked JVM
 
@@ -145,12 +145,12 @@ to be corrupted but the Maven will never see the tests finished and build may ha
 
 This warning message appears if you use *FileDescriptor.out* or JVM prints GC summary.
 
-In that case the warning is printed *"Corrupted channel by directly writing to native stream in forked JVM"*,
+In that case the warning is printed *&quot;Corrupted channel by directly writing to native stream in forked JVM&quot;*,
 and a dump file can be found in Reports directory.
 
 If debug level is enabled then messages of corrupted stream appear in the console.
 
-<a name="kill-jvm"></a>
+<a id="kill-jvm"></a>
 
 ### The files cannot be deleted when Jenkins CI killed Maven process and the tests still continue running.
 
@@ -158,6 +158,6 @@ Surefire and Failsafe plugin may kill forked Surefire JVM when the standard-inpu
 when you stop Maven process by CTRL+C but it is not guaranteed on all platforms. By default, the plugins use
 process pipes for interprocess communication. Since version 3.0.0-M5, TCP/IP sockets are also available and can
 be selected with the forkNode configuration parameter. See the documentation of the configuration parameter
-"enableProcessChecker" for mechanisms to detect and kill orphan forked JVMs. These mechanisms have some
+&quot;enableProcessChecker&quot; for mechanisms to detect and kill orphan forked JVMs. These mechanisms have some
 drawbacks regarding your OS systems and GC, therefore see the documentation for the parameter
-"enableProcessChecker".
+&quot;enableProcessChecker&quot;.


### PR DESCRIPTION
Follow-up to #3423 (merged). Two defects in the converted FAQ page, one of which readers can see.

### The visible one: smart quotes

flexmark enables smart-punctuation, so a straight `"` in Markdown prose renders as a typographic quote. FML went through `XdocParser`, which does no such rewriting — so this page served straight quotes for years and now does not. Twenty-two of them changed appearance:

```
"The forked VM terminated without properly saying goodbye"
"extraordinary"   "jar"   "classesDirectory"   "${project.build.outputDirectory}"
"Corrupted channel by directly writing to native stream in forked JVM"
"enableProcessChecker"  (x2)
```

Written as `&quot;` here — the convention the already-converted `maven-site-plugin` pages use for exactly this reason. Quotes inside code spans and fenced blocks are untouched; smart-punctuation never applied to those.

**This is the class of defect the anchor test cannot catch** — it is a text change, not an anchor change.

### The latent one: `<a name>` → `<a id>`

maven-site-plugin **3.21.0 strips the `name` attribute from inline HTML; 3.22.0 keeps it**. Stripping it would delete every anchor on this page while the build stayed green.

This module is safe today — but only because the root pom pins `maven-site-plugin` 3.22.0 **explicitly**, rather than inheriting from `maven-parent` 47. That pin is the only thing standing between this page and silent anchor loss. `Xhtml5BaseParser` reads `Attribute.ID` first and falls back to `NAME`, so `id` is the primary path rather than a workaround, and `name` on `<a>` is obsolete in HTML5 anyway.

Each anchor stays on its own line — folding one into heading text suppresses the section's own generated id.

### Verification

Built `maven-surefire-plugin`'s site and compared against the FML original from before #3423, deleting `target/site` first so a page that failed to re-render could not be silently compared against itself:

* all ten anchors plus `#top` still served — `#dumpfiles` matters beyond the live site, `examples/shutdown.apt.vm` links to `../faq.html#dumpfiles`
* `<head>` byte-identical
* zero `Anchor name … used more than once` warnings
* no typographic quotes left in the visible text

Rebuilding locally needs **JDK 21** — the reactor does not build on JDK 26, `sisu-maven-plugin` 0.9.0.M4 fails on `maven-surefire-common` with "Unsupported class file major version 70". Unrelated to this change.

<sub>Drafted with Claude — please verify</sub>
