### PR TITLE
Discover tests in a fork when a toolchain JDK is used

### DIFF
--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializer.java
@@ -37,12 +37,14 @@ import org.apache.maven.surefire.booter.KeyValueSource;
 import org.apache.maven.surefire.booter.ProcessCheckerType;
 import org.apache.maven.surefire.booter.ProviderConfiguration;
 import org.apache.maven.surefire.booter.StartupConfiguration;
+import org.apache.maven.surefire.booter.TypeEncodedValue;
 
 import static org.apache.maven.plugin.surefire.SurefireHelper.replaceForkThreadsInPath;
 import static org.apache.maven.surefire.booter.AbstractPathConfiguration.CHILD_DELEGATION;
 import static org.apache.maven.surefire.booter.AbstractPathConfiguration.CLASSPATH;
 import static org.apache.maven.surefire.booter.AbstractPathConfiguration.ENABLE_ASSERTIONS;
 import static org.apache.maven.surefire.booter.AbstractPathConfiguration.SUREFIRE_CLASSPATH;
+import static org.apache.maven.surefire.booter.BooterConstants.DISCOVER_TESTS_OUTPUT_FILE;
 import static org.apache.maven.surefire.booter.BooterConstants.EXCLUDES_PROPERTY_PREFIX;
 import static org.apache.maven.surefire.booter.BooterConstants.FAIL_FAST_COUNT;
 import static org.apache.maven.surefire.booter.BooterConstants.FORKTESTSET;
