### PR TITLE
Fix missing UniqueId import in RunListenerAdapter

### DIFF
--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -43,6 +43,7 @@ import org.apache.maven.surefire.report.ClassMethodIndexer;
 import org.apache.maven.surefire.report.RunModeSetter;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;


### PR DESCRIPTION
Follow-up of #3418, which uses UniqueId in RunListenerAdapter without
importing it, so surefire-junit-platform fails to compile on master.

Adds the missing org.junit.platform.engine.UniqueId import.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
