### PR TITLE
Upgrade Doxia to 2.1.0 on the 3.5.x line

### DIFF
--- a/maven-surefire-report-plugin/pom.xml
+++ b/maven-surefire-report-plugin/pom.xml
@@ -46,7 +46,7 @@
   </prerequisites>
 
   <properties>
-    <doxiaVersion>2.0.0</doxiaVersion>
+    <doxiaVersion>2.1.0</doxiaVersion>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This line still built the report plugin against Doxia 2.0.0; `master` has been on 2.1.0 since the
release, and 2.1.0 is the current release on Central.

Not inheritable: neither `maven-parent` nor the ASF parent defines a Doxia version property — both
mention Doxia zero times — and `master` also keeps `doxiaVersion` in this module's own `pom.xml`. So
this matches how `master` does it rather than moving the property up.

Worth a look at the IT output before merging: 2.1.0 restores `id` attributes on anchors that 2.0.0
had dropped, so report HTML changes.

*This change was created with AI assistance.*