@@ -105,10 +107,12 @@ class BooterSerializer {
             boolean readTestsFromInStream,
             Long pid,
             int forkNumber,
-            String forkNodeConnectionString)
+            String forkNodeConnectionString,
+            String discoverTestsOutputFile)
             throws IOException {
         SurefireProperties properties = new SurefireProperties(sourceProperties);
         properties.setNullableProperty(FORK_NODE_CONNECTION_STRING, forkNodeConnectionString);
+        properties.setNullableProperty(DISCOVER_TESTS_OUTPUT_FILE, discoverTestsOutputFile);
         properties.setProperty(PLUGIN_PID, pid);
 
         AbstractPathConfiguration cp = startupConfiguration.getClasspathConfiguration();
@@ -178,6 +182,10 @@ class BooterSerializer {
     private static String getTypeEncoded(Object value) {
         if (value == null) {
             return null;
+        }
+        if (value instanceof TypeEncodedValue) {
+            TypeEncodedValue encoded = (TypeEncodedValue) value;
+            return encoded.getType() + "|" + encoded.getValue();
         }
         String valueToUse = value instanceof Class ? ((Class<?>) value).getName() : value.toString();
         return value.getClass().getName() + "|" + valueToUse;

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
@@ -793,11 +793,9 @@ public class ForkStarter {
     private Iterable<?> getForkPerTestSetTestSets(SurefireProperties effectiveSystemProperties)
             throws SurefireBooterForkException {
         if (isForkJvmDifferentFromBuildJvm()) {
-            List<TypeEncodedValue> testSets = new ArrayList<>();
-            for (String testClassName : discoverTestClassNames(effectiveSystemProperties)) {
-                testSets.add(new TypeEncodedValue(Class.class.getName(), testClassName));
-            }
-            return testSets;
+            return discoverTestClassNames(effectiveSystemProperties).stream()
+                    .map(testClassName -> new TypeEncodedValue(Class.class.getName(), testClassName))
+                    .collect(toList());
         }
         return getSuitesIterator();
     }
@@ -868,13 +866,10 @@ public class ForkStarter {
             return Collections.emptyList();
         }
         try {
-            List<String> testClassNames = new ArrayList<>();
-            for (String line : Files.readAllLines(discoveryFile.toPath(), UTF_8)) {
-                if (!line.trim().isEmpty()) {
-                    testClassNames.add(line.trim());
-                }
-            }
-            return testClassNames;
+            return Files.readAllLines(discoveryFile.toPath(), UTF_8).stream()
+                    .map(String::trim)
+                    .filter(String::isEmpty)
+                    .collect(toList());
         } catch (IOException e) {
             throw new SurefireBooterForkException("Cannot read discovered tests from " + discoveryFile, e);
         }

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
@@ -23,9 +23,12 @@ import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -73,6 +76,7 @@ import org.apache.maven.surefire.booter.ProviderFactory;
 import org.apache.maven.surefire.booter.StartupConfiguration;
 import org.apache.maven.surefire.booter.SurefireBooterForkException;
 import org.apache.maven.surefire.booter.SurefireExecutionException;
+import org.apache.maven.surefire.booter.TypeEncodedValue;
 import org.apache.maven.surefire.extensions.EventHandler;
 import org.apache.maven.surefire.extensions.ForkChannel;
 import org.apache.maven.surefire.extensions.ForkNodeFactory;
@@ -86,6 +90,7 @@ import org.apache.maven.surefire.extensions.util.LineConsumerThread;
 import static java.lang.StrictMath.min;
 import static java.lang.System.currentTimeMillis;
 import static java.lang.Thread.currentThread;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.addAll;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
@@ -109,6 +114,7 @@ import static org.apache.maven.surefire.api.util.internal.DaemonThreadFactory.ne
 import static org.apache.maven.surefire.api.util.internal.StringUtils.NL;
 import static org.apache.maven.surefire.booter.SystemPropertyManager.writePropertiesFile;
 import static org.apache.maven.surefire.booter.SystemUtils.pidOf;
+import static org.apache.maven.surefire.booter.SystemUtils.toJdkHomeFromJre;
 import static org.apache.maven.surefire.shared.utils.cli.ShutdownHookUtils.addShutDownHook;
 import static org.apache.maven.surefire.shared.utils.cli.ShutdownHookUtils.removeShutdownHook;
 
@@ -342,8 +348,8 @@ public class ForkStarter {
 
         Queue<String> tests = new ConcurrentLinkedQueue<>();
 
-        for (Class<?> clazz : getSuitesIterator()) {
-            tests.add(clazz.getName());
+        for (String testClassName : getTestClassNames(effectiveSystemProps)) {
+            tests.add(testClassName);
         }
 
         Queue<TestProvidingInputStream> forks = new ConcurrentLinkedQueue<>();
@@ -408,7 +414,8 @@ public class ForkStarter {
             addShutDownHook(shutdown);
             int failFastCount = providerConfiguration.getSkipAfterFailureCount();
             AtomicInteger notifyForksToSkipTestsNow = new AtomicInteger(failFastCount);
-            Collection<Future<RunResult>> results = stream(((Iterable<?>) getSuitesIterator()).spliterator(), false)
+            Collection<Future<RunResult>> results = stream(
+                            getForkPerTestSetTestSets(effectiveSystemProps).spliterator(), false)
                     .filter(fork -> !forkConfiguration.getPluginPlatform().isShutdown())
                     .map(testSet -> (Callable<RunResult>) () -> {
                         int forkNumber = drawNumber();
@@ -513,6 +520,29 @@ public class ForkStarter {
             ForkNodeFactory forkNodeFactory,
             boolean readTestsFromInStream)
             throws SurefireBooterForkException {
+        return fork(
+                testSet,
+                providerProperties,
+                forkClient,
+                effectiveSystemProperties,
+                forkNumber,
+                commandReader,
+                forkNodeFactory,
+                readTestsFromInStream,
+                null);
+    }
+
+    private RunResult fork(
+            Object testSet,
+            PropertiesWrapper providerProperties,
+            ForkClient forkClient,
+            SurefireProperties effectiveSystemProperties,
+            int forkNumber,
+            AbstractCommandReader commandReader,
+            ForkNodeFactory forkNodeFactory,
+            boolean readTestsFromInStream,
+            String discoverTestsOutputFile)
+            throws SurefireBooterForkException {
         CloseableCloser closer = new CloseableCloser(forkNumber, commandReader);
         final String tempDir;
         final File surefireProperties;
@@ -542,7 +572,8 @@ public class ForkStarter {
                     readTestsFromInStream,
                     pluginPid,
                     forkNumber,
-                    connectionString);
+                    connectionString,
+                    discoverTestsOutputFile);
 
             if (effectiveSystemProperties != null) {
                 SurefireProperties filteredProperties =
@@ -720,8 +751,132 @@ public class ForkStarter {
                     startupConfiguration, providerConfiguration, unifiedClassLoader, reporterFactory);
             SurefireProvider surefireProvider = providerFactory.createProvider(false);
             return surefireProvider.getSuites();
+        } catch (UnsupportedClassVersionError e) {
+            throw new SurefireBooterForkException(
+                    "Could not load the test classes to figure out which tests to run. This usually means the tests "
+                            + "were compiled with a newer JDK than the one running Maven, and forking (forkCount greater "
+                            + "than 1 or reuseForks=false) needs to list the tests using Maven's own JVM. Point the "
+                            + "'jvm' parameter or a 'jdk' toolchain at a JDK that is at least as new as the one used to "
+                            + "compile the tests.",
+                    e);
         } catch (SurefireExecutionException e) {
             throw new SurefireBooterForkException("Unable to create classloader to find test suites", e);
+        }
+    }
+
+    /**
+     * Gives back the names of the test classes to run. If the tests run in a different JVM than Maven itself
+     * (because a {@code jdk} toolchain or the {@code jvm} parameter is set), we ask a short-lived fork to list
+     * them, so Maven never has to load test classes that may be compiled for a newer JDK. Otherwise we just
+     * list them here, like before.
+     *
+     * @see <a href="https://github.com/apache/maven-surefire/issues/2151">Issue 2151</a>
+     */
+    private List<String> getTestClassNames(SurefireProperties effectiveSystemProperties)
+            throws SurefireBooterForkException {
+        if (isForkJvmDifferentFromBuildJvm()) {
+            return discoverTestClassNames(effectiveSystemProperties);
+        }
+        List<String> testClassNames = new ArrayList<>();
+        for (Class<?> clazz : getSuitesIterator()) {
+            testClassNames.add(clazz.getName());
+        }
+        return testClassNames;
+    }
+
+    /**
+     * Gives back the test sets for {@code fork-per-test-set} runs. When the tests run in a different JVM than Maven,
+     * we discover the class names in a fork (see {@link #getTestClassNames}) and wrap each one as a
+     * {@link TypeEncodedValue} of type {@link Class}, so every fork loads the class with its own JVM. Otherwise we
+     * reuse the already-loaded {@link Class} instances, like before.
+     */
+    private Iterable<?> getForkPerTestSetTestSets(SurefireProperties effectiveSystemProperties)
+            throws SurefireBooterForkException {
+        if (isForkJvmDifferentFromBuildJvm()) {
+            List<TypeEncodedValue> testSets = new ArrayList<>();
+            for (String testClassName : discoverTestClassNames(effectiveSystemProperties)) {
+                testSets.add(new TypeEncodedValue(Class.class.getName(), testClassName));
+            }
+            return testSets;
+        }
+        return getSuitesIterator();
+    }
+
+    /**
+     * @return {@code true} when the tests run in a different JDK than Maven (set through a {@code jdk} toolchain or the
+     *     {@code jvm} parameter), in which case we need a fork to list the test classes.
+     */
+    private boolean isForkJvmDifferentFromBuildJvm() {
+        File testsJdkHome = forkConfiguration.getJdkForTests().getJdkHome();
+        return testsJdkHome != null && !testsJdkHome.equals(toJdkHomeFromJre());
+    }
+
+    /**
+     * Starts one short-lived fork with the configured test JVM that lists the test classes to run and writes their
+     * names to a temporary file, then reads them back. The candidate class names already travel to the fork through
+     * the provider properties (from the directory scan Maven did earlier), so no test class is loaded in Maven's JVM.
+     */
+    private List<String> discoverTestClassNames(SurefireProperties effectiveSystemProperties)
+            throws SurefireBooterForkException {
+        File discoveryFile;
+        try {
+            discoveryFile =
+                    File.createTempFile("surefire-discovered-tests", ".txt", forkConfiguration.getTempDirectory());
+        } catch (IOException e) {
+            throw new SurefireBooterForkException("Cannot create temporary file for test discovery", e);
+        }
+
+        TestLessInputStreamBuilder builder = new TestLessInputStreamBuilder();
+        TestLessInputStream stream = builder.build();
+        Thread shutdown = createImmediateShutdownHookThread(builder, providerConfiguration.getShutdown());
+        ScheduledFuture<?> ping = triggerPingTimerForShutdown(builder);
+        int forkNumber = drawNumber();
+        PropertiesWrapper props = new PropertiesWrapper(providerConfiguration.getProviderProperties());
+        try {
+            addShutDownHook(shutdown);
+            DefaultReporterFactory forkedReporterFactory =
+                    new DefaultReporterFactory(startupReportConfiguration, log, forkNumber);
+            defaultReporterFactories.add(forkedReporterFactory);
+            ForkClient forkClient = new ForkClient(forkedReporterFactory, stream, forkNumber);
+            ForkNodeFactory node = forkConfiguration.getForkNodeFactory();
+            if (!forkConfiguration.getPluginPlatform().isShutdown()) {
+                fork(
+                        null,
+                        props,
+                        forkClient,
+                        effectiveSystemProperties,
+                        forkNumber,
+                        stream,
+                        node,
+                        false,
+                        discoveryFile.getAbsolutePath());
+            }
+            return readTestClassNames(discoveryFile);
+        } finally {
+            returnNumber(forkNumber);
+            removeShutdownHook(shutdown);
+            ping.cancel(true);
+            builder.removeStream(stream);
+            if (!forkConfiguration.isDebug() && !discoveryFile.delete()) {
+                discoveryFile.deleteOnExit();
+            }
+        }
+    }
+
+    private static List<String> readTestClassNames(File discoveryFile) throws SurefireBooterForkException {
+        if (!discoveryFile.isFile()) {
+            return Collections.emptyList();
+        }
+        try {
+            List<String> testClassNames = new ArrayList<>();
+            for (String line : Files.readAllLines(discoveryFile.toPath(), UTF_8)) {
+                if (!line.trim().isEmpty()) {
+                    testClassNames.add(line.trim());
+                }
+            }
+            return testClassNames;
+        } catch (IOException e) {
+            throw new SurefireBooterForkException("Cannot read discovered tests from " + discoveryFile, e);
         }
     }
 

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerProviderConfigurationTest.java
@@ -234,7 +234,15 @@ public class BooterDeserializerProviderConfigurationTest {
             test = "aTest";
         }
         final File propsTest = booterSerializer.serialize(
-                props, booterConfiguration, testProviderConfiguration, test, readTestsFromInStream, 51L, 1, "pipe://1");
+                props,
+                booterConfiguration,
+                testProviderConfiguration,
+                test,
+                readTestsFromInStream,
+                51L,
+                1,
+                "pipe://1",
+                null);
         BooterDeserializer booterDeserializer = new BooterDeserializer(new FileInputStream(propsTest));
         assertEquals("51", (Object) booterDeserializer.getPluginPid());
         assertEquals("pipe://1", booterDeserializer.getConnectionString());

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterDeserializerStartupConfigurationTest.java
@@ -165,7 +165,8 @@ public class BooterDeserializerStartupConfigurationTest {
                 false,
                 null,
                 1,
-                "tcp://localhost:63003");
+                "tcp://localhost:63003",
+                null);
         try (InputStream inputStream = Files.newInputStream(propsTest.toPath())) {
             BooterDeserializer booterDeserializer = new BooterDeserializer(inputStream);
             assertNull(booterDeserializer.getPluginPid());

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializerTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/BooterSerializerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.surefire.booterclient;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.surefire.api.booter.Shutdown;
+import org.apache.maven.surefire.api.report.ReporterConfiguration;
+import org.apache.maven.surefire.api.testset.DirectoryScannerParameters;
+import org.apache.maven.surefire.api.testset.RunOrderParameters;
+import org.apache.maven.surefire.api.testset.TestArtifactInfo;
+import org.apache.maven.surefire.api.testset.TestListResolver;
+import org.apache.maven.surefire.api.testset.TestRequest;
+import org.apache.maven.surefire.api.util.RunOrder;
+import org.apache.maven.surefire.booter.BooterDeserializer;
+import org.apache.maven.surefire.booter.ClassLoaderConfiguration;
+import org.apache.maven.surefire.booter.ClasspathConfiguration;
+import org.apache.maven.surefire.booter.PropertiesWrapper;
+import org.apache.maven.surefire.booter.ProviderConfiguration;
+import org.apache.maven.surefire.booter.StartupConfiguration;
+import org.apache.maven.surefire.booter.TypeEncodedValue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.maven.surefire.booter.ProcessCheckerType.ALL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Checks the serialization of the fields added for the forked test discovery
+ * (<a href="https://github.com/apache/maven-surefire/issues/2151">Issue 2151</a>).
+ */
+class BooterSerializerTest {
+    private static int idx = 0;
+
+    private File basedir;
+
+    @BeforeEach
+    void setupDirectories() throws IOException {
+        File target = new File(System.getProperty("user.dir"), "target");
+        basedir = new File(target, "BooterSerializerTest-" + ++idx);
+        FileUtils.deleteDirectory(basedir);
+        assertTrue(basedir.mkdirs());
+    }
+
+    @AfterEach
+    void deleteDirectories() throws IOException {
+        FileUtils.deleteDirectory(basedir);
+    }
+
+    @Test
+    void discoverTestsOutputFileRoundTrips() throws IOException {
+        String discoverTestsOutputFile = new File(basedir, "discovered.txt").getAbsolutePath();
+
+        BooterDeserializer deserializer = serializeAndReload("aTest", discoverTestsOutputFile);
+
+        assertEquals(discoverTestsOutputFile, deserializer.getDiscoverTestsOutputFile());
+    }
+
+    @Test
+    void discoverTestsOutputFileIsNullForNormalRun() throws IOException {
+        BooterDeserializer deserializer = serializeAndReload("aTest", null);
+
+        assertNull(deserializer.getDiscoverTestsOutputFile());
+    }
+
+    @Test
+    void classNameTestSetIsEncodedAsClass() throws IOException {
+        TypeEncodedValue testSet = new TypeEncodedValue(Class.class.getName(), "com.example.SomeTest");
+
+        BooterDeserializer deserializer = serializeAndReload(testSet, null);
+
+        TypeEncodedValue forkTestSet = deserializer.deserialize().getTestForFork();
+        assertEquals(Class.class.getName(), forkTestSet.getType());
+        assertEquals("com.example.SomeTest", forkTestSet.getValue());
+    }
+
+    private BooterDeserializer serializeAndReload(Object testSet, String discoverTestsOutputFile) throws IOException {
+        ForkConfiguration forkConfiguration = ForkConfigurationTest.getForkConfiguration(basedir, null);
+        BooterSerializer booterSerializer = new BooterSerializer(forkConfiguration);
+        File propsTest = booterSerializer.serialize(
+                new PropertiesWrapper(new HashMap<>()),
+                getProviderConfiguration(),
+                getStartupConfiguration(),
+                testSet,
+                false,
+                51L,
+                1,
+                "pipe://1",
+                discoverTestsOutputFile);
+        return new BooterDeserializer(new FileInputStream(propsTest));
+    }
+
+    private ProviderConfiguration getProviderConfiguration() {
+        File cwd = new File(".");
+        DirectoryScannerParameters directoryScannerParameters = new DirectoryScannerParameters(
+                cwd,
+                Collections.<String>emptyList(),
+                Collections.<String>emptyList(),
+                Collections.<String>emptyList(),
+                RunOrder.asString(RunOrder.DEFAULT));
+        return new ProviderConfiguration(
+                directoryScannerParameters,
+                new RunOrderParameters(RunOrder.DEFAULT, null),
+                new ReporterConfiguration(cwd, true),
+                new TestArtifactInfo("5.0", "ABC"),
+                new TestRequest(new File("TestSrc"), new TestListResolver(""), 0),
+                new HashMap<>(),
+                null,
+                false,
+                Collections.<org.apache.maven.surefire.api.cli.CommandLineOption>emptyList(),
+                0,
+                Shutdown.DEFAULT,
+                0);
+    }
+
+    private StartupConfiguration getStartupConfiguration() {
+        return new StartupConfiguration(
+                "com.provider",
+                new ClasspathConfiguration(true, true),
+                new ClassLoaderConfiguration(true, false),
+                ALL,
+                Collections.<String[]>emptyList());
+    }
+}

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterConstants.java
@@ -54,4 +54,5 @@ public final class BooterConstants {
     public static final String PROCESS_CHECKER = "processChecker";
     public static final String FORK_NODE_CONNECTION_STRING = "forkNodeConnectionString";
     public static final String FORK_NUMBER = "forkNumber";
+    public static final String DISCOVER_TESTS_OUTPUT_FILE = "discoverTestsOutputFile";
 }

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/BooterDeserializer.java
@@ -79,6 +79,18 @@ public class BooterDeserializer {
         return properties.getProperty(PLUGIN_PID);
     }
 
+    /**
+     * When set, the fork runs in discovery mode: it just lists the test classes to run (using the provider),
+     * writes their names to this file (one per line, UTF-8) and exits without running any test. This lets us
+     * list the tests inside a JVM that matches the toolchain, for the cases where Maven's own JVM cannot load
+     * the test classes (see <a href="https://github.com/apache/maven-surefire/issues/2151">Issue 2151</a>).
+     *
+     * @return the absolute path of the discovery output file, or {@code null} for a normal run
+     */
+    public String getDiscoverTestsOutputFile() {
+        return properties.getProperty(DISCOVER_TESTS_OUTPUT_FILE);
+    }
+
     public ProviderConfiguration deserialize() {
         final File reportsDirectory = new File(properties.getProperty(REPORTSDIRECTORY));
         final String testNgVersion = properties.getProperty(TESTARTIFACT_VERSION);

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
@@ -29,6 +29,8 @@ import java.nio.file.Files;
 import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.Semaphore;
@@ -56,6 +58,7 @@ import org.apache.maven.surefire.shared.utils.cli.ShutdownHookUtils;
 import org.apache.maven.surefire.spi.MasterProcessChannelProcessorFactory;
 
 import static java.lang.Thread.currentThread;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.ServiceLoader.load;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.maven.surefire.api.cli.CommandLineOption.LOGGING_LEVEL_DEBUG;
@@ -101,6 +104,7 @@ public final class ForkedBooter {
     private ForkingReporterFactory forkingReporterFactory;
     private StartupConfiguration startupConfiguration;
     private Object testSet;
+    private String discoverTestsOutputFile;
 
     private void setupBooter(
             String tmpDir, String dumpFileName, String surefirePropsFileName, String effectiveSystemPropertiesFileName)
@@ -110,6 +114,7 @@ public final class ForkedBooter {
         setSystemProperties(new File(tmpDir, effectiveSystemPropertiesFileName));
 
         providerConfiguration = booterDeserializer.deserialize();
+        discoverTestsOutputFile = booterDeserializer.getDiscoverTestsOutputFile();
 
         // Configure StackTraceProvider with additional filter prefixes and max frames
         String stackTraceFilterPrefixes =
@@ -165,8 +170,10 @@ public final class ForkedBooter {
 
         ClassLoader classLoader = currentThread().getContextClassLoader();
         classLoader.setDefaultAssertionStatus(classpathConfiguration.isEnableAssertions());
-        boolean readTestsFromCommandReader = providerConfiguration.isReadTestsFromInStream();
-        testSet = createTestSet(providerConfiguration.getTestForFork(), readTestsFromCommandReader, classLoader);
+        if (discoverTestsOutputFile == null) {
+            boolean readTestsFromCommandReader = providerConfiguration.isReadTestsFromInStream();
+            testSet = createTestSet(providerConfiguration.getTestForFork(), readTestsFromCommandReader, classLoader);
+        }
     }
 
     private void execute() {
@@ -381,7 +388,29 @@ public final class ForkedBooter {
     }
 
     private void runSuitesInProcess() throws TestSetFailedException, InvocationTargetException {
-        createProviderInCurrentClassloader().invoke(testSet);
+        if (discoverTestsOutputFile != null) {
+            discoverTestsInProcess();
+        } else {
+            createProviderInCurrentClassloader().invoke(testSet);
+        }
+    }
+
+    /**
+     * Lists the test classes to run using the provider (which runs here, in the fork's JVM matching the toolchain),
+     * writes their names to {@link #discoverTestsOutputFile} (one per line, UTF-8) and returns without running any
+     * test. See <a href="https://github.com/apache/maven-surefire/issues/2151">Issue 2151</a>.
+     */
+    private void discoverTestsInProcess() throws TestSetFailedException {
+        SurefireProvider provider = createProviderInCurrentClassloader();
+        List<String> testClassNames = new ArrayList<>();
+        for (Class<?> testClass : provider.getSuites()) {
+            testClassNames.add(testClass.getName());
+        }
+        try {
+            Files.write(new File(discoverTestsOutputFile).toPath(), testClassNames, UTF_8);
+        } catch (IOException e) {
+            throw new TestSetFailedException("Cannot write discovered tests to " + discoverTestsOutputFile, e);
+        }
     }
 
     private ForkingReporterFactory createForkingReporterFactory() {

--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/TypeEncodedValue.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/TypeEncodedValue.java
@@ -39,6 +39,14 @@ public final class TypeEncodedValue {
         this.value = value;
     }
 
+    public String getType() {
+        return type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
     private boolean isTypeClass() {
         return Class.class.getName().equals(type);
     }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire2151ToolchainForkDiscoveryIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire2151ToolchainForkDiscoveryIT.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.apache.maven.surefire.its.fixture.AbstractJava9PlusIT;
+import org.apache.maven.surefire.its.fixture.SurefireLauncher;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Checks that Surefire can list and run tests across several forks when a JDK toolchain is in use
+ * (<a href="https://github.com/apache/maven-surefire/issues/2151">Issue 2151</a>).
+ * <p>
+ * With {@code forkCount > 1} (or {@code reuseForks=false}) Surefire has to list the test classes before
+ * spreading them across the forks. When those classes were compiled for a newer JDK than the one running
+ * Maven, listing them in Maven's JVM used to fail with {@code UnsupportedClassVersionError}. The fix does the
+ * listing in a fork that uses the toolchain JDK instead.
+ */
+public class Surefire2151ToolchainForkDiscoveryIT extends AbstractJava9PlusIT {
+    private static final String TOOLCHAIN_JDK_HOME_PROPERTY = "surefire.test.toolchain.jdkHome";
+
+    /**
+     * Guards the multi-fork listing and distribution path when a JDK toolchain is set. It uses the shared
+     * single-JDK {@code toolchains.xml} so it always runs in CI.
+     */
+    @Test
+    public void forkCountGreaterThanOneWithToolchainRunsAllTests() {
+        assumeJava9()
+                .setForkJvm()
+                .forkCount(2)
+                .reuseForks(true)
+                .activateProfile("use-toolchains")
+                .addGoal("--toolchains")
+                .addGoal(System.getProperty("maven.toolchains.file"))
+                .executeTest()
+                .verifyErrorFree(3);
+    }
+
+    /**
+     * Same as above but with {@code reuseForks=false}, which also makes Surefire list the tests first.
+     */
+    @Test
+    public void reuseForksFalseWithToolchainRunsAllTests() {
+        assumeJava9()
+                .setForkJvm()
+                .activateProfile("use-toolchains")
+                .activateProfile("reuse-forks-false")
+                .addGoal("--toolchains")
+                .addGoal(System.getProperty("maven.toolchains.file"))
+                .executeTest()
+                .verifyErrorFree(3);
+    }
+
+    /**
+     * The real reproduction: the tests are compiled and run with a JDK <em>newer</em> than the one running Maven,
+     * so listing them in Maven's JVM would fail without the discovery fork. Runs only when
+     * {@code -Dsurefire.test.toolchain.jdkHome} points at a newer JDK.
+     */
+    @Test
+    public void newerToolchainJdkAcrossMultipleForks() throws Exception {
+        String jdkHome = System.getProperty(TOOLCHAIN_JDK_HOME_PROPERTY);
+        assumeTrue(
+                jdkHome != null && !jdkHome.isEmpty(),
+                "set -D" + TOOLCHAIN_JDK_HOME_PROPERTY + " to a JDK newer than the running JVM to run this test");
+
+        SurefireLauncher launcher = assumeJava9();
+        File toolchainsFile = writeToolchainsFile(launcher.getUnpackedAt(), jdkHome);
+
+        launcher.setForkJvm()
+                .forkCount(2)
+                .reuseForks(true)
+                .activateProfile("use-toolchains")
+                .addGoal("--toolchains")
+                .addGoal(toolchainsFile.getAbsolutePath())
+                .executeTest()
+                .verifyErrorFree(3);
+    }
+
+    @Override
+    protected String getProjectDirectoryName() {
+        return "surefire-2151-toolchain-fork-discovery";
+    }
+
+    private static File writeToolchainsFile(File projectDir, String jdkHome) throws Exception {
+        File toolchainsFile = new File(projectDir, "toolchains.xml");
+        String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<toolchains>\n"
+                + "  <toolchain>\n"
+                + "    <type>jdk</type>\n"
+                + "    <provides>\n"
+                + "      <version>newer</version>\n"
+                + "    </provides>\n"
+                + "    <configuration>\n"
+                + "      <jdkHome>" + jdkHome + "</jdkHome>\n"
+                + "    </configuration>\n"
+                + "  </toolchain>\n"
+                + "</toolchains>\n";
+        Files.write(toolchainsFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
+        return toolchainsFile;
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2151-toolchain-fork-discovery/pom.xml
+++ b/surefire-its/src/test/resources/surefire-2151-toolchain-fork-discovery/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-2151-it</artifactId>
+    <version>1.0</version>
+
+    <properties>
+        <maven.compiler.source>${java.specification.version}</maven.compiler.source>
+        <maven.compiler.target>${java.specification.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <forkCount>2</forkCount>
+                    <reuseForks>true</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <!--
+          Turns on a jdk toolchain for the tests. Together with a forkCount greater than one, this makes
+          Surefire list the test classes up front.
+          See https://github.com/apache/maven-surefire/issues/2151.
+        -->
+        <profile>
+            <id>use-toolchains</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-toolchains-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>toolchain</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <toolchains>
+                                <jdk/>
+                            </toolchains>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>reuse-forks-false</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <forkCount>2</forkCount>
+                            <reuseForks>false</reuseForks>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/surefire-its/src/test/resources/surefire-2151-toolchain-fork-discovery/src/test/java/com/example/ServiceOneTest.java
+++ b/surefire-its/src/test/resources/surefire-2151-toolchain-fork-discovery/src/test/java/com/example/ServiceOneTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ServiceOneTest {
+    @Test
+    void test() {
+        assertEquals(2, 1 + 1);
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2151-toolchain-fork-discovery/src/test/java/com/example/ServiceThreeTest.java
+++ b/surefire-its/src/test/resources/surefire-2151-toolchain-fork-discovery/src/test/java/com/example/ServiceThreeTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ServiceThreeTest {
+    @Test
+    void test() {
+        assertEquals(2, 1 + 1);
+    }
+}

--- a/surefire-its/src/test/resources/surefire-2151-toolchain-fork-discovery/src/test/java/com/example/ServiceTwoTest.java
+++ b/surefire-its/src/test/resources/surefire-2151-toolchain-fork-discovery/src/test/java/com/example/ServiceTwoTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ServiceTwoTest {
+    @Test
+    void test() {
+        assertEquals(2, 1 + 1);
+    }
+}


### PR DESCRIPTION
When forking has to list the tests first (forkCount > 1 or
reuseForks=false), Surefire did it in Maven's JVM. If the tests were
built for a newer JDK, that failed with UnsupportedClassVersionError.

Now the listing runs in a short-lived fork using the toolchain JDK, so
no test class is loaded in Maven's JVM. The extra fork only starts when
the test JVM differs from Maven's.

Fixes #2151

Signed-off-by: Olivier Lamy <olamy@apache.org>

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
