### PR TITLE
Fix inverted filter predicate in ForkStarter#readTestClassNames

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -30,7 +30,17 @@ jobs:
       ff-jdk: '21'
       ff-goal: 'clean install site site:stage -P reporting -nsu'
       ff-site-goal: '-v'
-      verify-goal: 'clean install -nsu -P run-its'
+      # setup-java installs these and exports JAVA_HOME_<version>_<arch> for each one.
+      # 25 is newer than anything in jdk-matrix, so it can act as the toolchain JDK.
+      jdk-toolchain: |
+        11
+        17
+        21
+        25
+      # Gives Surefire2151ToolchainForkDiscoveryIT a toolchain JDK that really differs from
+      # the JVM running Maven. Without it the test never gets to the fork it is about.
+      # Only the x64 bash runners expand this; elsewhere it is empty and the test skips.
+      verify-goal: 'clean install -nsu -P run-its "-Dsurefire.test.toolchain.jdkHome=$JAVA_HOME_25_X64"'
       verify-fail-fast: false
       # Investigation reasons: Some tests generate custom files, standard reports and logs.
       # Remove the line with `*-jvmRun*-events.bin` pattern if large streams should be investigated.

--- a/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
+++ b/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/ForkStarter.java
@@ -849,7 +849,12 @@ public class ForkStarter {
                         false,
                         discoveryFile.getAbsolutePath());
             }
-            return readTestClassNames(discoveryFile);
+            List<String> testClassNames = readTestClassNames(discoveryFile);
+            if (testClassNames.isEmpty()) {
+                log.warning("The test-listing fork did not discover any test class (see " + discoveryFile
+                        + "). No tests will run.");
+            }
+            return testClassNames;
         } finally {
             returnNumber(forkNumber);
             removeShutdownHook(shutdown);
@@ -868,7 +873,7 @@ public class ForkStarter {
         try {
             return Files.readAllLines(discoveryFile.toPath(), UTF_8).stream()
                     .map(String::trim)
-                    .filter(String::isEmpty)
+                    .filter(line -> !line.isEmpty())
                     .collect(toList());
         } catch (IOException e) {
             throw new SurefireBooterForkException("Cannot read discovered tests from " + discoveryFile, e);

--- a/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
+++ b/maven-surefire-common/src/test/java/org/apache/maven/plugin/surefire/booterclient/ForkStarterTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.List;
 import java.util.jar.Manifest;
 import java.util.zip.Deflater;
 
@@ -62,6 +63,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -288,6 +291,19 @@ public class ForkStarterTest {
                 new LegacyForkNodeFactory(),
                 true);
         testLessInputStream.close();
+    }
+
+    @Test
+    public void readTestClassNamesShouldKeepDiscoveredClassesAndDropBlankLines() throws Exception {
+        File discoveryFile = new File(tmp, "surefire-discovered-tests.txt");
+        Files.write(discoveryFile.toPath(), asList("com.example.FooTest", "", "  com.example.BarTest  ", "   "), UTF_8);
+
+        Method method = ForkStarter.class.getDeclaredMethod("readTestClassNames", File.class);
+        method.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<String> testClassNames = (List<String>) method.invoke(null, discoveryFile);
+
+        assertThat(testClassNames).containsExactly("com.example.FooTest", "com.example.BarTest");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Description
In `ForkStarter#readTestClassNames`, `Files.readAllLines` was filtered using `String::isEmpty`, which inadvertently discarded all discovered test class names and retained only blank lines.

When using toolchains or `forkCount > 1` / `reuseForks=false`, this resulted in zero tests being scheduled and the build passing silently without running any test classes.

### Changes
- Changed `.filter(String::isEmpty)` to `.filter(line -> !line.isEmpty())` in `ForkStarter#readTestClassNames`.
- Added a warning if the discovery file contains no test classes.
- Added unit test `readTestClassNamesShouldKeepDiscoveredClassesAndDropBlankLines` in `ForkStarterTest`.