### PR TITLE
[SUREFIRE-1639] Add ability to configure JUnit 5 TestExecutionListener

### DIFF
--- a/maven-surefire-plugin/src/site/markdown/examples/junit-platform.md.vm
+++ b/maven-surefire-plugin/src/site/markdown/examples/junit-platform.md.vm
@@ -539,6 +539,43 @@ Be aware that this feature reserves system properties `includejunit5engines` and
 ...
 ```
 
+Registering a custom TestExecutionListener
+-------------------------------------------
+
+Similar to the JUnit 4 `RunListener` support, a JUnit Platform `TestExecutionListener` can be registered
+through the `listener` provider property. Each class name configured there is instantiated and registered
+with the JUnit Platform `Launcher` for every test run:
+
+```text
+...
+<build>
+    <plugins>
+        ...
+        <plugin>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${project.artifactId}</artifactId>
+            <version>${project.version}</version>
+            <configuration>
+                <properties>
+                    <property>
+                        <name>listener</name>
+                        <value>com.example.MyTestExecutionListener</value>
+                    </property>
+                </properties>
+            </configuration>
+        </plugin>
+        ...
+    </plugins>
+</build>
+...
+```
+
+The `listener` property accepts a comma-separated list of class names; whitespace around each entry
+is trimmed and empty entries are ignored. Each class name may refer to a JUnit Platform
+`TestExecutionListener`, a JUnit 4 `org.junit.runner.notification.RunListener`, or a TestNG listener.
+JUnit Platform and JUnit 4 listeners are handled by the provider, while TestNG listeners are forwarded
+to the TestNG engine.
+
 Configuration Parameters
 ------------------------
 

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit5TestExecutionListenerIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/JUnit5TestExecutionListenerIT.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test verifying that a JUnit Platform {@code TestExecutionListener} configured through the
+ * Surefire {@code listener} property is instantiated and invoked.
+ */
+public class JUnit5TestExecutionListenerIT extends SurefireJUnit4IntegrationTestCase {
+
+    @Test
+    public void testJUnit5TestExecutionListener() {
+        OutputValidator outputValidator = unpack("junit5-testexecutionlistener")
+                .setJUnitVersion("5.14.4")
+                .sysProp("junit.platform.version", "1.14.4")
+                .executeTest()
+                .verifyErrorFreeLog();
+
+        outputValidator.assertTestSuiteResults(1, 0, 0, 0);
+        outputValidator.getTargetFile("testexecutionlistener-output.txt").assertFileExists();
+    }
+}

--- a/surefire-its/src/test/resources/junit5-testexecutionlistener/pom.xml
+++ b/surefire-its/src/test/resources/junit5-testexecutionlistener/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>junit5-testexecutionlistener</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Test for a configured TestExecutionListener in JUnit 5/Platform</name>
+
+    <properties>
+        <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+        <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit.platform.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>listener.FileWritingTestExecutionListener</value>
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/surefire-its/src/test/resources/junit5-testexecutionlistener/src/test/java/listener/FileWritingTestExecutionListener.java
+++ b/surefire-its/src/test/resources/junit5-testexecutionlistener/src/test/java/listener/FileWritingTestExecutionListener.java
@@ -1,0 +1,34 @@
+package listener;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+/**
+ * {@link TestExecutionListener} that writes a file when a test starts, whose existence can be checked
+ * by surefire-integration.
+ */
+public class FileWritingTestExecutionListener implements TestExecutionListener {
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        if (testIdentifier.isTest()) {
+            writeFile("testexecutionlistener-output.txt", "TestExecutionListener#executionStarted()");
+        }
+    }
+
+    private static void writeFile(String fileName, String content) {
+        try {
+            File target = new File("target").getAbsoluteFile();
+            File listenerOutput = new File(target, fileName);
+            try (FileWriter out = new FileWriter(listenerOutput)) {
+                out.write(content);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/surefire-its/src/test/resources/junit5-testexecutionlistener/src/test/java/listener/JUnit5TestExecutionListenerTest.java
+++ b/surefire-its/src/test/resources/junit5-testexecutionlistener/src/test/java/listener/JUnit5TestExecutionListenerTest.java
@@ -1,0 +1,11 @@
+package listener;
+
+import org.junit.jupiter.api.Test;
+
+public class JUnit5TestExecutionListenerTest {
+
+    @Test
+    void simpleTest() {
+        // no-op
+    }
+}

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -272,11 +272,7 @@ public class JUnitPlatformProvider extends AbstractProvider {
     private void execute(LauncherAdapter launcher, TestsToRun testsToRun, RunListenerAdapter adapter) {
         List<TestExecutionListener> testExecutionListeners = new ArrayList<>();
         testExecutionListeners.add(adapter);
-
-        TestExecutionListener customListeners = createJUnit4Listeners();
-        if (customListeners != null) {
-            testExecutionListeners.add(customListeners);
-        }
+        testExecutionListeners.addAll(createTestExecutionListeners());
 
         if (testsToRun.allowEagerReading()) {
             List<DiscoverySelector> selectors = new ArrayList<>();
@@ -292,29 +288,70 @@ public class JUnitPlatformProvider extends AbstractProvider {
         }
     }
 
-    /* Takes care for JUnit 4 RunListener execution.
-     * The problem we have here is that testng's listeners are being configured with the same name in the project's pom.
-     * So we have to try wether we can instantiate something from JUnit 4 or not.
+    /**
+     * Instantiates the listeners configured through the {@code listener} provider property.
+     * A class name may refer to a JUnit Platform {@link TestExecutionListener}, a JUnit 4
+     * {@code org.junit.runner.notification.RunListener}, or a TestNG listener. TestNG listeners
+     * are ignored here because they are forwarded to the TestNG engine through the
+     * {@code testng.listeners} configuration parameter instead.
+     *
+     * @return the configured JUnit Platform {@link TestExecutionListener}s, or an empty list
+     *     if none were declared
      */
-    private TestExecutionListener createJUnit4Listeners() {
-
+    private List<TestExecutionListener> createTestExecutionListeners() {
         String listeners = parameters.getProviderProperties().get("listener");
-        if (listeners != null) {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            List<Object> runListeners = new ArrayList<>();
-            for (String listener : listeners.split(",")) {
-                try {
-                    Class<?> runListenerClass = cl.loadClass("org.junit.runner.notification.RunListener");
-                    runListeners.add(ReflectionUtils.instantiate(cl, listener, runListenerClass));
-                } catch (ClassCastException | ClassNotFoundException c) {
-                    // ignored as we may be in not-JUnit 4 context like testng
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            return new JUnit4ListenersAdapter(runListeners);
+        if (listeners == null) {
+            return Collections.emptyList();
         }
-        return null;
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        List<Object> runListeners = new ArrayList<>();
+        List<TestExecutionListener> testExecutionListeners = new ArrayList<>();
+        for (String listener : stream(listeners.split(","))
+                .map(String::trim)
+                .filter(trimmed -> !trimmed.isEmpty())
+                .collect(toList())) {
+            TestExecutionListener testExecutionListener = instantiateTestExecutionListener(cl, listener);
+            if (testExecutionListener != null) {
+                testExecutionListeners.add(testExecutionListener);
+            } else {
+                Object runListener = instantiateJUnit4RunListener(cl, listener);
+                if (runListener != null) {
+                    runListeners.add(runListener);
+                }
+                // otherwise ignored as we may be in a TestNG context
+            }
+        }
+        if (!runListeners.isEmpty()) {
+            testExecutionListeners.add(new JUnit4ListenersAdapter(runListeners));
+        }
+        return testExecutionListeners;
+    }
+
+    private TestExecutionListener instantiateTestExecutionListener(ClassLoader cl, String listener) {
+        try {
+            Class<?> listenerClass = cl.loadClass(listener);
+            if (!TestExecutionListener.class.isAssignableFrom(listenerClass)) {
+                return null;
+            }
+            return ReflectionUtils.instantiate(cl, listener, TestExecutionListener.class);
+        } catch (ClassNotFoundException e) {
+            // the configured class is not on the classpath
+            return null;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Object instantiateJUnit4RunListener(ClassLoader cl, String listener) {
+        try {
+            Class<?> runListenerClass = cl.loadClass("org.junit.runner.notification.RunListener");
+            return ReflectionUtils.instantiate(cl, listener, runListenerClass);
+        } catch (ClassCastException | ClassNotFoundException c) {
+            // ignored as we may be in not-JUnit 4 context like testng
+            return null;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     LauncherDiscoveryRequest buildLauncherDiscoveryRequestForRerunFailures(RunListenerAdapter adapter) {

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -829,6 +829,24 @@ public class JUnitPlatformProviderTest {
     }
 
     @Test
+    public void testExecutionListenerIsConfiguredViaListenerProperty() throws Exception {
+        RecordingTestExecutionListener.EVENTS.clear();
+
+        // whitespace and empty entries are ignored
+        Map<String, String> providerProperties =
+                singletonMap("listener", " " + RecordingTestExecutionListener.class.getName() + " ,");
+        ProviderParameters providerParameters = providerParametersMock(VerboseTestClass.class);
+        when(providerParameters.getProviderProperties()).thenReturn(providerProperties);
+
+        JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
+
+        invokeProvider(provider, newTestsToRun(VerboseTestClass.class));
+
+        assertThat(RecordingTestExecutionListener.EVENTS)
+                .contains("executionStarted:test()", "executionFinished:test()");
+    }
+
+    @Test
     public void onlyGroupsIsDeclared() {
         Map<String, String> properties = singletonMap(GROUPS_PROP, "groupOne, groupTwo");
 
@@ -1345,6 +1363,20 @@ public class JUnitPlatformProviderTest {
         void test() {
             System.out.println("stdout");
             System.err.println("stderr");
+        }
+    }
+
+    public static class RecordingTestExecutionListener implements TestExecutionListener {
+        static final List<String> EVENTS = new ArrayList<>();
+
+        @Override
+        public void executionStarted(TestIdentifier testIdentifier) {
+            EVENTS.add("executionStarted:" + testIdentifier.getDisplayName());
+        }
+
+        @Override
+        public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+            EVENTS.add("executionFinished:" + testIdentifier.getDisplayName());
         }
     }
 


### PR DESCRIPTION
Issue: https://github.com/apache/maven-surefire/issues/2122

## Description

The `listener` provider property now accepts JUnit Platform
`TestExecutionListener` classes in addition to JUnit 4
`org.junit.runner.notification.RunListener` classes.

For each comma-separated entry, whitespace is trimmed and empty entries are
ignored. The provider then tries, in order:

1. JUnit Platform `TestExecutionListener` (instantiated directly and registered
   with the `Launcher`)
2. JUnit 4 `RunListener` (wrapped in `JUnit4ListenersAdapter`)
3. otherwise ignored by this provider (TestNG listeners are forwarded to the
   TestNG engine via `testng.listeners`)

## Changes

- `JUnitPlatformProvider` resolves each `listener` entry as a JUnit Platform
  `TestExecutionListener` or a JUnit 4 `RunListener`, trimming whitespace and
  skipping empty entries.
- Documents the new `Registering a custom TestExecutionListener` section in
  `maven-surefire-plugin/src/site/markdown/examples/junit-platform.md.vm`.
- Adds unit test `testExecutionListenerIsConfiguredViaListenerProperty` and the
  `junit5-testexecutionlistener` integration test with
  `JUnit5TestExecutionListenerIT`.

```xml
<plugin>
  <groupId>org.apache.maven.plugins</groupId>
  <artifactId>maven-surefire-plugin</artifactId>
  <configuration>
    <properties>
      <property>
        <name>listener</name>
        <value>com.example.MyTestExecutionListener</value>
      </property>
    </properties>
  </configuration>
</plugin>
```

## How it was tested

- `mvn -pl surefire-providers/surefire-junit-platform test
  -Dtest=JUnitPlatformProviderTest` - 48 tests pass
- `mvn -pl surefire-providers/surefire-junit-platform checkstyle:check` -
  no violations
- Integration test `JUnit5TestExecutionListenerIT` verifies end-to-end that
  the configured listener runs in a forked test JVM

## Checklist

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
   (I'm committer of other Apache projects and have already signed the ICLA)
