### PR TITLE
Force forked JVM mode for Maven 4 ITs

### DIFF
--- a/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/util/CountdownCloseable.java
+++ b/surefire-extensions-api/src/main/java/org/apache/maven/surefire/extensions/util/CountdownCloseable.java
@@ -53,7 +53,7 @@ public final class CountdownCloseable implements Closeable {
      * @throws InterruptedException see {@link Object#wait()}
      */
     public synchronized void awaitClosed() throws InterruptedException {
-        if (countdown > 0) {
+        while (countdown > 0) {
             wait();
         }
     }

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/MavenLauncher.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/fixture/MavenLauncher.java
@@ -76,8 +76,10 @@ public final class MavenLauncher {
         this.resourceName = resourceName;
         this.suffix = suffix != null ? suffix : "";
         this.cli = cli == null ? null : cli.clone();
-        // by default use embedded mode
-        this.forkJvm = false;
+        // Use forked mode for Maven 4+ because maven-verifier 2.0.0-M1's embedded mode
+        // uses reflection against MavenCling.doMain() with an incompatible method signature.
+        // Once surefire migrates from maven-verifier to maven-executor, this can be removed.
+        this.forkJvm = isMaven4();
         resetGoals();
         resetCliOptions();
     }
@@ -407,6 +409,32 @@ public final class MavenLauncher {
         return defaultCliOptions == null
                 ? new Verifier(basedir, settingsFile, false)
                 : new Verifier(basedir, settingsFile, false, defaultCliOptions);
+    }
+
+    /**
+     * Detects if the current Maven installation is version 4.x or later by checking for the
+     * presence of {@code maven-cli-*.jar} in the Maven home lib directory. Maven 4 introduced
+     * the {@code maven-cli} module which is not present in Maven 3.x installations.
+     *
+     * @return {@code true} if Maven 4+ is detected
+     */
+    private static boolean isMaven4() {
+        String mavenHome = System.getProperty("maven.home", "");
+        if (mavenHome.isEmpty()) {
+            return false;
+        }
+        File libDir = new File(mavenHome, "lib");
+        if (libDir.isDirectory()) {
+            String[] files = libDir.list();
+            if (files != null) {
+                for (String file : files) {
+                    if (file.startsWith("maven-cli-")) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private static File settingsXmlPath() {


### PR DESCRIPTION
## Summary

Re-rolls Guillaume's Maven 4 IT workaround as a standalone PR against master so it can't get lost in future rebases of #3352.

- **Force forked JVM for Maven 4:** `maven-verifier 2.0.0-M1`'s embedded mode reflects on `MavenCli.doMain(...)`, which Maven 4 replaced with `MavenCling` (incompatible signature → `NoSuchMethodException` → 437 IT failures). `MavenLauncher` now detects Maven 4 by checking for `maven-cli-*.jar` in `$MAVEN_HOME/lib/` and forces `forkJvm=true`, bypassing the broken reflection entirely.
- **Fix `CountdownCloseable` spurious wakeup:** `awaitClosed()` used `if` instead of `while` to guard `Object.wait()`, violating the JLS contract. Could explain intermittent `CommandlineExecutorTest` failures.

This is a **short-term workaround**. The long-term fix is migrating from the deprecated `maven-verifier` to [`maven-executor`](https://github.com/apache/maven-executor) which natively supports both Maven 3.x and 4.x (apache/maven-verifier#186).

Context: https://github.com/apache/maven-surefire/pull/3352#issuecomment-5245583078

## Test plan

- [ ] Maven 3 ITs remain unaffected (`isMaven4()` returns `false`, `forkJvm` stays `false`)
- [ ] Maven 4 ITs no longer fail with `NoSuchMethodException` (forked mode bypasses embedded reflection)
- [ ] `CountdownCloseable.awaitClosed()` is robust against JLS spurious wakeups

🤖 Generated with [Claude Code](https://claude.com/claude-code)