### PR TITLE
Fix #3428: resolve parents via TestPlan.getParent for pre-1.8 platforms

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/CucumberJUnit4VintageIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/CucumberJUnit4VintageIT.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import javax.xml.transform.Source;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.TestFile;
+import org.hamcrest.collection.IsIterableWithSize;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.Input;
+import org.xmlunit.xpath.JAXPXPathEngine;
+
+import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaVersion;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Cucumber via JUnit 4 + vintage on JUnit Platform 1.7.2.
+ * {@code TestIdentifier#getParentIdObject()} is absent there, so parent walks must
+ * use {@code TestPlan#getParent} or scenarios are reported as {@code Tests run: 0}
+ * (issue #3428). The modern {@link CucumberIT} stays on Platform 1.13 and cannot
+ * show that regression.
+ */
+@SuppressWarnings("checkstyle:magicnumber")
+public class CucumberJUnit4VintageIT extends SurefireJUnit4IntegrationTestCase {
+
+    @BeforeEach
+    public void setUp() {
+        assumeJavaVersion(17);
+    }
+
+    @Test
+    public void cucumberScenariosCountedOnPlatform17() throws Exception {
+        OutputValidator outputValidator = unpack("cucumber-junit4-vintage-platform-1.7")
+                .executeTest()
+                .verifyErrorFreeLog()
+                .assertTestSuiteResults(1, 0, 0, 0);
+
+        TestFile xmlReportFile = outputValidator.getSurefireReportsXmlFile("TEST-org.sample.cucumber.CucumberTest.xml");
+        xmlReportFile.assertFileExists();
+
+        Source source = Input.fromFile(xmlReportFile.getFile()).build();
+
+        Iterable<Node> ite = new JAXPXPathEngine().selectNodes("//testcase", source);
+        assertThat(ite, IsIterableWithSize.iterableWithSize(1));
+        ite = new JAXPXPathEngine().selectNodes("//testcase[@classname='org.sample.cucumber.CucumberTest']", source);
+        assertThat(ite, IsIterableWithSize.iterableWithSize(1));
+    }
+}

--- a/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/pom.xml
+++ b/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>cucumber-junit4-vintage-platform-1.7</artifactId>
+  <version>1.0</version>
+  <name>Cucumber JUnit4 + vintage on platform 1.7</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <cucumber.version>7.18.1</cucumber.version>
+    <junit5.version>5.7.2</junit5.version>
+    <platform.version>1.7.2</platform.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-java</artifactId>
+      <version>${cucumber.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-junit</artifactId>
+      <version>${cucumber.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>${platform.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.14.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/java/org/sample/cucumber/CucumberTest.java
+++ b/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/java/org/sample/cucumber/CucumberTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.sample.cucumber;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "classpath:org/sample/cucumber", glue = "org.sample.cucumber")
+public class CucumberTest {}

--- a/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/java/org/sample/cucumber/StepDefinitions.java
+++ b/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/java/org/sample/cucumber/StepDefinitions.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.sample.cucumber;
+
+import io.cucumber.java.en.Given;
+
+public class StepDefinitions {
+    @Given("a step that always passes")
+    public void aStepThatAlwaysPasses() {}
+}

--- a/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/resources/org/sample/cucumber/dummy.feature
+++ b/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/resources/org/sample/cucumber/dummy.feature
@@ -1,0 +1,4 @@
+Feature: dummy
+
+  Scenario: Run a dummy cucumber test
+    Given a step that always passes

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -37,12 +37,10 @@ import org.apache.maven.surefire.api.report.Stoppable;
 import org.apache.maven.surefire.api.report.TestOutputReceiver;
 import org.apache.maven.surefire.api.report.TestOutputReportEntry;
 import org.apache.maven.surefire.api.report.TestReportListener;
-import org.apache.maven.surefire.api.util.ReflectionUtils;
 import org.apache.maven.surefire.report.ClassMethodIndexer;
 import org.apache.maven.surefire.report.RunModeSetter;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
-import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -339,15 +337,12 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     }
 
     private TestIdentifier findTopParent(TestIdentifier testIdentifier) {
-        if (!hasParentId(testIdentifier)) {
+        Optional<TestIdentifier> parentOptional = resolveParent(testIdentifier);
+        if (!parentOptional.isPresent()) {
             return testIdentifier;
         }
-        TestIdentifier parent =
-                // Get the parent test identifier using the parent ID object is from 1.10
-                // use deprecated method
-                testPlan.getTestIdentifier(
-                        testIdentifier.getParentIdObject().get().toString());
-        if (!parent.getParentIdObject().isPresent()) {
+        TestIdentifier parent = parentOptional.get();
+        if (!resolveParent(parent).isPresent()) {
             return testIdentifier;
         }
         // Inside a Suite the hierarchy contains a nested engine (like junit-jupiter under
@@ -378,28 +373,21 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     }
 
     /**
-     * Checks if the test identifier has a parent ID but using reflection as it's
-     * only available from 1.8.
+     * Resolve the parent identifier via {@link TestPlan#getParent(TestIdentifier)}.
+     * That API has existed since JUnit Platform 1.0. Prefer it over
+     * {@code TestIdentifier#getParentIdObject()}, which is only available from 1.8 and
+     * previously gated parent walks so pre-1.8 launchers (for example Cucumber via
+     * vintage) lost class-level source names and reported {@code Tests run: 0}.
      *
-     * @param testIdentifier the test identifier to check
-     * @return true if the test identifier has a parent ID, false otherwise
+     * @param testIdentifier the test identifier whose parent is needed
+     * @return the parent, or empty when the identifier is at the root of the plan
      */
-    private boolean hasParentId(TestIdentifier testIdentifier) {
-        Method getParentIdObjectMethod = ReflectionUtils.tryGetMethod(testIdentifier.getClass(), "getParentIdObject");
-        if (getParentIdObjectMethod == null) {
-            return false;
-        }
-        try {
-            Optional<UniqueId> uniqueIdOptional = (Optional<UniqueId>) getParentIdObjectMethod.invoke(testIdentifier);
-            return uniqueIdOptional.isPresent();
-        } catch (Throwable ignore) {
-            // ignore this
-        }
-        return false;
+    private Optional<TestIdentifier> resolveParent(TestIdentifier testIdentifier) {
+        return testPlan.getParent(testIdentifier);
     }
 
     private TestIdentifier findFirstParentContainerAndSourceClass(TestIdentifier testIdentifier) {
-        if (!hasParentId(testIdentifier)
+        if (!resolveParent(testIdentifier).isPresent()
                 || (testIdentifier.isContainer()
                         && testIdentifier
                                 .getSource()
@@ -407,11 +395,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                                 .isPresent())) {
             return testIdentifier;
         }
-        TestIdentifier parent =
-                // Get the parent test identifier using the parent ID object is from 1.10
-                // use deprecated method
-                testPlan.getTestIdentifier(
-                        testIdentifier.getParentIdObject().get().toString());
+        TestIdentifier parent = resolveParent(testIdentifier).get();
         return findFirstParentContainerAndSourceClass(parent);
     }
 

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -695,6 +695,8 @@ public class RunListenerAdapterTest {
         // Cucumber does: SuiteEngine -> SuiteClass -> CucumberEngine -> feature -> scenario.
         // The feature/scenario nodes carry no ClassSource, so the test must be attributed to the
         // enclosing Suite class instead of being dropped (see issue #3264 follow-up / Cucumber IT).
+        // Parent walks must use TestPlan#getParent (Platform 1.0+), not getParentIdObject (1.8+),
+        // otherwise pre-1.8 launchers report Tests run: 0 (issue #3428).
         EngineDescriptor suiteEngine =
                 new EngineDescriptor(UniqueId.forEngine("junit-platform-suite"), "JUnit Platform Suite");
 
@@ -748,6 +750,54 @@ public class RunListenerAdapterTest {
         // No test class exists below the Cucumber engine, so the Suite class is the attribution.
         assertEquals(MySuiteClass.class.getName(), entry.getSourceName());
         assertEquals("Invalid test", entry.getName());
+    }
+
+    @Test
+    public void notifiedWithRunnerClassWhenCucumberScenarioHasNoClassSource() {
+        // Cucumber-via-JUnit hierarchy without Suite: Engine -> runner class -> feature -> scenario.
+        // Scenario nodes have no ClassSource; class-level source must still resolve to the runner
+        // class via TestPlan#getParent so stats buckets match testSetCompleted (issue #3428).
+        EngineDescriptor cucumberEngine = new EngineDescriptor(UniqueId.forEngine("cucumber"), "Cucumber");
+
+        TestDescriptor runnerClass = new ClassTestDescriptor(
+                cucumberEngine.getUniqueId().append("class", MyTestClass.class.getName()),
+                MyTestClass.class,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        cucumberEngine.addChild(runnerClass);
+
+        TestDescriptor feature =
+                new AbstractTestDescriptor(runnerClass.getUniqueId().append("feature", "dummy.feature"), "dummy") {
+                    @Override
+                    public Type getType() {
+                        return Type.CONTAINER;
+                    }
+                };
+        runnerClass.addChild(feature);
+
+        TestDescriptor scenario =
+                new AbstractTestDescriptor(feature.getUniqueId().append("scenario", "1"), "Run a dummy cucumber test") {
+                    @Override
+                    public Type getType() {
+                        return Type.TEST;
+                    }
+                };
+        feature.addChild(scenario);
+
+        TestPlan plan = TestPlan.from(false, singletonList(cucumberEngine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(cucumberEngine));
+        adapter.executionStarted(TestIdentifier.from(runnerClass));
+        adapter.executionStarted(TestIdentifier.from(feature));
+        adapter.executionStarted(TestIdentifier.from(scenario));
+
+        ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
+        adapter.executionFinished(TestIdentifier.from(scenario), successful());
+        verify(listener).testSucceeded(entryCaptor.capture());
+
+        ReportEntry entry = entryCaptor.getValue();
+        assertEquals(MyTestClass.class.getName(), entry.getSourceName());
+        assertEquals("Run a dummy cucumber test", entry.getName());
     }
 
     private static TestIdentifier newMethodIdentifier() throws Exception {


### PR DESCRIPTION
## Summary

Cucumber scenarios can still report `Tests run: 0` when the JUnit Platform on the test classpath is older than 1.8.

`RunListenerAdapter` walked parents through `TestIdentifier.getParentIdObject()`, which only exists from Platform 1.8. On older launchers the walk no-ops, scenarios keep the feature display name as `sourceName`, and `TestSetRunListener` flushes an empty stats bucket for the runner class.

This switches parent resolution to `TestPlan.getParent(TestIdentifier)`, available since Platform 1.0, for both `findTopParent` and `findFirstParentContainerAndSourceClass`.

Fixes #3428

## Test plan

- [x] `mvn -pl surefire-providers/surefire-junit-platform test -Dtest=RunListenerAdapterTest` - 28/28 GREEN (includes new `notifiedWithRunnerClassWhenCucumberScenarioHasNoClassSource`)
- [x] `mvn -pl surefire-providers/surefire-junit-platform test` - 84/84 GREEN
- [x] `mvn -pl surefire-its -Prun-its -Dit.test=CucumberJUnit4VintageIT verify` - GREEN (cucumber-junit + vintage 5.7.2 + platform 1.7.2)