### PR TITLE
[SUREFIRE-523] Link all reported tests to source XRef

### DIFF
--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/AbstractSurefireReport.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/AbstractSurefireReport.java
@@ -74,8 +74,8 @@ public abstract class AbstractSurefireReport extends AbstractMavenReport {
     private File reportsDirectory;
 
     /**
-     * Link the violation line numbers to the (Test) Source XRef. Links will be created automatically if the JXR plugin is
-     * being used.
+     * Link test names to the (Test) Source XRef. Failure details link to the exact source line when available. Links will
+     * be created automatically if the JXR plugin is being used.
      */
     @Parameter(property = "linkXRef", defaultValue = "true")
     private boolean linkXRef;

--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportRenderer.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReportRenderer.java
@@ -366,9 +366,7 @@ public class SurefireReportRenderer extends AbstractMavenReportRenderer {
 
         if (!testCase.isSuccessful()) {
             sink.tableCell();
-            sinkAnchor("TC_" + toHtmlId(testCase.getFullName()));
-
-            link("#" + toHtmlId(testCase.getFullName()), testCase.getName());
+            linkTestCaseToSource(testCase);
 
             SinkEventAttributeSet atts = new SinkEventAttributeSet();
             atts.addAttribute(CLASS, "detailToggle");
@@ -398,7 +396,9 @@ public class SurefireReportRenderer extends AbstractMavenReportRenderer {
 
             sink.tableCell_();
         } else {
-            sinkCellAnchor(testCase.getName(), "TC_" + toHtmlId(testCase.getFullName()));
+            sink.tableCell();
+            linkTestCaseToSource(testCase);
+            sink.tableCell_();
         }
 
         tableCell(formatI18nString("surefire", "value.time", testCase.getTime()));
@@ -507,13 +507,13 @@ public class SurefireReportRenderer extends AbstractMavenReportRenderer {
 
                 String fullClassName = testCase.getFullClassName();
                 String errorLineNumber = testCase.getFailureErrorLine();
-                if (xrefTestLocation != null) {
-                    String path = fullClassName.replace('.', '/');
-                    sink.link(xrefTestLocation + "/" + path + ".html#L" + errorLineNumber);
+                String xrefLocation = getXrefTestSourceLocation(fullClassName, errorLineNumber);
+                if (xrefLocation != null) {
+                    sink.link(xrefLocation);
                 }
                 sink.text(fullClassName + ":" + errorLineNumber);
 
-                if (xrefTestLocation != null) {
+                if (xrefLocation != null) {
                     sink.link_();
                 }
                 sink.unknown("div", TAG_TYPE_END, null);
@@ -529,6 +529,44 @@ public class SurefireReportRenderer extends AbstractMavenReportRenderer {
         sink.lineBreak();
 
         endSection();
+    }
+
+    private void linkTestCaseToSource(ReportTestCase testCase) {
+        String xrefLocation = getXrefTestSourceLocation(testCase.getFullClassName(), null);
+        SinkEventAttributeSet atts = new SinkEventAttributeSet(ID, "TC_" + toHtmlId(testCase.getFullName()));
+        if (xrefLocation == null && !testCase.isSuccessful()) {
+            xrefLocation = "#" + toHtmlId(testCase.getFullName());
+        }
+        if (xrefLocation != null) {
+            atts.addAttribute(HREF, xrefLocation);
+        }
+
+        sink.unknown(A.toString(), TAG_TYPE_START, atts);
+        text(testCase.getName());
+        sink.unknown(A.toString(), TAG_TYPE_END, null);
+    }
+
+    private String getXrefTestSourceLocation(String fullClassName, String lineNumber) {
+        if (xrefTestLocation == null || fullClassName == null) {
+            return null;
+        }
+
+        String location = xrefTestLocation + "/" + toXrefTestSourcePath(fullClassName);
+        return lineNumber == null || lineNumber.isEmpty() ? location : location + "#L" + lineNumber;
+    }
+
+    static String toXrefTestSourcePath(String fullClassName) {
+        int reportNameSuffix = fullClassName.indexOf('(');
+        if (reportNameSuffix >= 0) {
+            fullClassName = fullClassName.substring(0, reportNameSuffix);
+        }
+
+        int nestedClass = fullClassName.indexOf('$');
+        if (nestedClass >= 0) {
+            fullClassName = fullClassName.substring(0, nestedClass);
+        }
+
+        return fullClassName.replace('.', '/') + ".html";
     }
 
     private void constructHotLinks() {

--- a/maven-surefire-report-plugin/src/site/markdown/examples/cross-referencing.md.vm
+++ b/maven-surefire-report-plugin/src/site/markdown/examples/cross-referencing.md.vm
@@ -20,7 +20,7 @@ date: July 2006
 <!-- limitations under the License.-->
 # Source Code Cross Reference
 
-There are times when we wish to know right away the line number of the source code that caused a test to the fail. The Surefire Report Plugin has the capability to cross reference the source code that made the test fail. In order to activate this feature, the `maven-jxr-plugin` should be declared in the `<reporting>` section of the POM along with the `maven-surefire-report-plugin`. For more details, please read the documentation of the [Maven JXR Plugin](http://maven.apache.org/plugins/maven-jxr-plugin/).
+The Surefire Report Plugin can link every reported test to its source class. For failed tests, the failure details link directly to the source line when it is available from the stack trace. To activate this feature, declare the `maven-jxr-plugin` in the `<reporting>` section of the POM along with the `maven-surefire-report-plugin`. For more details, read the documentation of the [Maven JXR Plugin](https://maven.apache.org/jxr/maven-jxr-plugin/).
 
 ```xml
 <project>
@@ -46,7 +46,7 @@ There are times when we wish to know right away the line number of the source co
 </project>
 ```
 
-After executing `mvn site` for site generation, you'll notice that from the **Failure Details** section of the report, a link is available to redirect you to the source code that caused the failure.
+After executing `mvn site`, each test name links to its source class. The **Failure Details** section additionally links to the source line that caused the failure when that line can be determined.
 
 In the figure below the code that caused the failure is _com.test.proj.AppTest:36_
 

--- a/maven-surefire-report-plugin/src/test/java/org/apache/maven/plugins/surefire/report/SurefireReportTest.java
+++ b/maven-surefire-report-plugin/src/test/java/org/apache/maven/plugins/surefire/report/SurefireReportTest.java
@@ -77,6 +77,21 @@ class SurefireReportTest {
 
         int idx = htmlContent.indexOf("images/icon_success_sml.gif");
         assertTrue(idx >= 0, "Wrong content in file: " + report);
+
+        assertThat(
+                htmlContent,
+                containsString("<a id=\"TC_com.shape.CircleTest.testX\" "
+                        + "href=\"./xref-test/com/shape/CircleTest.html\">testX</a>"));
+        assertThat(
+                htmlContent,
+                containsString("<a id=\"TC_com.shape.CircleTest.testRadius\" "
+                        + "href=\"./xref-test/com/shape/CircleTest.html\">testRadius</a>"));
+        assertThat(
+                htmlContent,
+                containsString("<a href=\"#com.shape.CircleTest.testRadius\">"
+                        + "<img src=\"images/icon_warning_sml.gif\" /></a>"));
+        assertThat(htmlContent, containsString("toggleDisplay('com.shape.CircleTest.testRadius')"));
+        assertThat(htmlContent, containsString("./xref-test/com/shape/CircleTest.html#L34"));
     }
 
     @Test
@@ -106,8 +121,7 @@ class SurefireReportTest {
 
         String htmlContent = String.join(System.lineSeparator(), Files.readAllLines(report.toPath()));
 
-        int idx = htmlContent.indexOf("./xref-test/com/shape/CircleTest.html#L44");
-        assertEquals(-1, idx);
+        assertFalse(htmlContent.contains("./xref-test/com/shape/CircleTest.html"));
     }
 
     @Test
@@ -119,8 +133,17 @@ class SurefireReportTest {
         assertTrue(report.exists());
         String htmlContent = String.join(System.lineSeparator(), Files.readAllLines(report.toPath()));
 
-        int idx = htmlContent.indexOf("./xref-test/com/shape/CircleTest.html#L44");
-        assertTrue(idx < 0);
+        assertFalse(htmlContent.contains("./xref-test/com/shape/CircleTest.html"));
+    }
+
+    @Test
+    void testXrefTestSourcePath() {
+        assertEquals("com/shape/CircleTest.html", SurefireReportRenderer.toXrefTestSourcePath("com.shape.CircleTest"));
+        assertEquals(
+                "com/shape/OuterTest.html", SurefireReportRenderer.toXrefTestSourcePath("com.shape.OuterTest$Nested"));
+        assertEquals(
+                "com/shape/CircleTest.html",
+                SurefireReportRenderer.toXrefTestSourcePath("com.shape.CircleTest(Linux)"));
     }
 
     @SuppressWarnings("checkstyle:methodname")
@@ -133,11 +156,11 @@ class SurefireReportTest {
         assertTrue(report.exists());
         String htmlContent = String.join(System.lineSeparator(), Files.readAllLines(report.toPath()));
 
-        int idx = htmlContent.indexOf("<td><a id=\"TC_com.shape.CircleTest.testX\"></a>testX</td>");
+        int idx = htmlContent.indexOf("<td><a id=\"TC_com.shape.CircleTest.testX\">testX</a></td>");
         assertTrue(idx > 0);
 
-        idx = htmlContent.indexOf("<td><a id=\"TC_com.shape.CircleTest.testRadius\"></a>"
-                + "<a href=\"#com.shape.CircleTest.testRadius\">testRadius</a>");
+        idx = htmlContent.indexOf("<td><a id=\"TC_com.shape.CircleTest.testRadius\" "
+                + "href=\"#com.shape.CircleTest.testRadius\">testRadius</a>");
         assertTrue(idx > 0);
     }
 

--- a/maven-surefire-report-plugin/src/test/java/org/apache/maven/plugins/surefire/report/stubs/ReportTestStub.java
+++ b/maven-surefire-report-plugin/src/test/java/org/apache/maven/plugins/surefire/report/stubs/ReportTestStub.java
@@ -18,7 +18,20 @@
  */
 package org.apache.maven.plugins.surefire.report.stubs;
 
+import java.io.InputStream;
+
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+
 public class ReportTestStub extends SurefireReportMavenProjectStub {
+
+    public ReportTestStub() {
+        try (InputStream is =
+                ReportTestStub.class.getResourceAsStream("/unit/basic-surefire-report-test/plugin-config.xml")) {
+            setModel(new MavenXpp3Reader().read(is));
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not read test project model", e);
+        }
+    }
 
     @Override
     protected String getProjectDirName() {


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

## What and why

Link every displayed test name in the Surefire report to its test-source class when JXR is configured. Failed-test details continue to link to the exact source line when it can be determined.

This also normalizes nested test classes and report-name suffixes to the source page generated by JXR, while preserving the existing report-local failure-detail links when XRef is unavailable or disabled.

## Validation

 - `mvn spotless:apply`
 - `mvn spotless:check`
 - `mvn clean install`
 - `mvn -pl maven-surefire-report-plugin -am clean verify`
 - `mvn -Dtest=SurefireReportTest -Dsurefire.failIfNoSpecifiedTests=false -pl maven-surefire-report-plugin -am clean test`
 - `mvn clean`
 - `mvn -Prun-its install` (775 tests, 0 failures, 0 errors, 154 skipped)

Fixes #1162
