### PR TITLE
[BACKPORT 3.5.x] Fix #3428: resolve parents via TestPlan.getParent for pre-1.8 platforms (#3429)

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/CucumberJUnit4VintageIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/CucumberJUnit4VintageIT.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import javax.xml.transform.Source;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.TestFile;
+import org.hamcrest.collection.IsIterableWithSize;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.Input;
+import org.xmlunit.xpath.JAXPXPathEngine;
+
+import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaVersion;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Cucumber via JUnit 4 + vintage on JUnit Platform 1.7.2.
+ * {@code TestIdentifier#getParentIdObject()} is absent there, so parent walks must
+ * use {@code TestPlan#getParent} or scenarios are reported as {@code Tests run: 0}
+ * (issue #3428). The modern {@link CucumberIT} stays on Platform 1.13 and cannot
+ * show that regression.
+ */
+@SuppressWarnings("checkstyle:magicnumber")
+public class CucumberJUnit4VintageIT extends SurefireJUnit4IntegrationTestCase {
+
+    @Before
+    public void setUp() {
+        assumeJavaVersion(17);
+    }
+
+    @Test
+    public void cucumberScenariosCountedOnPlatform17() throws Exception {
+        OutputValidator outputValidator = unpack("cucumber-junit4-vintage-platform-1.7")
+                .executeTest()
+                .verifyErrorFreeLog()
+                .assertTestSuiteResults(1, 0, 0, 0);
+
+        TestFile xmlReportFile = outputValidator.getSurefireReportsXmlFile("TEST-org.sample.cucumber.CucumberTest.xml");
+        xmlReportFile.assertFileExists();
+
+        Source source = Input.fromFile(xmlReportFile.getFile()).build();
+
+        Iterable<Node> ite = new JAXPXPathEngine().selectNodes("//testcase", source);
+        assertThat(ite, IsIterableWithSize.iterableWithSize(1));
+        ite = new JAXPXPathEngine().selectNodes("//testcase[@classname='org.sample.cucumber.CucumberTest']", source);
+        assertThat(ite, IsIterableWithSize.iterableWithSize(1));
+    }
+}

--- a/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/pom.xml
+++ b/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>cucumber-junit4-vintage-platform-1.7</artifactId>
+  <version>1.0</version>
+  <name>Cucumber JUnit4 + vintage on platform 1.7</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <cucumber.version>7.18.1</cucumber.version>
+    <junit5.version>5.7.2</junit5.version>
+    <platform.version>1.7.2</platform.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-java</artifactId>
+      <version>${cucumber.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-junit</artifactId>
+      <version>${cucumber.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>${platform.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.14.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/java/org/sample/cucumber/CucumberTest.java
+++ b/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/java/org/sample/cucumber/CucumberTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.sample.cucumber;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "classpath:org/sample/cucumber", glue = "org.sample.cucumber")
+public class CucumberTest {}

--- a/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/java/org/sample/cucumber/StepDefinitions.java
+++ b/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/java/org/sample/cucumber/StepDefinitions.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.sample.cucumber;
+
+import io.cucumber.java.en.Given;
+
+public class StepDefinitions {
+    @Given("a step that always passes")
+    public void aStepThatAlwaysPasses() {}
+}

--- a/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/resources/org/sample/cucumber/dummy.feature
+++ b/surefire-its/src/test/resources/cucumber-junit4-vintage-platform-1.7/src/test/resources/org/sample/cucumber/dummy.feature
@@ -1,0 +1,4 @@
+Feature: dummy
+
+  Scenario: Run a dummy cucumber test
+    Given a step that always passes

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -37,13 +37,11 @@ import org.apache.maven.surefire.api.report.Stoppable;
 import org.apache.maven.surefire.api.report.TestOutputReceiver;
 import org.apache.maven.surefire.api.report.TestOutputReportEntry;
 import org.apache.maven.surefire.api.report.TestReportListener;
-import org.apache.maven.surefire.api.util.ReflectionUtils;
 import org.apache.maven.surefire.report.ClassMethodIndexer;
 import org.apache.maven.surefire.report.PojoStackTraceWriter;
 import org.apache.maven.surefire.report.RunModeSetter;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
-import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -320,39 +318,30 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     }
 
     private TestIdentifier findTopParent(TestIdentifier testIdentifier) {
-        if (!hasParentId(testIdentifier)) {
+        Optional<TestIdentifier> parentOptional = resolveParent(testIdentifier);
+        if (!parentOptional.isPresent()) {
             return testIdentifier;
         }
-        TestIdentifier parent =
-                // Get the parent test identifier using the parent ID object is from 1.10
-                // use deprecated method
-                testPlan.getTestIdentifier(
-                        testIdentifier.getParentIdObject().get().toString());
-        return !parent.getParentIdObject().isPresent() ? testIdentifier : findTopParent(parent);
+        TestIdentifier parent = parentOptional.get();
+        return !resolveParent(parent).isPresent() ? testIdentifier : findTopParent(parent);
     }
 
     /**
-     * Checks if the test identifier has a parent ID but using reflection as it's only available from 1.8.
+     * Resolve the parent identifier via {@link TestPlan#getParent(TestIdentifier)}.
+     * That API has existed since JUnit Platform 1.0. Prefer it over
+     * {@code TestIdentifier#getParentIdObject()}, which is only available from 1.8 and
+     * previously gated parent walks so pre-1.8 launchers (for example Cucumber via
+     * vintage) lost class-level source names and reported {@code Tests run: 0}.
      *
-     * @param testIdentifier the test identifier to check
-     * @return true if the test identifier has a parent ID, false otherwise
+     * @param testIdentifier the test identifier whose parent is needed
+     * @return the parent, or empty when the identifier is at the root of the plan
      */
-    private boolean hasParentId(TestIdentifier testIdentifier) {
-        Method getParentIdObjectMethod = ReflectionUtils.tryGetMethod(testIdentifier.getClass(), "getParentIdObject");
-        if (getParentIdObjectMethod == null) {
-            return false;
-        }
-        try {
-            Optional<UniqueId> uniqueIdOptional = (Optional<UniqueId>) getParentIdObjectMethod.invoke(testIdentifier);
-            return uniqueIdOptional.isPresent();
-        } catch (Throwable ignore) {
-            // ignore this
-        }
-        return false;
+    private Optional<TestIdentifier> resolveParent(TestIdentifier testIdentifier) {
+        return testPlan.getParent(testIdentifier);
     }
 
     private TestIdentifier findFirstParentContainerAndSourceClass(TestIdentifier testIdentifier) {
-        if (!hasParentId(testIdentifier)
+        if (!resolveParent(testIdentifier).isPresent()
                 || (testIdentifier.isContainer()
                         && testIdentifier
                                 .getSource()
@@ -360,11 +349,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                                 .isPresent())) {
             return testIdentifier;
         }
-        TestIdentifier parent =
-                // Get the parent test identifier using the parent ID object is from 1.10
-                // use deprecated method
-                testPlan.getTestIdentifier(
-                        testIdentifier.getParentIdObject().get().toString());
+        TestIdentifier parent = resolveParent(testIdentifier).get();
         return findFirstParentContainerAndSourceClass(parent);
     }
 

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -633,6 +633,54 @@ public class RunListenerAdapterTest {
         assertEquals("some display name", value.getNameText());
     }
 
+    @Test
+    public void notifiedWithRunnerClassWhenCucumberScenarioHasNoClassSource() {
+        // Cucumber-via-JUnit hierarchy: Engine -> runner class -> feature -> scenario.
+        // Scenario nodes have no ClassSource; class-level source must still resolve to the runner
+        // class via TestPlan#getParent so stats buckets match testSetCompleted (issue #3428).
+        EngineDescriptor cucumberEngine = new EngineDescriptor(UniqueId.forEngine("cucumber"), "Cucumber");
+
+        TestDescriptor runnerClass = new ClassTestDescriptor(
+                cucumberEngine.getUniqueId().append("class", MyTestClass.class.getName()),
+                MyTestClass.class,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        cucumberEngine.addChild(runnerClass);
+
+        TestDescriptor feature =
+                new AbstractTestDescriptor(runnerClass.getUniqueId().append("feature", "dummy.feature"), "dummy") {
+                    @Override
+                    public Type getType() {
+                        return Type.CONTAINER;
+                    }
+                };
+        runnerClass.addChild(feature);
+
+        TestDescriptor scenario =
+                new AbstractTestDescriptor(feature.getUniqueId().append("scenario", "1"), "Run a dummy cucumber test") {
+                    @Override
+                    public Type getType() {
+                        return Type.TEST;
+                    }
+                };
+        feature.addChild(scenario);
+
+        TestPlan plan = TestPlan.from(singletonList(cucumberEngine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(cucumberEngine));
+        adapter.executionStarted(TestIdentifier.from(runnerClass));
+        adapter.executionStarted(TestIdentifier.from(feature));
+        adapter.executionStarted(TestIdentifier.from(scenario));
+
+        ArgumentCaptor<ReportEntry> entryCaptor = ArgumentCaptor.forClass(ReportEntry.class);
+        adapter.executionFinished(TestIdentifier.from(scenario), successful());
+        verify(listener).testSucceeded(entryCaptor.capture());
+
+        ReportEntry entry = entryCaptor.getValue();
+        assertEquals(MyTestClass.class.getName(), entry.getSourceName());
+        assertEquals("Run a dummy cucumber test", entry.getName());
+    }
+
     private static TestIdentifier newMethodIdentifier() throws Exception {
         return TestIdentifier.from(newMethodDescriptor());
     }


### PR DESCRIPTION
Backport of #3429 (909444c) from master, adapted for 3.5.x, as requested in https://github.com/apache/maven-surefire/pull/3429#issuecomment-5277757345.

Fixes #3428 on the 3.5.x line. `RunListenerAdapter` walked parents through `TestIdentifier.getParentIdObject()`, which only exists from JUnit Platform 1.8. On older launchers the walk no-ops, Cucumber scenarios keep the feature display name as `sourceName`, and `TestSetRunListener` flushes an empty stats bucket for the runner class, so the run reports `Tests run: 0`. Parent resolution now goes through `TestPlan.getParent(TestIdentifier)`, available since Platform 1.0.

### Not a clean cherry-pick

`git cherry-pick 909444cba` conflicts in `RunListenerAdapter.java` and `RunListenerAdapterTest.java`, because master has Suite-boundary handling in `findTopParent` (`isEngineIdentifier` / `hasClassSource`) that landed after 3.5.x branched. Resolved by hand:

- Only the parent-resolution change is taken. The Suite-boundary logic is not pulled in, and the surrounding 3.5.x logic is left as-is.
- Of the three unit tests touched on master, only the new `notifiedWithRunnerClassWhenCucumberScenarioHasNoClassSource` is backported. The two Suite-hierarchy tests it sits next to do not exist on this branch.
- `CucumberJUnit4VintageIT` uses JUnit 4 annotations, matching the rest of `surefire-its` on 3.5.x (master has since migrated the ITs to JUnit 5).

### Verification

`CucumberJUnit4VintageIT` (cucumber-junit + vintage 5.7.2 + platform 1.7.2) was run both ways on this branch, since the unit test alone cannot reproduce the bug — the unit-test JVM has a modern Platform where `getParentIdObject` is present:

- with this change: `Tests run: 1, Failures: 0, Errors: 0`
- against unmodified `surefire-3.5.x`: `cucumberScenariosCountedOnPlatform17:56 wrong number of tests expected:<1> but was:<0>`

`RunListenerAdapterTest` shows no change in results before and after.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
