### PR TITLE
[SUREFIRE-3460] Don't NPE when StackWalkerStrategy inits with a null TCCL

### DIFF
--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/report/StackWalkerStrategy.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/report/StackWalkerStrategy.java
@@ -55,7 +55,12 @@ final class StackWalkerStrategy {
     private static final Method FRAME_METHOD_NAME; // StackWalker.StackFrame.getMethodName() -> String
 
     static {
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        // java.lang.StackWalker is a JDK class; load it from this class's defining loader (the system
+        // loader if that is bootstrap null), not from the current thread's TCCL, which can be null.
+        ClassLoader classLoader = StackWalkerStrategy.class.getClassLoader();
+        if (classLoader == null) {
+            classLoader = ClassLoader.getSystemClassLoader();
+        }
 
         Class<?> stackWalkerClass = tryLoadClass(classLoader, "java.lang.StackWalker");
         // The concrete frame implementation is a non-exported jdk.internal class, so the accessor methods must be

--- a/surefire-api/src/main/java/org/apache/maven/surefire/api/util/ReflectionUtils.java
+++ b/surefire-api/src/main/java/org/apache/maven/surefire/api/util/ReflectionUtils.java
@@ -146,13 +146,15 @@ public final class ReflectionUtils {
         return newInstance(constructor, params);
     }
 
-    @SuppressWarnings("checkstyle:emptyblock")
     public static Class<?> tryLoadClass(ClassLoader classLoader, String className) {
+        if (classLoader == null) {
+            return null;
+        }
         try {
             return classLoader.loadClass(className);
-        } catch (NoClassDefFoundError | ClassNotFoundException ignore) {
+        } catch (NoClassDefFoundError | ClassNotFoundException e) {
+            return null;
         }
-        return null;
     }
 
     public static Class<?> loadClass(ClassLoader classLoader, String className) {

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/report/StackTraceProviderTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/report/StackTraceProviderTest.java
@@ -142,4 +142,18 @@ class StackTraceProviderTest {
         assertThat(frames).noneMatch(frame -> frame.startsWith(StackWalkerStrategy.class.getName() + "#"));
         assertThat(frames.get(0)).isEqualTo(getClass().getName() + "#strategyWalkAppliesExcludePredicate");
     }
+
+    @Test
+    void getStackDoesNotThrowWhenContextClassLoaderIsNull() {
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(null);
+        try {
+            List<String> stack = StackTraceProvider.getStack();
+            assertThat(stack).isNotNull();
+            assertThat(stack.get(0))
+                    .isEqualTo(getClass().getName() + "#getStackDoesNotThrowWhenContextClassLoaderIsNull");
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
 }

--- a/surefire-api/src/test/java/org/apache/maven/surefire/api/util/ReflectionUtilsTest.java
+++ b/surefire-api/src/test/java/org/apache/maven/surefire/api/util/ReflectionUtilsTest.java
@@ -54,6 +54,24 @@ public class ReflectionUtilsTest {
     }
 
     @Test
+    public void tryLoadClassReturnsNullWhenClassLoaderIsNull() {
+        assertThat(ReflectionUtils.tryLoadClass(null, "java.lang.String")).isNull();
+    }
+
+    @Test
+    public void tryLoadClassReturnsNullWhenClassIsMissing() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        assertThat(ReflectionUtils.tryLoadClass(cl, "org.apache.maven.surefire.api.util.DoesNotExist"))
+                .isNull();
+    }
+
+    @Test
+    public void tryLoadClassLoadsExistingClass() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        assertThat(ReflectionUtils.tryLoadClass(cl, "java.lang.String")).isEqualTo(String.class);
+    }
+
+    @Test
     public void shouldNotInvokeStaticMethod() {
         assertThrows(
                 RuntimeException.class,

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3460IT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3460IT.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration Test for #3460.
+ */
+public class Surefire3460IT extends SurefireJUnit4IntegrationTestCase {
+    @Test
+    void printFromNullTcclThread() {
+        executeErrorFreeTest("surefire-3460-null-tccl", 1);
+    }
+}

--- a/surefire-its/src/test/resources/surefire-3460-null-tccl/pom.xml
+++ b/surefire-its/src/test/resources/surefire-3460-null-tccl/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.surefire</groupId>
+  <artifactId>surefire-3460-null-tccl</artifactId>
+  <version>1.0</version>
+  <name>Test console capture with a null context class loader</name>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <junit5.version>5.14.4</junit5.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/surefire-its/src/test/resources/surefire-3460-null-tccl/src/test/java/issue3460/NullTcclPrintTest.java
+++ b/surefire-its/src/test/resources/surefire-3460-null-tccl/src/test/java/issue3460/NullTcclPrintTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package issue3460;
+
+import org.junit.jupiter.api.Test;
+
+class NullTcclPrintTest {
+
+    @Test
+    void printFromThreadWithNullContextClassLoader() throws Exception {
+        Throwable[] failure = new Throwable[1];
+        Thread t = new Thread(() -> {
+            try {
+                System.err.println("hello from null-TCCL thread");
+            } catch (Throwable e) {
+                failure[0] = e;
+            }
+        });
+        t.setContextClassLoader(null);
+        t.start();
+        t.join();
+        if (failure[0] != null) {
+            throw new AssertionError("println failed", failure[0]);
+        }
+    }
+}


### PR DESCRIPTION
`StackWalkerStrategy.<clinit>` loaded `java.lang.StackWalker` through the current thread's TCCL. When that loader is `null` (user threads that cleared it, or the JVM `Attach Listener` while a dynamic agent is installed), `ReflectionUtils.tryLoadClass` threw an uncaught `NullPointerException`. That failed class initialization and every later reference became `NoClassDefFoundError: Could not initialize class ...StackWalkerStrategy`.

Because console capture walks the stack on every `println`, a write from a null-TCCL thread could poison the forked JVM. On 3.6.0 this also surfaces as a confusing Byte Buddy / BlockHound self-attach failure when the JDK prints the dynamic-agent warning from `Attach Listener`.

This change:

- treats a null `ClassLoader` as "not found" in `tryLoadClass` (`ClassNotFoundException` / `NoClassDefFoundError` only)
- resolves `StackWalker` / `StackFrame` from `StackWalkerStrategy`'s defining loader (system loader if that is bootstrap `null`), since those types are JDK classes and do not need the TCCL

Fixes #3460

Following this checklist to help us incorporate your contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`).

Validation (JDK 21, Maven 3.9.11):

 - `mvn -pl surefire-api -Dtest=ReflectionUtilsTest,StackTraceProviderTest test` — 23 tests, 0 failures
 - `mvn -pl surefire-api test` — 217 tests, 0 failures, 6 skipped

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

