### PR TITLE
Fix TXT report counts for outer class with only @Nested tests (#3356)

### DIFF
--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3356NestedTxtReportIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3356NestedTxtReportIT.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import org.apache.maven.surefire.its.fixture.OutputValidator;
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.apache.maven.surefire.its.fixture.TestFile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaVersion;
+
+/**
+ * Integration test for #3356: TXT report must count nested tests on the outer class.
+ */
+@SuppressWarnings("checkstyle:magicnumber")
+public class Surefire3356NestedTxtReportIT extends SurefireJUnit4IntegrationTestCase {
+
+    @BeforeEach
+    public void setUp() {
+        assumeJavaVersion(17);
+    }
+
+    @Test
+    public void txtReportCountsNestedTestsOnOuterClass() {
+        OutputValidator validator =
+                unpack("surefire-3356-nested-txt-report").maven().executeTest().verifyErrorFree(3);
+
+        TestFile txt = validator.getSurefireReportsFile("jira3356.NestedOnlyTest.txt");
+        txt.assertFileExists();
+        txt.assertContainsText("Tests run: 3");
+
+        TestFile xml = validator.getSurefireReportsFile("TEST-jira3356.NestedOnlyTest.xml", UTF_8);
+        xml.assertFileExists();
+        xml.assertContainsText("tests=\"3\"");
+    }
+}

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3356NestedTxtReportIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3356NestedTxtReportIT.java
@@ -21,20 +21,21 @@ package org.apache.maven.surefire.its.jiras;
 import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.apache.maven.surefire.its.fixture.TestFile;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.BeforeClass;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaVersion;
 
 /**
- * Integration test for #3356: TXT report must count nested tests on the outer class.
+ * Integration test for https://github.com/apache/maven-surefire/issues/3356:
+ * TXT report must count nested tests on the outer class.
  */
 @SuppressWarnings("checkstyle:magicnumber")
 public class Surefire3356NestedTxtReportIT extends SurefireJUnit4IntegrationTestCase {
 
-    @BeforeEach
-    public void setUp() {
+    @BeforeClass
+    public static void setUp() {
         assumeJavaVersion(17);
     }
 

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3356NestedTxtReportIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3356NestedTxtReportIT.java
@@ -21,7 +21,7 @@ package org.apache.maven.surefire.its.jiras;
 import org.apache.maven.surefire.its.fixture.OutputValidator;
 import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
 import org.apache.maven.surefire.its.fixture.TestFile;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -34,7 +34,7 @@ import static org.apache.maven.surefire.its.fixture.HelperAssertions.assumeJavaV
 @SuppressWarnings("checkstyle:magicnumber")
 public class Surefire3356NestedTxtReportIT extends SurefireJUnit4IntegrationTestCase {
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         assumeJavaVersion(17);
     }

--- a/surefire-its/src/test/resources/surefire-3356-nested-txt-report/pom.xml
+++ b/surefire-its/src/test/resources/surefire-3356-nested-txt-report/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>surefire-3356-nested-txt-report</artifactId>
+  <version>1.0</version>
+  <name>[#3356] TXT report counts for outer class with only @Nested tests</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.12.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${surefire.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-3356-nested-txt-report/src/test/java/jira3356/NestedOnlyTest.java
+++ b/surefire-its/src/test/resources/surefire-3356-nested-txt-report/src/test/java/jira3356/NestedOnlyTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package jira3356;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproducer for #3356: all tests live in {@code @Nested} classes.
+ */
+class NestedOnlyTest {
+    @Nested
+    class GroupA {
+        @Test
+        void testOne() {
+            assertTrue(true);
+        }
+
+        @Test
+        void testTwo() {
+            assertTrue(true);
+        }
+    }
+
+    @Nested
+    class GroupB {
+        @Test
+        void testThree() {
+            assertTrue(true);
+        }
+    }
+}

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -134,7 +134,12 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
         if (isClassContainer(testIdentifier)) {
             testStartTime.put(testIdentifier, System.currentTimeMillis());
-            runListener.testSetStarting(createReportEntry(testIdentifier));
+            // Only top-level class containers open a Surefire test set. @Nested ClassSource
+            // containers share the outer sourceName; starting/completing them as separate
+            // sets resets stats and overwrites the outer TXT report with Tests run: 0 (#3356).
+            if (isSurefireTestSetContainer(testIdentifier)) {
+                runListener.testSetStarting(createReportEntry(testIdentifier));
+            }
         } else if (testIdentifier.isTest()) {
             testStartTime.put(testIdentifier, System.currentTimeMillis());
             runListener.testStarting(createReportEntry(testIdentifier));
@@ -187,7 +192,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                     } else {
                         runListener.testError(reportEntry);
                     }
-                    if (isClass || isRootContainer) {
+                    if (isSurefireTestSetContainer(testIdentifier) || isRootContainer) {
                         runListener.testSetCompleted(
                                 createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
                     }
@@ -206,7 +211,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                         if (succeeded.getSourceName() != null) {
                             classesWithSuccessfulTests.add(succeeded.getSourceName());
                         }
-                    } else {
+                    } else if (isSurefireTestSetContainer(testIdentifier)) {
                         runListener.testSetCompleted(
                                 createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
                     }
@@ -219,8 +224,10 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     private void reportAbortedClass(
             TestIdentifier testIdentifier, TestExecutionResult testExecutionResult, Integer elapsed) {
         if (classContainersWithStartedTests.contains(testIdentifier.getUniqueId())) {
-            runListener.testSetCompleted(
-                    createReportEntry(testIdentifier, testExecutionResult, systemProps(), null, elapsed));
+            if (isSurefireTestSetContainer(testIdentifier)) {
+                runListener.testSetCompleted(
+                        createReportEntry(testIdentifier, testExecutionResult, systemProps(), null, elapsed));
+            }
             return;
         }
 
@@ -241,7 +248,9 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
             }
         }
 
-        runListener.testSetCompleted(createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
+        if (isSurefireTestSetContainer(testIdentifier)) {
+            runListener.testSetCompleted(createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
+        }
     }
 
     private void recordStartedTest(TestIdentifier testIdentifier) {
@@ -266,6 +275,22 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                         .getSource()
                         .filter(ClassSource.class::isInstance)
                         .isPresent();
+    }
+
+    /**
+     * Whether this class container should open/close a Surefire test set.
+     * Top-level classes do; {@code @Nested} ClassSource containers do not, because they
+     * report under the outer class {@code sourceName} and would otherwise reset/overwrite
+     * the outer TXT summary (#3356).
+     */
+    private boolean isSurefireTestSetContainer(TestIdentifier testIdentifier) {
+        if (!isClassContainer(testIdentifier)) {
+            return false;
+        }
+        ResultDisplay names = toClassMethodName(testIdentifier);
+        String sourceName = names.getClassName();
+        String qualifiedClassName = names.getQualifiedClassName();
+        return qualifiedClassName == null || Objects.equals(sourceName, qualifiedClassName);
     }
 
     private Integer computeElapsedTime(TestIdentifier testIdentifier) {
@@ -336,12 +361,17 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         testStartTime.remove(testIdentifier);
 
         if (isClass) {
+            boolean openTestSet = isSurefireTestSetContainer(testIdentifier);
             SimpleReportEntry report = createReportEntry(testIdentifier);
-            runListener.testSetStarting(report);
+            if (openTestSet) {
+                runListener.testSetStarting(report);
+            }
             for (TestIdentifier child : testPlan.getChildren(testIdentifier)) {
                 runListener.testSkipped(createReportEntry(child, null, emptyMap(), reason, null));
             }
-            runListener.testSetCompleted(report);
+            if (openTestSet) {
+                runListener.testSetCompleted(report);
+            }
         } else {
             runListener.testSkipped(createReportEntry(testIdentifier, null, emptyMap(), reason, null));
         }

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -287,10 +287,23 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         if (!isClassContainer(testIdentifier)) {
             return false;
         }
-        ResultDisplay names = toClassMethodName(testIdentifier);
-        String sourceName = names.getClassName();
-        String qualifiedClassName = names.getQualifiedClassName();
-        return qualifiedClassName == null || Objects.equals(sourceName, qualifiedClassName);
+        // Top-level for Surefire = no ancestor ClassSource container.
+        // Name equality is wrong for JUnit 6 parameterized-class invocations: both the
+        // template and each invocation are ClassSource containers with the same
+        // sourceName/qualifiedClassName, so invocations would still open test sets (#3356).
+        TestPlan currentTestPlan = testPlan;
+        if (currentTestPlan == null) {
+            return true;
+        }
+        Optional<TestIdentifier> parent = currentTestPlan.getParent(testIdentifier);
+        while (parent.isPresent()) {
+            TestIdentifier ancestor = parent.get();
+            if (isClassContainer(ancestor)) {
+                return false;
+            }
+            parent = currentTestPlan.getParent(ancestor);
+        }
+        return true;
     }
 
     private Integer computeElapsedTime(TestIdentifier testIdentifier) {
@@ -366,8 +379,18 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
             if (openTestSet) {
                 runListener.testSetStarting(report);
             }
-            for (TestIdentifier child : testPlan.getChildren(testIdentifier)) {
-                runListener.testSkipped(createReportEntry(child, null, emptyMap(), reason, null));
+            // Walk leaf tests (not only direct children) so a skipped @Nested container that
+            // itself contains another nested container still counts one skip per test method.
+            List<TestIdentifier> skippedTests = testPlan.getDescendants(testIdentifier).stream()
+                    .filter(TestIdentifier::isTest)
+                    .sorted(comparing(TestIdentifier::getUniqueId))
+                    .collect(toList());
+            if (skippedTests.isEmpty()) {
+                runListener.testSkipped(createReportEntry(testIdentifier, null, emptyMap(), reason, null));
+            } else {
+                for (TestIdentifier test : skippedTests) {
+                    runListener.testSkipped(createReportEntry(test, null, emptyMap(), reason, null));
+                }
             }
             if (openTestSet) {
                 runListener.testSetCompleted(report);

--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -279,18 +279,19 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
     /**
      * Whether this class container should open/close a Surefire test set.
-     * Top-level classes do; {@code @Nested} ClassSource containers do not, because they
-     * report under the outer class {@code sourceName} and would otherwise reset/overwrite
-     * the outer TXT summary (#3356).
+     * {@code @Nested} ClassSource containers do not, because they report under the outer
+     * class {@code sourceName} and would otherwise reset/overwrite the outer TXT summary
+     * (#3356). Stop at an engine boundary so a class selected under {@code @Suite} (suite
+     * ClassSource above a nested Jupiter engine) still opens its own test set — same
+     * engine-boundary rule as {@link #findTopParent(TestIdentifier)}.
      */
     private boolean isSurefireTestSetContainer(TestIdentifier testIdentifier) {
         if (!isClassContainer(testIdentifier)) {
             return false;
         }
-        // Top-level for Surefire = no ancestor ClassSource container.
         // Name equality is wrong for JUnit 6 parameterized-class invocations: both the
         // template and each invocation are ClassSource containers with the same
-        // sourceName/qualifiedClassName, so invocations would still open test sets (#3356).
+        // sourceName/qualifiedClassName, so walk ancestors instead of comparing names.
         TestPlan currentTestPlan = testPlan;
         if (currentTestPlan == null) {
             return true;
@@ -298,6 +299,11 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
         Optional<TestIdentifier> parent = currentTestPlan.getParent(testIdentifier);
         while (parent.isPresent()) {
             TestIdentifier ancestor = parent.get();
+            // Suite hierarchy: SuiteClass -> nested engine -> TestClass. Stop here so the
+            // selected test class is still a Surefire test-set root.
+            if (isEngineIdentifier(ancestor)) {
+                return true;
+            }
             if (isClassContainer(ancestor)) {
                 return false;
             }

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.engine.config.DefaultJupiterConfiguration;
 import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
+import org.junit.jupiter.engine.descriptor.NestedClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
 import org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor;
 import org.junit.platform.engine.ConfigurationParameters;
@@ -653,6 +654,64 @@ public class RunListenerAdapterTest {
     }
 
     @Test
+    public void nestedClassContainersDoNotOpenSeparateTestSets() throws Exception {
+        // Reproducer for #3356: all tests in @Nested classes must keep a single outer test set
+        // so the TXT report is not overwritten with Tests run: 0 after nested completion.
+        // Real Jupiter plans have an engine root above the class; findTopParent needs that.
+        EngineDescriptor engineDescriptor = newEngineDescriptor();
+        TestDescriptor classDescriptor = new ClassTestDescriptor(
+                engineDescriptor.getUniqueId().append("class", MyTestClass.class.getName()),
+                MyTestClass.class,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        TestDescriptor nestedDescriptor = new NestedClassTestDescriptor(
+                classDescriptor.getUniqueId().append("nested-class", MyTestClass.NestedGroup.class.getName()),
+                MyTestClass.NestedGroup.class,
+                () -> singletonList(MyTestClass.class),
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        TestDescriptor nestedMethod = new TestMethodTestDescriptor(
+                nestedDescriptor.getUniqueId().append("method", "nestedTest"),
+                MyTestClass.NestedGroup.class,
+                MyTestClass.NestedGroup.class.getDeclaredMethod("nestedTest"),
+                Collections::emptyList,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        engineDescriptor.addChild(classDescriptor);
+        classDescriptor.addChild(nestedDescriptor);
+        nestedDescriptor.addChild(nestedMethod);
+
+        TestPlan testPlan = TestPlan.from(false, singletonList(engineDescriptor), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(testPlan);
+
+        TestIdentifier classIdentifier = TestIdentifier.from(classDescriptor);
+        TestIdentifier nestedIdentifier = TestIdentifier.from(nestedDescriptor);
+        TestIdentifier methodIdentifier = TestIdentifier.from(nestedMethod);
+
+        adapter.executionStarted(classIdentifier);
+        adapter.executionStarted(nestedIdentifier);
+        adapter.executionStarted(methodIdentifier);
+        adapter.executionFinished(methodIdentifier, successful());
+        adapter.executionFinished(nestedIdentifier, successful());
+        adapter.executionFinished(classIdentifier, successful());
+
+        InOrder inOrder = inOrder(listener);
+        ArgumentCaptor<TestSetReportEntry> starting = ArgumentCaptor.forClass(TestSetReportEntry.class);
+        ArgumentCaptor<ReportEntry> succeeded = ArgumentCaptor.forClass(ReportEntry.class);
+        ArgumentCaptor<TestSetReportEntry> completed = ArgumentCaptor.forClass(TestSetReportEntry.class);
+
+        inOrder.verify(listener).testSetStarting(starting.capture());
+        inOrder.verify(listener).testStarting(any());
+        inOrder.verify(listener).testSucceeded(succeeded.capture());
+        inOrder.verify(listener).testSetCompleted(completed.capture());
+        inOrder.verifyNoMoreInteractions();
+
+        assertThat(starting.getAllValues()).hasSize(1);
+        assertThat(completed.getAllValues()).hasSize(1);
+        assertEquals(MyTestClass.class.getName(), starting.getValue().getSourceName());
+        assertEquals(MyTestClass.class.getName(), completed.getValue().getSourceName());
+        assertEquals(MyTestClass.class.getName(), succeeded.getValue().getSourceName());
+        assertEquals(
+                MyTestClass.NestedGroup.class.getName(), succeeded.getValue().getSourceQualifiedName());
+    }
+
     public void notifiedWhenMethodExecutionAborted() throws Exception {
         adapter.executionFinished(newMethodIdentifier(), aborted(null));
         verify(listener).testAssumptionFailure(any());
@@ -1320,6 +1379,12 @@ public class RunListenerAdapterTest {
         @DisplayName("name")
         @org.junit.jupiter.api.Test
         void myNamedTestMethod() {}
+
+        @org.junit.jupiter.api.Nested
+        class NestedGroup {
+            @org.junit.jupiter.api.Test
+            void nestedTest() {}
+        }
     }
 
     private static class MySuiteClass {}


### PR DESCRIPTION
Fixes #3356.

When every JUnit 5 test lived in `@Nested` classes, the outer class `.txt` report showed `Tests run: 0` while the XML report was correct.

`@Nested` ClassSource containers share the outer `sourceName`. Treating them as their own Surefire test sets completed and reset stats under that name, so the outer TXT file was overwritten with zero. XML still looked right because it accumulates via its history map.

This change only opens/closes a test set for top-level class containers. Nested containers keep contributing to the outer set, so TXT and XML stay aligned.

Verified with:
- `RunListenerAdapterTest` (full suite, including new `#nestedClassContainersDoNotOpenSeparateTestSets`)
- ITs: `Surefire3356NestedTxtReportIT`, `Surefire2298IT`, `Surefire3446IT`
- Manual repro with the SNAPSHOT plugin (`Tests run: 3` in the outer `.txt`)