### PR TITLE
Use TestPlan#getParent to attribute tests on older JUnit Platform

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/CucumberLegacyPlatformIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/CucumberLegacyPlatformIT.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import javax.xml.transform.Source;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.TestFile;
+import org.hamcrest.collection.IsIterableWithSize;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.Input;
+import org.xmlunit.xpath.JAXPXPathEngine;
+
+import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaVersion;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Cucumber scenarios run by the Vintage engine must be counted on a JUnit Platform older than 1.8,
+ * where {@code TestIdentifier#getParentIdObject} is not available.
+ */
+public class CucumberLegacyPlatformIT extends SurefireJUnit4IntegrationTestCase {
+
+    @BeforeEach
+    public void setUp() {
+        assumeJavaVersion(17);
+    }
+
+    @Test
+    public void scenariosAreCountedOnLegacyPlatform() {
+        OutputValidator outputValidator =
+                unpack("cucumber-legacy-platform").maven().executeTest().assertTestSuiteResults(2, 0, 0, 0);
+
+        TestFile xmlReportFile =
+                outputValidator.getSurefireReportsXmlFile("TEST-org.sample.cucumber.RunCucumberTest.xml");
+        xmlReportFile.assertFileExists();
+
+        Source source = Input.fromFile(xmlReportFile.getFile()).build();
+
+        Iterable<Node> testCases = new JAXPXPathEngine().selectNodes("//testcase", source);
+        assertThat(testCases, IsIterableWithSize.iterableWithSize(2));
+
+        testCases = new JAXPXPathEngine()
+                .selectNodes("//testcase[@classname='org.sample.cucumber.RunCucumberTest']", source);
+        assertThat(testCases, IsIterableWithSize.iterableWithSize(2));
+    }
+}

--- a/surefire-its/src/test/resources/cucumber-legacy-platform/pom.xml
+++ b/surefire-its/src/test/resources/cucumber-legacy-platform/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>cucumber-legacy-platform</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- JUnit Platform 1.7.x predates TestIdentifier#getParentIdObject -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-bom</artifactId>
+                <version>7.18.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/cucumber-legacy-platform/src/test/java/org/sample/cucumber/RunCucumberTest.java
+++ b/surefire-its/src/test/resources/cucumber-legacy-platform/src/test/java/org/sample/cucumber/RunCucumberTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.sample.cucumber;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "classpath:org/sample/cucumber", glue = "org.sample.cucumber")
+public class RunCucumberTest {}

--- a/surefire-its/src/test/resources/cucumber-legacy-platform/src/test/java/org/sample/cucumber/StepDefs.java
+++ b/surefire-its/src/test/resources/cucumber-legacy-platform/src/test/java/org/sample/cucumber/StepDefs.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.sample.cucumber;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+
+import static org.junit.Assert.assertTrue;
+
+public class StepDefs {
+    private int value;
+
+    @Given("a number {int}")
+    public void aNumber(int value) {
+        this.value = value;
+    }
+
+    @Then("it is positive")
+    public void itIsPositive() {
+        assertTrue(value > 0);
+    }
+}

--- a/surefire-its/src/test/resources/cucumber-legacy-platform/src/test/resources/org/sample/cucumber/numbers.feature
+++ b/surefire-its/src/test/resources/cucumber-legacy-platform/src/test/resources/org/sample/cucumber/numbers.feature
@@ -1,0 +1,9 @@
+Feature: numbers
+
+  Scenario: one is positive
+    Given a number 1
+    Then it is positive
+
+  Scenario: two is positive
+    Given a number 2
+    Then it is positive

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -37,12 +37,10 @@ import org.apache.maven.surefire.api.report.Stoppable;
 import org.apache.maven.surefire.api.report.TestOutputReceiver;
 import org.apache.maven.surefire.api.report.TestOutputReportEntry;
 import org.apache.maven.surefire.api.report.TestReportListener;
-import org.apache.maven.surefire.api.util.ReflectionUtils;
 import org.apache.maven.surefire.report.ClassMethodIndexer;
 import org.apache.maven.surefire.report.RunModeSetter;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
