### PR TITLE
Bump Maven parent version from 47 to 49

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,6 @@ updates:
   schedule:
     interval: "daily"
   ignore:
-    # Ignore Maven Core updates
-    - dependency-name: "org.apache.maven:*"
     # to remove when depending on core 4.x
     - dependency-name: "org.slf4j:*"
       versions: [ ">=2.0"]

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/lazytestprovider/TestLessInputStreamBuilderTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/lazytestprovider/TestLessInputStreamBuilderTest.java
@@ -180,42 +180,48 @@ public class TestLessInputStreamBuilderTest {
     @Test
     public void shouldThrowUnsupportedException1() {
         TestLessInputStreamBuilder builder = new TestLessInputStreamBuilder();
-        assertThrows(UnsupportedOperationException.class, () -> builder.getImmediateCommands()
-                .provideNewTest());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> builder.getImmediateCommands().provideNewTest());
     }
 
     @Test
     public void shouldThrowUnsupportedException2() {
         TestLessInputStreamBuilder builder = new TestLessInputStreamBuilder();
-        assertThrows(UnsupportedOperationException.class, () -> builder.getImmediateCommands()
-                .skipSinceNextTest());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> builder.getImmediateCommands().skipSinceNextTest());
     }
 
     @Test
     public void shouldThrowUnsupportedException3() {
         TestLessInputStreamBuilder builder = new TestLessInputStreamBuilder();
-        assertThrows(UnsupportedOperationException.class, () -> builder.getImmediateCommands()
-                .acknowledgeByeEventReceived());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> builder.getImmediateCommands().acknowledgeByeEventReceived());
     }
 
     @Test
     public void shouldThrowUnsupportedException4() {
         TestLessInputStreamBuilder builder = new TestLessInputStreamBuilder();
-        assertThrows(UnsupportedOperationException.class, () -> builder.getCachableCommands()
-                .acknowledgeByeEventReceived());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> builder.getCachableCommands().acknowledgeByeEventReceived());
     }
 
     @Test
     public void shouldThrowUnsupportedException5() {
         TestLessInputStreamBuilder builder = new TestLessInputStreamBuilder();
-        assertThrows(UnsupportedOperationException.class, () -> builder.getCachableCommands()
-                .provideNewTest());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> builder.getCachableCommands().provideNewTest());
     }
 
     @Test
     public void shouldThrowUnsupportedException6() {
         TestLessInputStreamBuilder builder = new TestLessInputStreamBuilder();
-        assertThrows(UnsupportedOperationException.class, () -> builder.getCachableCommands()
-                .noop());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> builder.getCachableCommands().noop());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>47</version>
+    <version>49</version>
   </parent>
 
   <groupId>org.apache.maven.surefire</groupId>


### PR DESCRIPTION
What changed:
- Updated Maven parent version from 47 to 49 in `pom.xml`.
- Removed the ignore rule for Maven Core updates in `dependabot.yml`, also block report of parent updates

