### PR TITLE
[SUREFIRE-3446] Fix direct selection of JUnit Jupiter @Nested classes

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3446IT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3446IT.java
@@ -28,7 +28,7 @@ public class Surefire3446IT extends SurefireJUnit4IntegrationTestCase {
     @Test
     void shouldRunSelectedNestedClass() {
         unpack("surefire-3446-nested-selection")
-                .setTestToRun("issue3446.NestedTest$Selected")
+                .setTestToRun("issue3446.NestedTest$Intermediate$Selected")
                 .executeTest()
                 .verifyErrorFree(1);
     }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3446IT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3446IT.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration Test for #3446.
+ */
+public class Surefire3446IT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    void shouldRunSelectedNestedClass() {
+        unpack("surefire-3446-nested-selection")
+                .setTestToRun("issue3446.NestedTest$Selected")
+                .executeTest()
+                .verifyErrorFree(1);
+    }
+}

--- a/surefire-its/src/test/resources/surefire-3446-nested-selection/pom.xml
+++ b/surefire-its/src/test/resources/surefire-3446-nested-selection/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>surefire-3446-nested-selection</artifactId>
+  <version>1.0</version>
+  <name>Test for direct selection of a JUnit Jupiter nested class</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit5.version>5.14.4</junit5.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-3446-nested-selection/src/test/java/issue3446/NestedTest.java
+++ b/surefire-its/src/test/resources/surefire-3446-nested-selection/src/test/java/issue3446/NestedTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package issue3446;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class NestedTest {
+    private boolean outerSetUp;
+
+    @BeforeEach
+    void setUpOuter() {
+        outerSetUp = true;
+    }
+
+    @Test
+    void outerTestMustNotRun() {
+        fail("The outer test must not run");
+    }
+
+    @Nested
+    class Selected {
+        @Test
+        void selectedTest() {
+            assertTrue(outerSetUp);
+        }
+    }
+
+    @Nested
+    class Sibling {
+        @Test
+        void siblingTestMustNotRun() {
+            fail("A sibling nested test must not run");
+        }
+    }
+}

--- a/surefire-its/src/test/resources/surefire-3446-nested-selection/src/test/java/issue3446/NestedTest.java
+++ b/surefire-its/src/test/resources/surefire-3446-nested-selection/src/test/java/issue3446/NestedTest.java
@@ -39,18 +39,35 @@ class NestedTest {
     }
 
     @Nested
