### PR TITLE
Pin Maven prerequisite to 3.6.3 and drop mavenVersion.prerequisite

### DIFF
--- a/maven-failsafe-plugin/pom.xml
+++ b/maven-failsafe-plugin/pom.xml
@@ -34,7 +34,7 @@
   <description>Maven Failsafe MOJO in maven-failsafe-plugin.</description>
 
   <prerequisites>
-    <maven>${mavenVersion.prerequisite}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <properties>

--- a/maven-surefire-plugin/pom.xml
+++ b/maven-surefire-plugin/pom.xml
@@ -34,7 +34,7 @@
   <description>Maven Surefire MOJO in maven-surefire-plugin.</description>
 
   <prerequisites>
-    <maven>${mavenVersion.prerequisite}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <properties>

--- a/maven-surefire-report-plugin/pom.xml
+++ b/maven-surefire-report-plugin/pom.xml
@@ -42,7 +42,7 @@
   </developers>
 
   <prerequisites>
-    <maven>${mavenVersion.prerequisite}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,6 @@
     <junit.jupiter.execution.parallel.mode.classes.default>concurrent</junit.jupiter.execution.parallel.mode.classes.default>
     <junit.jupiter.execution.parallel.mode.default>same_thread</junit.jupiter.execution.parallel.mode.default>
     <mavenVersion>3.9.14</mavenVersion>
-    <mavenVersion.prerequisite>3.6.3</mavenVersion.prerequisite>
     <resolverVersion>1.9.27</resolverVersion>
     <commonsLang3Version>3.20.0</commonsLang3Version>
     <commonsCompress>1.28.0</commonsCompress>


### PR DESCRIPTION
`mavenVersion.prerequisite` was doing the right thing — keeping the declared baseline decoupled from `${mavenVersion}` (currently `3.9.14`) — but it is a property holding a single literal, referenced from exactly three module POMs. Inlining `3.6.3` says the same thing with one less indirection and matches how the rest of the 3.x plugin line declares it.

No behaviour change. Verified per module with `mvn -pl <module> help:evaluate -Dexpression=project.prerequisites.maven` → `3.6.3` for `maven-surefire-plugin`, `maven-failsafe-plugin` and `maven-surefire-report-plugin`.

<sub>Drafted with Claude — please verify</sub>
