### PR TITLE
Fix #3303: distinguish JUnit 6 ParameterizedClass invocations

### DIFF
--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -283,6 +283,32 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                 .orElseGet(Stream::empty);
     }
 
+    /**
+     * Extract the invocation index from a JUnit Jupiter {@code [class-template-invocation:#N]} unique-id
+     * segment. JUnit 6 {@code @ParameterizedClass} uses this segment; the method-level legacy name
+     * no longer carries the {@code [N]} suffix that {@code @ParameterizedTest} still has.
+     *
+     * @param uniqueId the platform unique id string
+     * @return the numeric index, or {@code null} when the id has no class-template invocation
+     */
+    private static String extractClassTemplateInvocationIndex(String uniqueId) {
+        if (uniqueId == null) {
+            return null;
+        }
+        String marker = "[class-template-invocation:";
+        int start = uniqueId.lastIndexOf(marker);
+        if (start < 0) {
+            return null;
+        }
+        start += marker.length();
+        int end = uniqueId.indexOf(']', start);
+        if (end <= start) {
+            return null;
+        }
+        String value = uniqueId.substring(start, end);
+        return value.startsWith("#") ? value.substring(1) : value;
+    }
+
     private String safeGetMessage(Throwable throwable) {
         try {
             SafeThrowable t = throwable == null ? null : new SafeThrowable(throwable);
@@ -553,14 +579,22 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                     .map(TestIdentifier::getLegacyReportingName)
                     .anyMatch(legacyReportingName -> legacyReportingName.matches("^\\[.+]$"));
             boolean isTestTemplate = testIdentifier.getLegacyReportingName().matches("^.*\\[\\d+]$");
+            // JUnit 6 @ParameterizedClass parents have a ClassSource, so they are missed by
+            // hasParameterizedParent, and the method legacy name no longer includes [N] (#3303).
+            String classTemplateInvocationIndex = extractClassTemplateInvocationIndex(testIdentifier.getUniqueId());
 
-            boolean parameterized = isParameterized || hasParameterizedParent || isTestTemplate;
+            boolean parameterized =
+                    isParameterized || hasParameterizedParent || isTestTemplate || classTemplateInvocationIndex != null;
             String methodName = methodSource.getMethodName();
             String description = testIdentifier.getLegacyReportingName();
             boolean equalDescriptions = methodDisplay.equals(description);
             boolean hasLegacyDescription = description.startsWith(methodName + '(');
             boolean hasDisplayName = !equalDescriptions || !hasLegacyDescription;
             String methodDesc = parameterized ? description : methodName;
+            if (classTemplateInvocationIndex != null
+                    && !methodDesc.endsWith("[" + classTemplateInvocationIndex + "]")) {
+                methodDesc = methodDesc + "[" + classTemplateInvocationIndex + "]";
+            }
             String methodDisp = hasDisplayName ? methodDisplay : methodDesc;
 
             // The behavior of methods getLegacyReportingName() and getDisplayName().

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -284,29 +284,39 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     }
 
     /**
-     * Extract the invocation index from a JUnit Jupiter {@code [class-template-invocation:#N]} unique-id
-     * segment. JUnit 6 {@code @ParameterizedClass} uses this segment; the method-level legacy name
-     * no longer carries the {@code [N]} suffix that {@code @ParameterizedTest} still has.
+     * Build a {@code [outer][inner]} suffix from every JUnit Jupiter
+     * {@code [class-template-invocation:#N]} unique-id segment. Nested
+     * {@code @ParameterizedClass} declarations emit more than one; taking only
+     * the last would collapse outer #1/inner #1 with outer #2/inner #1.
      *
      * @param uniqueId the platform unique id string
-     * @return the numeric index, or {@code null} when the id has no class-template invocation
+     * @return the suffix, or an empty string when the id has no class-template invocation
      */
-    private static String extractClassTemplateInvocationIndex(String uniqueId) {
+    private static String extractClassTemplateInvocationSuffix(String uniqueId) {
         if (uniqueId == null) {
-            return null;
+            return "";
         }
         String marker = "[class-template-invocation:";
-        int start = uniqueId.lastIndexOf(marker);
-        if (start < 0) {
-            return null;
+        StringBuilder suffix = new StringBuilder();
+        int from = 0;
+        while (true) {
+            int start = uniqueId.indexOf(marker, from);
+            if (start < 0) {
+                break;
+            }
+            start += marker.length();
+            int end = uniqueId.indexOf(']', start);
+            if (end <= start) {
+                break;
+            }
+            String value = uniqueId.substring(start, end);
+            if (value.startsWith("#")) {
+                value = value.substring(1);
+            }
+            suffix.append('[').append(value).append(']');
+            from = end + 1;
         }
-        start += marker.length();
-        int end = uniqueId.indexOf(']', start);
-        if (end <= start) {
-            return null;
-        }
-        String value = uniqueId.substring(start, end);
-        return value.startsWith("#") ? value.substring(1) : value;
+        return suffix.toString();
     }
 
     private String safeGetMessage(Throwable throwable) {
@@ -581,19 +591,23 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
             boolean isTestTemplate = testIdentifier.getLegacyReportingName().matches("^.*\\[\\d+]$");
             // JUnit 6 @ParameterizedClass parents have a ClassSource, so they are missed by
             // hasParameterizedParent, and the method legacy name no longer includes [N] (#3303).
-            String classTemplateInvocationIndex = extractClassTemplateInvocationIndex(testIdentifier.getUniqueId());
+            String classTemplateInvocationSuffix = extractClassTemplateInvocationSuffix(testIdentifier.getUniqueId());
 
-            boolean parameterized =
-                    isParameterized || hasParameterizedParent || isTestTemplate || classTemplateInvocationIndex != null;
+            boolean parameterized = isParameterized
+                    || hasParameterizedParent
+                    || isTestTemplate
+                    || !classTemplateInvocationSuffix.isEmpty();
             String methodName = methodSource.getMethodName();
             String description = testIdentifier.getLegacyReportingName();
             boolean equalDescriptions = methodDisplay.equals(description);
             boolean hasLegacyDescription = description.startsWith(methodName + '(');
             boolean hasDisplayName = !equalDescriptions || !hasLegacyDescription;
             String methodDesc = parameterized ? description : methodName;
-            if (classTemplateInvocationIndex != null
-                    && !methodDesc.endsWith("[" + classTemplateInvocationIndex + "]")) {
-                methodDesc = methodDesc + "[" + classTemplateInvocationIndex + "]";
+            // JUnit 6.1+ already puts the class index before a method invocation index
+            // (method()[1][2]); do not append again just because the name does not end
+            // with the last class index.
+            if (!classTemplateInvocationSuffix.isEmpty() && !methodDesc.contains(classTemplateInvocationSuffix)) {
+                methodDesc = methodDesc + classTemplateInvocationSuffix;
             }
             String methodDisp = hasDisplayName ? methodDisplay : methodDesc;
 

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -284,39 +284,34 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     }
 
     /**
-     * Build a {@code [outer][inner]} suffix from every JUnit Jupiter
-     * {@code [class-template-invocation:#N]} unique-id segment. Nested
-     * {@code @ParameterizedClass} declarations emit more than one; taking only
-     * the last would collapse outer #1/inner #1 with outer #2/inner #1.
+     * Collect every {@code [class-template-invocation:#N]} / {@code [test-template-invocation:#N]}
+     * index from the unique id. Nested {@code @ParameterizedClass} declarations emit more than
+     * one class segment; taking only the last would collapse outer #1/inner #1 with outer #2/inner #1.
      *
      * @param uniqueId the platform unique id string
-     * @return the suffix, or an empty string when the id has no class-template invocation
+     * @param segmentType {@code class-template-invocation} or {@code test-template-invocation}
+     * @return {@code [outer][inner]} or empty when the id has no such segment
      */
-    private static String extractClassTemplateInvocationSuffix(String uniqueId) {
-        if (uniqueId == null) {
+    private static String extractInvocationIndexSuffix(String uniqueId, String segmentType) {
+        if (uniqueId == null || uniqueId.isEmpty()) {
             return "";
         }
-        String marker = "[class-template-invocation:";
-        StringBuilder suffix = new StringBuilder();
-        int from = 0;
-        while (true) {
-            int start = uniqueId.indexOf(marker, from);
-            if (start < 0) {
-                break;
+        try {
+            StringBuilder suffix = new StringBuilder();
+            for (UniqueId.Segment segment : UniqueId.parse(uniqueId).getSegments()) {
+                if (!segmentType.equals(segment.getType())) {
+                    continue;
+                }
+                String value = segment.getValue();
+                if (value.startsWith("#")) {
+                    value = value.substring(1);
+                }
+                suffix.append('[').append(value).append(']');
             }
-            start += marker.length();
-            int end = uniqueId.indexOf(']', start);
-            if (end <= start) {
-                break;
-            }
-            String value = uniqueId.substring(start, end);
-            if (value.startsWith("#")) {
-                value = value.substring(1);
-            }
-            suffix.append('[').append(value).append(']');
-            from = end + 1;
+            return suffix.toString();
+        } catch (RuntimeException ignored) {
+            return "";
         }
-        return suffix.toString();
     }
 
     private String safeGetMessage(Throwable throwable) {
@@ -591,7 +586,9 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
             boolean isTestTemplate = testIdentifier.getLegacyReportingName().matches("^.*\\[\\d+]$");
             // JUnit 6 @ParameterizedClass parents have a ClassSource, so they are missed by
             // hasParameterizedParent, and the method legacy name no longer includes [N] (#3303).
-            String classTemplateInvocationSuffix = extractClassTemplateInvocationSuffix(testIdentifier.getUniqueId());
+            String uniqueId = testIdentifier.getUniqueId();
+            String classTemplateInvocationSuffix = extractInvocationIndexSuffix(uniqueId, "class-template-invocation");
+            String testTemplateInvocationSuffix = extractInvocationIndexSuffix(uniqueId, "test-template-invocation");
 
             boolean parameterized = isParameterized
                     || hasParameterizedParent
@@ -603,11 +600,20 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
             boolean hasLegacyDescription = description.startsWith(methodName + '(');
             boolean hasDisplayName = !equalDescriptions || !hasLegacyDescription;
             String methodDesc = parameterized ? description : methodName;
-            // JUnit 6.1+ already puts the class index before a method invocation index
-            // (method()[1][2]); do not append again just because the name does not end
-            // with the last class index.
-            if (!classTemplateInvocationSuffix.isEmpty() && !methodDesc.contains(classTemplateInvocationSuffix)) {
-                methodDesc = methodDesc + classTemplateInvocationSuffix;
+            // Rebuild as [class][method]. A contains() check on the class index alone
+            // treated foo()[2] (method #2) as already tagged for class #2, and
+            // foo()[1] + class #2 became foo()[1][2] instead of foo()[2][1].
+            if (!classTemplateInvocationSuffix.isEmpty()) {
+                String desired = classTemplateInvocationSuffix + testTemplateInvocationSuffix;
+                if (!methodDesc.endsWith(desired)) {
+                    if (!testTemplateInvocationSuffix.isEmpty() && methodDesc.endsWith(testTemplateInvocationSuffix)) {
+                        methodDesc =
+                                methodDesc.substring(0, methodDesc.length() - testTemplateInvocationSuffix.length())
+                                        + desired;
+                    } else {
+                        methodDesc = methodDesc + classTemplateInvocationSuffix;
+                    }
+                }
             }
             String methodDisp = hasDisplayName ? methodDisplay : methodDesc;
 

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -287,6 +287,80 @@ public class RunListenerAdapterTest {
     }
 
     @Test
+    public void distinguishedNestedJUnit6ParameterizedClassInvocations() throws Exception {
+        EngineDescriptor engine = new EngineDescriptor(UniqueId.forEngine("junit-jupiter"), "JUnit Jupiter");
+        TestDescriptor outerTemplate = newParameterizedClassTemplateDescriptor(engine.getUniqueId());
+        engine.addChild(outerTemplate);
+
+        TestDescriptor outer1 = newParameterizedClassInvocationDescriptor(outerTemplate.getUniqueId(), 1);
+        TestDescriptor innerTemplate1 = newParameterizedClassTemplateDescriptor(outer1.getUniqueId());
+        TestDescriptor inner1 = newParameterizedClassInvocationDescriptor(innerTemplate1.getUniqueId(), 1);
+        TestDescriptor method11 = newUnparameterizedMethodDescriptor(inner1.getUniqueId());
+        outerTemplate.addChild(outer1);
+        outer1.addChild(innerTemplate1);
+        innerTemplate1.addChild(inner1);
+        inner1.addChild(method11);
+
+        TestDescriptor outer2 = newParameterizedClassInvocationDescriptor(outerTemplate.getUniqueId(), 2);
+        TestDescriptor innerTemplate2 = newParameterizedClassTemplateDescriptor(outer2.getUniqueId());
+        TestDescriptor inner2 = newParameterizedClassInvocationDescriptor(innerTemplate2.getUniqueId(), 1);
+        TestDescriptor method21 = newUnparameterizedMethodDescriptor(inner2.getUniqueId());
+        outerTemplate.addChild(outer2);
+        outer2.addChild(innerTemplate2);
+        innerTemplate2.addChild(inner2);
+        inner2.addChild(method21);
+
+        TestPlan plan = TestPlan.from(false, singletonList(engine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(engine));
+        adapter.executionStarted(TestIdentifier.from(outerTemplate));
+        adapter.executionStarted(TestIdentifier.from(outer1));
+        adapter.executionStarted(TestIdentifier.from(innerTemplate1));
+        adapter.executionStarted(TestIdentifier.from(inner1));
+        adapter.executionStarted(TestIdentifier.from(method11));
+        adapter.executionFinished(TestIdentifier.from(method11), successful());
+        adapter.executionStarted(TestIdentifier.from(outer2));
+        adapter.executionStarted(TestIdentifier.from(innerTemplate2));
+        adapter.executionStarted(TestIdentifier.from(inner2));
+        adapter.executionStarted(TestIdentifier.from(method21));
+        adapter.executionFinished(TestIdentifier.from(method21), failed(new AssertionError("fail")));
+
+        ArgumentCaptor<ReportEntry> started = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener, times(2)).testStarting(started.capture());
+        assertEquals(
+                MY_TEST_METHOD_NAME + "()[1][1]", started.getAllValues().get(0).getName());
+        assertEquals(
+                MY_TEST_METHOD_NAME + "()[2][1]", started.getAllValues().get(1).getName());
+    }
+
+    @Test
+    public void doesNotReappendClassIndexWhenLegacyNameAlreadyHasIt() throws Exception {
+        // JUnit 6.1+ parameterized methods already report method()[class][method].
+        EngineDescriptor engine = new EngineDescriptor(UniqueId.forEngine("junit-jupiter"), "JUnit Jupiter");
+        TestDescriptor classTemplate = newParameterizedClassTemplateDescriptor(engine.getUniqueId());
+        engine.addChild(classTemplate);
+
+        TestDescriptor invocation = newParameterizedClassInvocationDescriptor(classTemplate.getUniqueId(), 1);
+        TestDescriptor method = newLegacyIndexedMethodDescriptor(invocation.getUniqueId(), "()[1][2]");
+        classTemplate.addChild(invocation);
+        invocation.addChild(method);
+
+        TestPlan plan = TestPlan.from(false, singletonList(engine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(engine));
+        adapter.executionStarted(TestIdentifier.from(classTemplate));
+        adapter.executionStarted(TestIdentifier.from(invocation));
+        adapter.executionStarted(TestIdentifier.from(method));
+        adapter.executionFinished(TestIdentifier.from(method), successful());
+
+        ArgumentCaptor<ReportEntry> started = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener).testStarting(started.capture());
+        assertEquals(MY_TEST_METHOD_NAME + "()[1][2]", started.getValue().getName());
+    }
+
+    @Test
     public void notifiedEagerlyForTestSetWhenClassExecutionStarted() throws Exception {
         EngineDescriptor engine = newEngineDescriptor();
         TestDescriptor parent = newClassDescriptor();
@@ -1045,6 +1119,11 @@ public class RunListenerAdapterTest {
     }
 
     private static TestDescriptor newUnparameterizedMethodDescriptor(UniqueId parentId) throws Exception {
+        return newLegacyIndexedMethodDescriptor(parentId, "()");
+    }
+
+    private static TestDescriptor newLegacyIndexedMethodDescriptor(UniqueId parentId, String legacySuffix)
+            throws Exception {
         Method method = MyTestClass.class.getDeclaredMethod(MY_TEST_METHOD_NAME);
         return new AbstractTestDescriptor(
                 parentId.append("method", method.getName() + "()"),
@@ -1057,8 +1136,7 @@ public class RunListenerAdapterTest {
 
             @Override
             public String getLegacyReportingName() {
-                // JUnit 6 keeps the method legacy name without the class-invocation index.
-                return method.getName() + "()";
+                return method.getName() + legacySuffix;
             }
         };
     }

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -342,7 +342,7 @@ public class RunListenerAdapterTest {
         engine.addChild(classTemplate);
 
         TestDescriptor invocation = newParameterizedClassInvocationDescriptor(classTemplate.getUniqueId(), 1);
-        TestDescriptor method = newLegacyIndexedMethodDescriptor(invocation.getUniqueId(), "()[1][2]");
+        TestDescriptor method = newLegacyIndexedMethodDescriptor(invocation.getUniqueId(), "()[1][2]", 2);
         classTemplate.addChild(invocation);
         invocation.addChild(method);
 
@@ -358,6 +358,57 @@ public class RunListenerAdapterTest {
         ArgumentCaptor<ReportEntry> started = ArgumentCaptor.forClass(ReportEntry.class);
         verify(listener).testStarting(started.capture());
         assertEquals(MY_TEST_METHOD_NAME + "()[1][2]", started.getValue().getName());
+    }
+
+    @Test
+    public void classIndexGoesBeforeMethodIndexWhenLegacyNameOnlyHasMethodIndex() throws Exception {
+        // JUnit 6.0 @ParameterizedTest under @ParameterizedClass: legacy is foo()[m] only.
+        EngineDescriptor engine = new EngineDescriptor(UniqueId.forEngine("junit-jupiter"), "JUnit Jupiter");
+        TestDescriptor classTemplate = newParameterizedClassTemplateDescriptor(engine.getUniqueId());
+        engine.addChild(classTemplate);
+
+        TestDescriptor invocation = newParameterizedClassInvocationDescriptor(classTemplate.getUniqueId(), 2);
+        TestDescriptor method = newLegacyIndexedMethodDescriptor(invocation.getUniqueId(), "()[1]", 1);
+        classTemplate.addChild(invocation);
+        invocation.addChild(method);
+
+        TestPlan plan = TestPlan.from(false, singletonList(engine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(engine));
+        adapter.executionStarted(TestIdentifier.from(classTemplate));
+        adapter.executionStarted(TestIdentifier.from(invocation));
+        adapter.executionStarted(TestIdentifier.from(method));
+        adapter.executionFinished(TestIdentifier.from(method), successful());
+
+        ArgumentCaptor<ReportEntry> started = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener).testStarting(started.capture());
+        assertEquals(MY_TEST_METHOD_NAME + "()[2][1]", started.getValue().getName());
+    }
+
+    @Test
+    public void classAndMethodIndexOnTheDiagonalStayDistinct() throws Exception {
+        EngineDescriptor engine = new EngineDescriptor(UniqueId.forEngine("junit-jupiter"), "JUnit Jupiter");
+        TestDescriptor classTemplate = newParameterizedClassTemplateDescriptor(engine.getUniqueId());
+        engine.addChild(classTemplate);
+
+        TestDescriptor invocation = newParameterizedClassInvocationDescriptor(classTemplate.getUniqueId(), 2);
+        TestDescriptor method = newLegacyIndexedMethodDescriptor(invocation.getUniqueId(), "()[2]", 2);
+        classTemplate.addChild(invocation);
+        invocation.addChild(method);
+
+        TestPlan plan = TestPlan.from(false, singletonList(engine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(engine));
+        adapter.executionStarted(TestIdentifier.from(classTemplate));
+        adapter.executionStarted(TestIdentifier.from(invocation));
+        adapter.executionStarted(TestIdentifier.from(method));
+        adapter.executionFinished(TestIdentifier.from(method), successful());
+
+        ArgumentCaptor<ReportEntry> started = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener).testStarting(started.capture());
+        assertEquals(MY_TEST_METHOD_NAME + "()[2][2]", started.getValue().getName());
     }
 
     @Test
@@ -1124,11 +1175,18 @@ public class RunListenerAdapterTest {
 
     private static TestDescriptor newLegacyIndexedMethodDescriptor(UniqueId parentId, String legacySuffix)
             throws Exception {
+        return newLegacyIndexedMethodDescriptor(parentId, legacySuffix, 0);
+    }
+
+    private static TestDescriptor newLegacyIndexedMethodDescriptor(
+            UniqueId parentId, String legacySuffix, int testTemplateInvocationIndex) throws Exception {
         Method method = MyTestClass.class.getDeclaredMethod(MY_TEST_METHOD_NAME);
+        UniqueId methodId = parentId.append("method", method.getName() + "()");
+        if (testTemplateInvocationIndex > 0) {
+            methodId = methodId.append("test-template-invocation", "#" + testTemplateInvocationIndex);
+        }
         return new AbstractTestDescriptor(
-                parentId.append("method", method.getName() + "()"),
-                method.getName() + "()",
-                MethodSource.from(MyTestClass.class, method)) {
+                methodId, method.getName() + "()", MethodSource.from(MyTestClass.class, method)) {
             @Override
             public Type getType() {
                 return TEST;

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -240,6 +240,53 @@ public class RunListenerAdapterTest {
     }
 
     @Test
+    public void distinguishedJUnit6ParameterizedClassInvocationsByIndex() throws Exception {
+        // JUnit 6 @ParameterizedClass uses [class-template-invocation:#N] parents with a ClassSource.
+        // The method's own legacy name has no [N] suffix (unlike JUnit 5.14 / @ParameterizedTest),
+        // so invocations must still be reported under distinct names or rerunFailingTestsCount
+        // aggregates a pass+fail pair as a flake (#3303).
+        EngineDescriptor engine = new EngineDescriptor(UniqueId.forEngine("junit-jupiter"), "JUnit Jupiter");
+        TestDescriptor classTemplate = newParameterizedClassTemplateDescriptor(engine.getUniqueId());
+        engine.addChild(classTemplate);
+
+        TestDescriptor invocation1 = newParameterizedClassInvocationDescriptor(classTemplate.getUniqueId(), 1);
+        TestDescriptor method1 = newUnparameterizedMethodDescriptor(invocation1.getUniqueId());
+        classTemplate.addChild(invocation1);
+        invocation1.addChild(method1);
+
+        TestDescriptor invocation2 = newParameterizedClassInvocationDescriptor(classTemplate.getUniqueId(), 2);
+        TestDescriptor method2 = newUnparameterizedMethodDescriptor(invocation2.getUniqueId());
+        classTemplate.addChild(invocation2);
+        invocation2.addChild(method2);
+
+        TestPlan plan = TestPlan.from(false, singletonList(engine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(engine));
+        adapter.executionStarted(TestIdentifier.from(classTemplate));
+        adapter.executionStarted(TestIdentifier.from(invocation1));
+        adapter.executionStarted(TestIdentifier.from(method1));
+        adapter.executionFinished(TestIdentifier.from(method1), successful());
+        adapter.executionFinished(TestIdentifier.from(invocation1), successful());
+        adapter.executionStarted(TestIdentifier.from(invocation2));
+        adapter.executionStarted(TestIdentifier.from(method2));
+        adapter.executionFinished(TestIdentifier.from(method2), failed(new AssertionError("fail")));
+
+        ArgumentCaptor<ReportEntry> started = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener, times(2)).testStarting(started.capture());
+        assertEquals(
+                MY_TEST_METHOD_NAME + "()[1]", started.getAllValues().get(0).getName());
+        assertEquals(
+                MY_TEST_METHOD_NAME + "()[2]", started.getAllValues().get(1).getName());
+
+        ArgumentCaptor<ReportEntry> failed = ArgumentCaptor.forClass(ReportEntry.class);
+        verify(listener).testFailed(failed.capture());
+        assertEquals(MY_TEST_METHOD_NAME + "()[2]", failed.getValue().getName());
+        assertThat(failed.getValue().getName())
+                .isNotEqualTo(started.getAllValues().get(0).getName());
+    }
+
+    @Test
     public void notifiedEagerlyForTestSetWhenClassExecutionStarted() throws Exception {
         EngineDescriptor engine = newEngineDescriptor();
         TestDescriptor parent = newClassDescriptor();
@@ -971,6 +1018,49 @@ public class RunListenerAdapterTest {
         ReportEntry entry = entryCaptor.getValue();
         assertEquals(MyTestClass.class.getName(), entry.getSourceName());
         assertEquals("Run a dummy cucumber test", entry.getName());
+    }
+
+    private static TestDescriptor newParameterizedClassTemplateDescriptor(UniqueId engineId) {
+        return new ClassTestDescriptor(
+                engineId.append("class-template", MyTestClass.class.getName()),
+                MyTestClass.class,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+    }
+
+    private static TestDescriptor newParameterizedClassInvocationDescriptor(UniqueId classTemplateId, int index) {
+        return new AbstractTestDescriptor(
+                classTemplateId.append("class-template-invocation", "#" + index),
+                "Parameterization with index: [" + index + "]",
+                ClassSource.from(MyTestClass.class)) {
+            @Override
+            public Type getType() {
+                return CONTAINER;
+            }
+
+            @Override
+            public String getLegacyReportingName() {
+                return MyTestClass.class.getSimpleName() + "[" + index + "]";
+            }
+        };
+    }
+
+    private static TestDescriptor newUnparameterizedMethodDescriptor(UniqueId parentId) throws Exception {
+        Method method = MyTestClass.class.getDeclaredMethod(MY_TEST_METHOD_NAME);
+        return new AbstractTestDescriptor(
+                parentId.append("method", method.getName() + "()"),
+                method.getName() + "()",
+                MethodSource.from(MyTestClass.class, method)) {
+            @Override
+            public Type getType() {
+                return TEST;
+            }
+
+            @Override
+            public String getLegacyReportingName() {
+                // JUnit 6 keeps the method legacy name without the class-invocation index.
+                return method.getName() + "()";
+            }
+        };
     }
 
     private static TestIdentifier newMethodIdentifier() throws Exception {


### PR DESCRIPTION
Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

Targeted module tests: `mvn -pl surefire-providers/surefire-junit-platform test -Dtest=RunListenerAdapterTest,JUnitPlatformProviderTest` (75 passed). Did not run the full ITS profile locally.

Fixes #3303.

`rerunFailingTestsCount` treats two reports with the same class+method name as one test. JUnit 5 `@ParameterizedTest` already puts `[N]` on the method legacy name. JUnit 6 `@ParameterizedClass` does not: the index lives on a `[class-template-invocation:#N]` parent with a `ClassSource`, so `hasParameterizedParent` misses it and both invocations look like `testSomething()`. A fail then a pass on the next index gets collapsed into a flake/pass.

This reads that unique-id segment and appends `[N]` when the method name does not already have it.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