-    class Selected {
-        @Test
-        void selectedTest() {
-            assertTrue(outerSetUp);
-        }
-    }
+    class Intermediate {
+        private boolean intermediateSetUp;
 
-    @Nested
-    class Sibling {
+        @BeforeEach
+        void setUpIntermediate() {
+            assertTrue(outerSetUp);
+            intermediateSetUp = true;
+        }
+
         @Test
-        void siblingTestMustNotRun() {
-            fail("A sibling nested test must not run");
+        void intermediateTestMustNotRun() {
+            fail("The intermediate test must not run");
+        }
+
+        @Nested
+        class Selected {
+            @Test
+            void selectedTest() {
+                assertTrue(outerSetUp);
+                assertTrue(intermediateSetUp);
+            }
+        }
+
+        @Nested
+        class Sibling {
+            @Test
+            void siblingTestMustNotRun() {
+                fail("A sibling nested test must not run");
+            }
         }
     }
 }

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -441,6 +442,7 @@ public class JUnitPlatformProvider extends AbstractProvider {
         // includeClassNamePatterns support only regex patterns
         Optional<String> includesList =
                 Optional.ofNullable(parameters.getProviderProperties().get(ProviderParameterNames.INCLUDES_SCAN_LIST));
+        Set<String> enclosingClassNames = includesList.isPresent() ? getEnclosingClassNames() : Collections.emptySet();
         if (includesList.isPresent()) {
             String[] includesRegex = Stream.of(includesList.get().split(","))
                     .filter(s -> s.startsWith("%regex["))
@@ -448,7 +450,8 @@ public class JUnitPlatformProvider extends AbstractProvider {
                     .map(s -> s.substring(0, s.length() - 1))
                     .toArray(String[]::new);
             if (includesRegex.length > 0) {
-                filters.add(ClassNameFilter.includeClassNamePatterns(includesRegex));
+                filters.add(includeEnclosingClasses(
+                        ClassNameFilter.includeClassNamePatterns(includesRegex), enclosingClassNames));
             }
         }
 
@@ -475,16 +478,16 @@ public class JUnitPlatformProvider extends AbstractProvider {
                     .collect(toList());
             if (!includes.isEmpty()) {
                 // use of CompositeFilter?
-                ClassNameFilter classNameFilter = clasName -> {
+                ClassNameFilter classNameFilter = className -> {
                     FilterResult result = includes.stream()
                             .map(pattern -> FilterResult.includedIf(
-                                    match(pattern, clasName) || matchClassName(clasName, pattern)))
+                                    match(pattern, className) || matchClassName(className, pattern)))
                             .filter(FilterResult::included)
                             .findAny()
                             .orElse(FilterResult.excluded("Not included by any pattern: " + includes));
                     return result;
                 };
-                filters.add(classNameFilter);
+                filters.add(includeEnclosingClasses(classNameFilter, enclosingClassNames));
             }
         }
 
@@ -551,6 +554,33 @@ public class JUnitPlatformProvider extends AbstractProvider {
                 .ifPresent(filters::add);
 
         return filters.toArray(new Filter<?>[0]);
+    }
+
+    private Set<String> getEnclosingClassNames() {
+        Set<String> enclosingClassNames = new LinkedHashSet<>();
+        ScanResult scanResult = parameters.getScanResult();
+        for (int i = 0; i < scanResult.size(); i++) {
+            String className = scanResult.getClassName(i);
+            Class<?> testClass;
+            try {
+                testClass = parameters.getTestClassLoader().loadClass(className);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("Unable to create test class '" + className + "'", e);
+            }
+            for (Class<?> enclosingClass = testClass.getEnclosingClass();
+                    enclosingClass != null;
+                    enclosingClass = enclosingClass.getEnclosingClass()) {
+                enclosingClassNames.add(enclosingClass.getName());
+            }
+        }
+        return enclosingClassNames;
+    }
+
+    private static ClassNameFilter includeEnclosingClasses(
+            ClassNameFilter classNameFilter, Set<String> enclosingClassNames) {
+        return className -> enclosingClassNames.contains(className)
+                ? FilterResult.included("Enclosing class of an included test class")
+                : classNameFilter.apply(className);
     }
 
     Filter<?>[] getFilters() {

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
 
 import org.apache.maven.surefire.api.provider.ProviderParameters;
 import org.apache.maven.surefire.api.report.ReportEntry;
@@ -55,6 +56,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
@@ -81,6 +83,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.EXCLUDEDGROUPS_PROP;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.EXCLUDE_JUNIT5_ENGINES_PROP;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.GROUPS_PROP;
+import static org.apache.maven.surefire.api.booter.ProviderParameterNames.INCLUDES_SCAN_LIST;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.INCLUDE_JUNIT5_ENGINES_PROP;
 import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 import static org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.CONFIGURATION_PARAMETERS;
@@ -558,6 +561,51 @@ public class JUnitPlatformProviderTest {
                 reportEntries.get(1).getSourceText());
         assertEquals("level2test", reportEntries.get(1).getName());
         assertNull(reportEntries.get(1).getNameText());
+    }
+
+    @Test
+    public void runsDirectlySelectedNestedClass() throws Exception {
+        assertDirectNestedClassSelection(NestingTest.Level1NestedTest.Level2NestedTest.class.getName());
+    }
+
+    @Test
+    public void runsDirectlySelectedNestedClassWithRegexInclude() throws Exception {
+        String className = NestingTest.Level1NestedTest.Level2NestedTest.class.getName();
+        assertDirectNestedClassSelection("%regex[" + Pattern.quote(className) + "]");
+    }
+
+    @Test
+    public void doesNotTreatDollarAsNestedClassSeparator() {
+        TestListResolver testListResolver = new TestListResolver(LegalDollarClass$Test.class.getName());
+        ProviderParameters parameters = providerParametersMock(testListResolver, LegalDollarClass$Test.class);
+        when(parameters.getProviderProperties())
+                .thenReturn(singletonMap(INCLUDES_SCAN_LIST, LegalDollarClass$Test.class.getName()));
+
+        JUnitPlatformProvider provider = new JUnitPlatformProvider(parameters);
+
+        assertThat(provider.getFilters()).hasSize(1);
+        ClassNameFilter includeFilter = (ClassNameFilter) provider.getFilters()[0];
+        assertTrue(includeFilter.apply(LegalDollarClass$Test.class.getName()).included());
+        assertFalse(includeFilter.apply(LegalDollarClass.class.getName()).included());
+    }
+
+    private static void assertDirectNestedClassSelection(String includeScanPattern) throws Exception {
+        Class<?> selectedClass = NestingTest.Level1NestedTest.Level2NestedTest.class;
+        TestListResolver testListResolver = new TestListResolver(selectedClass.getName());
+        ProviderParameters parameters = providerParametersMock(testListResolver, selectedClass);
+        when(parameters.getProviderProperties()).thenReturn(singletonMap(INCLUDES_SCAN_LIST, includeScanPattern));
+
+        TestPlanSummaryListener executionListener = new TestPlanSummaryListener();
+        JUnitPlatformProvider provider =
+                new JUnitPlatformProvider(parameters, createLauncherSessionWithListeners(executionListener));
+
+        invokeProvider(provider, null);
+
+        assertThat(executionListener.summaries).hasSize(1);
+        TestExecutionSummary summary = executionListener.summaries.get(0);
+        assertEquals(1, summary.getTestsFoundCount());
+        assertEquals(1, summary.getTestsSucceededCount());
+        assertEquals(0, summary.getTestsFailedCount());
     }
 
     @Test
@@ -1194,6 +1242,10 @@ public class JUnitPlatformProviderTest {
 
         ScanResult scanResult = mock(ScanResult.class);
         when(scanResult.applyFilter(any(), any())).thenReturn(testsToRun);
+        when(scanResult.size()).thenReturn(testClasses.length);
+        for (int i = 0; i < testClasses.length; i++) {
+            when(scanResult.getClassName(i)).thenReturn(testClasses[i].getName());
+        }
 
         RunOrderCalculator runOrderCalculator = mock(RunOrderCalculator.class);
         when(runOrderCalculator.orderTestClasses(any())).thenReturn(testsToRun);
@@ -1209,6 +1261,7 @@ public class JUnitPlatformProviderTest {
         when(providerParameters.getRunOrderCalculator()).thenReturn(runOrderCalculator);
         when(providerParameters.getReporterFactory()).thenReturn(reporterFactory);
         when(providerParameters.getTestRequest()).thenReturn(testRequest);
+        when(providerParameters.getTestClassLoader()).thenReturn(JUnitPlatformProviderTest.class.getClassLoader());
 
         return providerParameters;
     }
@@ -1592,3 +1645,8 @@ public class JUnitPlatformProviderTest {
         return (T) field.get(target);
     }
 }
+
+class LegalDollarClass {}
+
+@SuppressWarnings("checkstyle:typename")
+class LegalDollarClass$Test {}


### PR DESCRIPTION
Direct selection of a non-static JUnit Jupiter `@Nested` class stopped
discovering tests after provider-level class-name filters were added. JUnit
needs the enclosing class hierarchy to construct the selected nested test, but
an exact include for the leaf class rejected those enclosing descriptors.

This change derives the actual enclosing hierarchy from `Class` metadata and
allows those classes through the include filters. It deliberately does not
infer nesting from `$` in the binary name, because `$` is also legal in a
top-level class name. Existing post-discovery filtering continues to prevent
tests in the enclosing classes or sibling nested classes from running.

The regression coverage includes ordinary and regex includes, a legal
top-level class containing `$`, and a two-level nested selection whose outer
and intermediate `@BeforeEach` callbacks must both run. Tests in the outer,
intermediate, and sibling classes fail if selection leaks beyond the requested
leaf.

Fixes #3446

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean install`).

Validation performed with JDK 17:

 - `mvn spotless:apply spotless:check`
 - `mvn -pl surefire-providers/surefire-junit-platform clean install` (99 tests)
 - `mvn -Prun-its -pl surefire-its -Dit.test=Surefire3446IT clean verify`
 - `mvn -nsu -Dmaven.build.cache.enabled=false -Prun-its clean install`
   (17-module reactor; 776 integration tests, 0 failures, 0 errors)

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