-import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -339,15 +337,12 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     }
 
     private TestIdentifier findTopParent(TestIdentifier testIdentifier) {
-        if (!hasParentId(testIdentifier)) {
+        Optional<TestIdentifier> parentIdentifier = testPlan.getParent(testIdentifier);
+        if (!parentIdentifier.isPresent()) {
             return testIdentifier;
         }
-        TestIdentifier parent =
-                // Get the parent test identifier using the parent ID object is from 1.10
-                // use deprecated method
-                testPlan.getTestIdentifier(
-                        testIdentifier.getParentIdObject().get().toString());
-        if (!parent.getParentIdObject().isPresent()) {
+        TestIdentifier parent = parentIdentifier.get();
+        if (!testPlan.getParent(parent).isPresent()) {
             return testIdentifier;
         }
         // Inside a Suite the hierarchy contains a nested engine (like junit-jupiter under
@@ -377,42 +372,12 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         return false;
     }
 
-    /**
-     * Checks if the test identifier has a parent ID but using reflection as it's
-     * only available from 1.8.
-     *
-     * @param testIdentifier the test identifier to check
-     * @return true if the test identifier has a parent ID, false otherwise
-     */
-    private boolean hasParentId(TestIdentifier testIdentifier) {
-        Method getParentIdObjectMethod = ReflectionUtils.tryGetMethod(testIdentifier.getClass(), "getParentIdObject");
-        if (getParentIdObjectMethod == null) {
-            return false;
-        }
-        try {
-            Optional<UniqueId> uniqueIdOptional = (Optional<UniqueId>) getParentIdObjectMethod.invoke(testIdentifier);
-            return uniqueIdOptional.isPresent();
-        } catch (Throwable ignore) {
-            // ignore this
-        }
-        return false;
-    }
-
     private TestIdentifier findFirstParentContainerAndSourceClass(TestIdentifier testIdentifier) {
-        if (!hasParentId(testIdentifier)
-                || (testIdentifier.isContainer()
-                        && testIdentifier
-                                .getSource()
-                                .filter(ClassSource.class::isInstance)
-                                .isPresent())) {
+        if (testIdentifier.isContainer() && hasClassSource(testIdentifier)) {
             return testIdentifier;
         }
-        TestIdentifier parent =
-                // Get the parent test identifier using the parent ID object is from 1.10
-                // use deprecated method
-                testPlan.getTestIdentifier(
-                        testIdentifier.getParentIdObject().get().toString());
-        return findFirstParentContainerAndSourceClass(parent);
+        Optional<TestIdentifier> parent = testPlan.getParent(testIdentifier);
+        return parent.isPresent() ? findFirstParentContainerAndSourceClass(parent.get()) : testIdentifier;
     }
 
     /**

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -690,6 +690,55 @@ public class RunListenerAdapterTest {
     }
 
     @Test
+    public void notifiedWithRunnerClassNameWhenScenariosHaveNoTestClass() {
+        // Cucumber driven by the Vintage engine: VintageEngine -> RunnerClass -> feature -> scenario.
+        // Only the runner class carries a ClassSource, so the scenarios must be attributed to it.
+        // Attributing them anywhere else splits the per-source statistics from the test set they
+        // belong to and the test set is reported as running no tests at all.
+        EngineDescriptor vintageEngine = new EngineDescriptor(UniqueId.forEngine("junit-vintage"), "JUnit Vintage");
+
+        TestDescriptor runnerClass = new ClassTestDescriptor(
+                vintageEngine.getUniqueId().append("runner", MySuiteClass.class.getName()),
+                MySuiteClass.class,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        vintageEngine.addChild(runnerClass);
+
+        TestDescriptor feature =
+                new AbstractTestDescriptor(runnerClass.getUniqueId().append("feature", "sum.feature"), "Sum test") {
+                    @Override
+                    public Type getType() {
+                        return Type.CONTAINER;
+                    }
+                };
+        runnerClass.addChild(feature);
+
+        TestDescriptor scenario =
+                new AbstractTestDescriptor(feature.getUniqueId().append("scenario", "1"), "Invalid test") {
+                    @Override
+                    public Type getType() {
+                        return Type.TEST;
+                    }
+                };
+        feature.addChild(scenario);
+
+        TestPlan plan = TestPlan.from(false, singletonList(vintageEngine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(vintageEngine));
+        adapter.executionStarted(TestIdentifier.from(runnerClass));
+        adapter.executionStarted(TestIdentifier.from(feature));
+        adapter.executionStarted(TestIdentifier.from(scenario));
+
+        ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
+        adapter.executionFinished(TestIdentifier.from(scenario), failed(new AssertionError("fail")));
+        verify(listener).testFailed(entryCaptor.capture());
+
+        ReportEntry entry = entryCaptor.getValue();
+        assertEquals(MySuiteClass.class.getName(), entry.getSourceName());
+        assertEquals("Invalid test", entry.getName());
+    }
+
+    @Test
     public void notifiedWithSuiteClassNameWhenEngineHasNoTestClass() {
         // Build a Suite hierarchy whose nested engine exposes no test class right below it, as
         // Cucumber does: SuiteEngine -> SuiteClass -> CucumberEngine -> feature -> scenario.


### PR DESCRIPTION
RunListenerAdapter walked the test plan through
TestIdentifier#getParentIdObject, which exists only from JUnit Platform 1.8 and was therefore looked up reflectively. On an older platform the lookup returns nothing, findTopParent hands back the identifier it was given and the class level name stays empty, so tests whose descriptors carry no ClassSource are attributed to the display name of their parent instead of to their test class. Cucumber scenarios are the common case.

The per source statistics introduced by SUREFIRE-1643 are keyed on that name, so the scenarios accumulate under the feature name while the test set completes under the runner class. The two buckets never meet and the test set is reported as having run nothing: "Tests run: 0" on the console and tests="0" with no testcase elements in the XML report.

TestPlan#getParent has been part of the launcher API since 1.0 and returns the same identifier, so use it and drop the reflection.

Add an integration test pinning junit-bom 5.7.2 to cover the case, and a unit test for the Vintage hierarchy that Cucumber produces.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
