### PR TITLE
Report AfterAll/AfterClass failures as errors, not flakes (#3412)

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactory.java
@@ -277,6 +277,7 @@ public class DefaultReporterFactory implements ReporterFactory, ReportsMerger {
             String testClassMethodName = entry.getKey();
 
             // Handle @BeforeAll failures (null, empty, or ends with ".null" method names)
+            // Do NOT include ".executionError" (AfterAll/AfterClass) — those stay as real errors (#3412).
             // But only if they actually failed (ERROR or FAILURE), not if they were skipped
             if ((StringUtils.isBlank(testClassMethodName) || testClassMethodName.endsWith(".null"))
                     && (testClassMethodName == null || !testClassMethodName.contains("$"))) {

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/report/StatelessXmlReporter.java
@@ -393,7 +393,10 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
 
     /**
      * Determines the final result type for a test method, applying special handling for @BeforeAll failures.
-     * If a @BeforeAll fails but any actual test methods succeed, it's classified as a FLAKE.
+     * If a @BeforeAll fails but any actual test methods succeed (on a later rerun), it's classified as a FLAKE.
+     * <p>
+     * AfterAll/AfterClass failures are reported as {@code executionError} by the JUnit Platform provider and
+     * are intentionally <em>not</em> covered here — they must remain errors (#3412).
      *
      * @param methodName the name of the test method (null or "null" for @BeforeAll)
      * @param methodRuns the list of runs for this method
@@ -406,14 +409,14 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
             Map<String, List<WrappedReportEntry>> methodStatistics) {
         TestResultType resultType = getTestResultType(methodRuns);
 
-        // Special handling for @BeforeAll failures (null method name or method name is "null")
+        // Special handling for @BeforeAll failures only (null method name or method name is "null").
+        // AfterAll/AfterClass teardown failures surface as "executionError" and must stay errors (#3412).
         // If @BeforeAll failed but any actual test methods succeeded, treat it as a flake
         if ((methodName == null || methodName.equals("null"))
                 && (resultType == TestResultType.ERROR || resultType == TestResultType.FAILURE)) {
-            // Check if any actual test methods (non-null and not "null" names) succeeded
+            // Check if any actual test methods (exclude synthetic class-level names) succeeded
             boolean hasSuccessfulTestMethods = methodStatistics.entrySet().stream()
-                    .filter(entry ->
-                            entry.getKey() != null && !entry.getKey().equals("null")) // Only actual test methods
+                    .filter(entry -> isActualTestMethodName(entry.getKey()))
                     .anyMatch(entry -> entry.getValue().stream()
                             .anyMatch(reportEntry -> reportEntry.getReportEntryType() == SUCCESS));
 
@@ -423,6 +426,14 @@ public class StatelessXmlReporter implements StatelessReportEventListener<Wrappe
         }
 
         return resultType;
+    }
+
+    /**
+     * Whether the method name refers to a real test method rather than a synthetic class-level failure
+     * (@BeforeAll {@code null}/{@code "null"} setup or @AfterAll {@code "executionError"} teardown).
+     */
+    private static boolean isActualTestMethodName(String methodName) {
+        return methodName != null && !methodName.equals("null") && !methodName.equals("executionError");
     }
 
     private Deque<WrappedReportEntry> getAddMethodRunHistoryMap(String testClassName) {

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/report/DefaultReporterFactoryTest.java
@@ -210,6 +210,67 @@ public class DefaultReporterFactoryTest extends TestCase {
         assertEquals(emptyList(), reporter.getMessages());
     }
 
+    /**
+     * AfterAll/AfterClass failures are reported as {@code Class.executionError}. They must count as
+     * errors (not flakes) even when test methods in the same class succeeded and rerun is enabled
+     * (#3412).
+     */
+    public void testAfterAllFailureRemainsErrorNotFlake() throws Exception {
+        MessageUtils.setColorEnabled(false);
+        File target = new File(System.getProperty("user.dir"), "target");
+        File reportsDirectory = new File(target, "tmp-afterall-3412");
+        StartupReportConfiguration reportConfig = new StartupReportConfiguration(
+                true,
+                true,
+                "PLAIN",
+                false,
+                reportsDirectory,
+                false,
+                null,
+                new File(reportsDirectory, "TESTHASH"),
+                false,
+                2,
+                null,
+                null,
+                false,
+                true,
+                true,
+                false,
+                new SurefireStatelessReporter(),
+                new SurefireConsoleOutputReporter(),
+                new SurefireStatelessTestsetInfoReporter(),
+                new ReporterFactoryOptions());
+
+        DummyTestReporter reporter = new DummyTestReporter();
+        DefaultReporterFactory factory = new DefaultReporterFactory(reportConfig, reporter);
+
+        String afterAllClass = "com.example.AfterAllFailClass";
+        Queue<TestMethodStats> runStats = new ArrayDeque<>();
+        runStats.add(new TestMethodStats(afterAllClass + ".testOne", ReportEntryType.SUCCESS, null));
+        runStats.add(new TestMethodStats(afterAllClass + ".testTwo", ReportEntryType.SUCCESS, null));
+        runStats.add(new TestMethodStats(
+                afterAllClass + ".executionError",
+                ReportEntryType.ERROR,
+                new DummyStackTraceWriter(afterAllClass + ".executionError " + TEST_ERROR_SUFFIX)));
+
+        TestSetRunListener runListener = mock(TestSetRunListener.class);
+        when(runListener.getTestMethodStats()).thenReturn(runStats);
+        factory.addListener(runListener);
+
+        invokeMethod(factory, "mergeTestHistoryResult");
+        RunStatistics mergedStatistics = factory.getGlobalRunStatistics();
+
+        assertEquals(3, mergedStatistics.getCompletedCount());
+        assertEquals(1, mergedStatistics.getErrors());
+        assertEquals(0, mergedStatistics.getFailures());
+        assertEquals(0, mergedStatistics.getFlakes());
+        assertEquals(0, mergedStatistics.getSkipped());
+
+        reporter.reset();
+        factory.printTestFailures(TestResultType.FLAKE);
+        assertEquals(emptyList(), reporter.getMessages());
+    }
+
     static final class DummyTestReporter implements ConsoleLogger {
         private final List<String> messages = new ArrayList<>();
 

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit4FailingAfterClassIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit4FailingAfterClassIT.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Integration test for JUnit 4 {@code @AfterClass} that always fails (#3412).
+ * Teardown failures must be reported as errors (not flakes) and must not
+ * re-execute already-passing test methods when {@code rerunFailingTestsCount} is set.
+ */
+public class JUnit4FailingAfterClassIT extends SurefireJUnit4IntegrationTestCase {
+    private static final String VERSION = "4.13.2";
+
+    @Test
+    public void testAfterClassFailureIsReported() {
+        OutputValidator outputValidator = unpack("junit4-failing-after-class", "-norerun")
+                .setJUnitVersion(VERSION)
+                .maven()
+                .withFailure()
+                .executeTest();
+
+        outputValidator.verifyTextInLog("AfterClass always fails");
+        // 4 completed: PassingTest (1) + AlwaysFailingAfterClassTest (2 methods + executionError)
+        // with 1 error — restore pre-3.5.5 behavior
+        outputValidator.assertTestSuiteResults(4, 1, 0, 0);
+
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit4.PassingTest.xml")
+                .assertContainsText("tests=\"1\" errors=\"0\"");
+
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit4.AlwaysFailingAfterClassTest.xml")
+                .assertContainsText("errors=\"1\"");
+    }
+
+    @Test
+    public void testAfterClassFailureWithRerunDoesNotRerunPassingTests() throws VerificationException {
+        OutputValidator outputValidator = unpack("junit4-failing-after-class", "-rerun")
+                .setJUnitVersion(VERSION)
+                .maven()
+                .addGoal("-Dsurefire.rerunFailingTestsCount=2")
+                .withFailure()
+                .executeTest();
+
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit4.AlwaysFailingAfterClassTest.xml")
+                .assertContainsText("errors=\"1\"");
+
+        // Passing methods must not be re-executed solely because teardown failed
+        outputValidator.assertThatLogLine(containsString("testOne passed"), is(1));
+        outputValidator.assertThatLogLine(containsString("testTwo passed"), is(1));
+    }
+}

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit5FailingAfterAllIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit5FailingAfterAllIT.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Integration test for JUnit 5 {@code @AfterAll} that always fails (#3412).
+ * Teardown failures must be reported as errors (not flakes) and must not
+ * re-execute already-passing test methods when {@code rerunFailingTestsCount} is set.
+ */
+public class JUnit5FailingAfterAllIT extends SurefireJUnit4IntegrationTestCase {
+    private static final String VERSION = "5.9.1";
+
+    @Test
+    public void testAfterAllFailureIsReported() {
+        OutputValidator outputValidator = unpack("junit5-failing-after-all", "-norerun")
+                .setJUnitVersion(VERSION)
+                .maven()
+                .withFailure()
+                .executeTest();
+
+        outputValidator.verifyTextInLog("AfterAll always fails");
+        // 4 completed: PassingTest (1) + AlwaysFailingAfterAllTest (2 methods + executionError)
+        // with 1 error — restore pre-3.5.5 behavior
+        outputValidator.assertTestSuiteResults(4, 1, 0, 0);
+
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit5.PassingTest.xml")
+                .assertContainsText("tests=\"1\" errors=\"0\"");
+
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit5.AlwaysFailingAfterAllTest.xml")
+                .assertContainsText("name=\"executionError\"")
+                .assertContainsText("errors=\"1\"");
+    }
+
+    @Test
+    public void testAfterAllFailureWithRerunDoesNotRerunPassingTests() throws VerificationException {
+        OutputValidator outputValidator = unpack("junit5-failing-after-all", "-rerun")
+                .setJUnitVersion(VERSION)
+                .maven()
+                .addGoal("-Dsurefire.rerunFailingTestsCount=2")
+                .withFailure()
+                .executeTest();
+
+        outputValidator
+                .getSurefireReportsXmlFile("TEST-junit5.AlwaysFailingAfterAllTest.xml")
+                .assertContainsText("name=\"executionError\"")
+                .assertContainsText("errors=\"1\"");
+
+        // Passing methods must not be re-executed solely because teardown failed
+        outputValidator.assertThatLogLine(containsString("testOne passed"), is(1));
+        outputValidator.assertThatLogLine(containsString("testTwo passed"), is(1));
+    }
+}

--- a/surefire-its/src/test/resources/junit4-failing-after-class/pom.xml
+++ b/surefire-its/src/test/resources/junit4-failing-after-class/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit4-failing-after-class</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Test for failing @AfterClass in JUnit 4</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <junit5.version>5.11.4</junit5.version>
+    </properties>
+
+    <!--
+        Declare the JUnit Vintage engine so that JUnit 4 tests run on the JUnit Platform
+        (matching how JUnit 4 executes on newer Surefire lines). "junit:junit" is pulled in
+        transitively for test compilation.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/surefire-its/src/test/resources/junit4-failing-after-class/src/test/java/junit4/AlwaysFailingAfterClassTest.java
+++ b/surefire-its/src/test/resources/junit4-failing-after-class/src/test/java/junit4/AlwaysFailingAfterClassTest.java
@@ -1,0 +1,29 @@
+package junit4;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+
+/**
+ * Test class with @AfterClass that always fails.
+ * All test methods pass, but the class-level teardown always throws.
+ */
+public class AlwaysFailingAfterClassTest
+{
+    @AfterClass
+    public static void tearDown()
+    {
+        throw new IllegalStateException( "AfterClass always fails" );
+    }
+
+    @Test
+    public void testOne()
+    {
+        System.out.println( "testOne passed" );
+    }
+
+    @Test
+    public void testTwo()
+    {
+        System.out.println( "testTwo passed" );
+    }
+}

--- a/surefire-its/src/test/resources/junit4-failing-after-class/src/test/java/junit4/PassingTest.java
+++ b/surefire-its/src/test/resources/junit4-failing-after-class/src/test/java/junit4/PassingTest.java
@@ -1,0 +1,16 @@
+package junit4;
+
+import org.junit.Test;
+
+/**
+ * A simple passing test class to verify that other tests are unaffected
+ * by the failing @AfterClass in another test class.
+ */
+public class PassingTest
+{
+    @Test
+    public void testPassingOne()
+    {
+        System.out.println( "testPassingOne passed" );
+    }
+}

--- a/surefire-its/src/test/resources/junit5-failing-after-all/pom.xml
+++ b/surefire-its/src/test/resources/junit5-failing-after-all/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit5-failing-after-all</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Test for failing @AfterAll in JUnit 5</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/surefire-its/src/test/resources/junit5-failing-after-all/src/test/java/junit5/AlwaysFailingAfterAllTest.java
+++ b/surefire-its/src/test/resources/junit5-failing-after-all/src/test/java/junit5/AlwaysFailingAfterAllTest.java
@@ -1,0 +1,29 @@
+package junit5;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class with @AfterAll that always fails.
+ * All test methods pass, but the class-level teardown always throws.
+ */
+public class AlwaysFailingAfterAllTest
+{
+    @AfterAll
+    static void tearDown()
+    {
+        throw new IllegalStateException( "AfterAll always fails" );
+    }
+
+    @Test
+    public void testOne()
+    {
+        System.out.println( "testOne passed" );
+    }
+
+    @Test
+    public void testTwo()
+    {
+        System.out.println( "testTwo passed" );
+    }
+}

--- a/surefire-its/src/test/resources/junit5-failing-after-all/src/test/java/junit5/PassingTest.java
+++ b/surefire-its/src/test/resources/junit5-failing-after-all/src/test/java/junit5/PassingTest.java
@@ -1,0 +1,16 @@
+package junit5;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A simple passing test class to verify that other tests are unaffected
+ * by the failing @AfterAll in another test class.
+ */
+public class PassingTest
+{
+    @Test
+    public void testPassingOne()
+    {
+        System.out.println( "testPassingOne passed" );
+    }
+}

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
@@ -59,10 +60,18 @@ import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
  * @since 2.22.0
  */
 final class RunListenerAdapter implements TestExecutionListener, TestOutputReceiver<OutputReportEntry>, RunModeSetter {
+    /**
+     * Synthetic method name used for a class-level teardown failure (e.g. {@code @AfterAll} / {@code @AfterClass})
+     * that happens after at least one test method of the class has already succeeded. Naming it distinctly lets the
+     * Maven-side reporter keep it as a real error instead of misclassifying it as a flaky {@code @BeforeAll} (#3412).
+     */
+    private static final String EXECUTION_ERROR = "executionError";
+
     private final ClassMethodIndexer classMethodIndexer = new ClassMethodIndexer();
     private final ConcurrentMap<TestIdentifier, Long> testStartTime = new ConcurrentHashMap<>();
     private final ConcurrentMap<TestIdentifier, TestExecutionResult> failures = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, TestIdentifier> runningTestIdentifiersByUniqueId = new ConcurrentHashMap<>();
+    private final Set<String> classesWithSuccessfulTests = ConcurrentHashMap.newKeySet();
     private final TestReportListener<TestOutputReportEntry> runListener;
     private final Stoppable stoppable;
     private volatile TestPlan testPlan;
@@ -152,11 +161,18 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                         runListener.testSetCompleted(
                                 createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
                     }
-                    failures.put(testIdentifier, testExecutionResult);
+                    // A class-level teardown failure (@AfterAll/@AfterClass) that happens after test methods have
+                    // already succeeded is renamed to "executionError". Such a failure must stay a real error, so it
+                    // is not recorded as a rerunnable failure (which would needlessly re-run passing methods) (#3412).
+                    if (!(isClass && EXECUTION_ERROR.equals(reportEntry.getName()))) {
+                        failures.put(testIdentifier, testExecutionResult);
+                    }
                     fireStopEvent();
                     break;
                 default:
                     if (isTest) {
+                        classesWithSuccessfulTests.add(
+                                toClassMethodName(testIdentifier).getClassName());
                         runListener.testSucceeded(createReportEntry(testIdentifier, null, elapsed));
                     } else {
                         runListener.testSetCompleted(
@@ -236,6 +252,17 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
         boolean failed = testExecutionResult == null || testExecutionResult.getStatus() == FAILED;
         String methodName = failed || testIdentifier.isTest() ? classMethodName.getMethodSignature() : null;
+        // Distinguish a class-level teardown failure (@AfterAll/@AfterClass) from a setup failure (@BeforeAll):
+        // when a container fails after at least one of its test methods already succeeded, name it "executionError"
+        // so the Maven-side reporter keeps it as a real error rather than a flaky @BeforeAll failure (#3412).
+        if (testExecutionResult != null
+                && testExecutionResult.getStatus() == FAILED
+                && testIdentifier.isContainer()
+                && !testIdentifier.isTest()
+                && methodName == null
+                && classesWithSuccessfulTests.contains(className)) {
+            methodName = EXECUTION_ERROR;
+        }
         String methodText = failed || testIdentifier.isTest() ? classMethodName.getMethodDisplayName() : null;
         if (Objects.equals(methodName, methodText)) {
             methodText = null;
@@ -526,6 +553,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
     void reset() {
         getFailures().clear();
+        classesWithSuccessfulTests.clear();
         testPlan = null;
     }
 

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -46,6 +46,7 @@ import org.apache.maven.surefire.api.util.RunOrderCalculator;
 import org.apache.maven.surefire.api.util.ScanResult;
 import org.apache.maven.surefire.api.util.TestsToRun;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -177,6 +178,37 @@ public class JUnitPlatformProviderTest {
                 .isEqualTo(FailingWithErrorBeforeAllJupiterTest.class.getName());
 
         assertThat(testSetCaptor.getAllValues().get(1).getName()).isNull();
+    }
+
+    @Test
+    public void shouldErrorClassOnAfterAll() throws Exception {
+        TestReportListener<TestOutputReportEntry> listener = mock(TestReportListener.class);
+
+        RunListenerAdapter adapter = new RunListenerAdapter(listener, Stoppable.NOOP);
+        adapter.setRunMode(NORMAL_RUN);
+
+        JUnitPlatformProvider provider =
+                new JUnitPlatformProvider(providerParametersMock(), createLauncherSessionWithListeners(adapter));
+
+        ArgumentCaptor<ReportEntry> testCaptor = ArgumentCaptor.forClass(ReportEntry.class);
+        ArgumentCaptor<TestSetReportEntry> testSetCaptor = ArgumentCaptor.forClass(TestSetReportEntry.class);
+
+        TestsToRun testsToRun = newTestsToRun(FailingWithErrorAfterAllJupiterTest.class);
+        invokeProvider(provider, testsToRun);
+        InOrder inOrder = inOrder(listener);
+        inOrder.verify(listener, times(1)).testSetStarting(testSetCaptor.capture());
+        inOrder.verify(listener, times(1)).testStarting(any(ReportEntry.class));
+        inOrder.verify(listener, times(1)).testSucceeded(any(ReportEntry.class));
+        inOrder.verify(listener, times(1)).testError(testCaptor.capture());
+        inOrder.verify(listener, times(1)).testSetCompleted(testSetCaptor.capture());
+
+        assertThat(testCaptor.getValue().getSourceName())
+                .isEqualTo(FailingWithErrorAfterAllJupiterTest.class.getName());
+        // AfterAll must be reported as executionError (not initializationError) so reporters
+        // keep it as a real error instead of a flaky BeforeAll (#3412).
+        assertThat(testCaptor.getValue().getName()).isEqualTo("executionError");
+        // Teardown failures must not be recorded for rerun of already-passing tests
+        assertThat(adapter.hasFailingTests()).isFalse();
     }
 
     @Test
@@ -1423,6 +1455,17 @@ public class JUnitPlatformProviderTest {
         @BeforeAll
         static void oneTimeSetUp() {
             throw new RuntimeException("oneTimeSetUp() threw an exception");
+        }
+
+        @org.junit.jupiter.api.Test
+        void test() {}
+    }
+
+    static class FailingWithErrorAfterAllJupiterTest {
+
+        @AfterAll
+        static void oneTimeTearDown() {
+            throw new RuntimeException("oneTimeTearDown() threw an exception");
         }
 
         @org.junit.jupiter.api.Test

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -465,6 +465,37 @@ public class RunListenerAdapterTest {
     }
 
     @Test
+    public void notifiedWithExecutionErrorWhenClassFailsAfterSuccessfulTest() throws Exception {
+        // Simulates @AfterAll: a test method already succeeded, then the class container fails.
+        ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
+        EngineDescriptor engineDescriptor = newEngineDescriptor();
+        TestDescriptor classDescriptor = newClassDescriptor();
+        TestDescriptor methodDescriptor = newMethodDescriptor();
+        engineDescriptor.addChild(classDescriptor);
+        classDescriptor.addChild(methodDescriptor);
+
+        TestPlan testPlan = TestPlan.from(singleton(engineDescriptor), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(testPlan);
+
+        TestIdentifier classIdentifier = TestIdentifier.from(classDescriptor);
+        TestIdentifier methodIdentifier = TestIdentifier.from(methodDescriptor);
+
+        adapter.executionStarted(classIdentifier);
+        adapter.executionStarted(methodIdentifier);
+        adapter.executionFinished(methodIdentifier, successful());
+        adapter.executionFinished(classIdentifier, failed(new RuntimeException("AfterAll always fails")));
+
+        verify(listener).testSucceeded(any());
+        verify(listener).testError(entryCaptor.capture());
+
+        ReportEntry entry = entryCaptor.getValue();
+        assertEquals(MyTestClass.class.getTypeName(), entry.getSourceName());
+        assertEquals("executionError", entry.getName());
+        // AfterAll must not be queued for rerun of already-passing tests (#3412)
+        assertThat(adapter.hasFailingTests()).isFalse();
+    }
+
+    @Test
     public void notifiedWithCorrectNamesWhenContainerFailed() throws Exception {
         ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
         TestPlan testPlan = TestPlan.from(


### PR DESCRIPTION
Backport of #3413 (da16ec2) from master, adapted for 3.5.x. The JUnit
Platform provider now names post-success container failures
"executionError" so the reporter keeps them as real errors instead of
misclassifying them as flaky @BeforeAll failures.

Signed-off-by: Olivier Lamy <olamy@apache.org>

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
