### PR TITLE
Stop dependabot from updating test fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
     - "master"
     - "dependencies"
   directory: "/"
+  exclude-paths:
+    - "maven-failsafe-plugin/src/it/**"
+    - "surefire-its/src/test/resources/**"
   schedule:
     interval: "daily"
   ignore:


### PR DESCRIPTION
Dependabot bumps fixture poms whose pinned version is the test input; #3384 breaks `PlexusConflictIT`, where the old plexus-utils *is* the assertion. Same fix as mojohaus/license-maven-plugin@c43d4ee0, after which that repo's stream of `src/it` PRs stopped.

Supersedes #3384, #3433.

*This change was created with AI assistance.*