### PR TITLE
[Issue-3456] Apply systemPropertyVariables before the fork initializes networking

### DIFF
--- a/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
+++ b/surefire-booter/src/main/java/org/apache/maven/surefire/booter/ForkedBooter.java
@@ -19,6 +19,7 @@
 package org.apache.maven.surefire.booter;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
@@ -109,9 +110,15 @@ public final class ForkedBooter {
     private void setupBooter(
             String tmpDir, String dumpFileName, String surefirePropsFileName, String effectiveSystemPropertiesFileName)
             throws IOException {
+        // The user's system properties must be applied before anything else in this JVM touches a subsystem which
+        // reads them only once, at initialization time. The JDK networking layer is such a subsystem: loading the
+        // native "net" library snapshots java.net.preferIPv4Stack (and java.net.preferIPv6Addresses), so a fork which
+        // has already initialized it silently ignores these properties. Keep this the very first statement here, and
+        // keep everything it transitively calls free of java.nio, which loads that library. See GitHub issue #3456.
+        setSystemProperties(new File(tmpDir, effectiveSystemPropertiesFileName));
+
         BooterDeserializer booterDeserializer =
                 new BooterDeserializer(createSurefirePropertiesIfFileExists(tmpDir, surefirePropsFileName));
-        setSystemProperties(new File(tmpDir, effectiveSystemPropertiesFileName));
 
         providerConfiguration = booterDeserializer.deserialize();
         discoverTestsOutputFile = booterDeserializer.getDiscoverTestsOutputFile();
@@ -558,10 +565,16 @@ public final class ForkedBooter {
         return executor;
     }
 
+    /**
+     * Deliberately uses {@link FileInputStream} instead of {@link java.nio.file.Files#newInputStream}: the latter
+     * initializes {@code sun.nio.ch.IOUtil}, which loads the native "net" library and therefore freezes
+     * {@code java.net.preferIPv4Stack} before the user's {@code systemPropertyVariables} could ever be applied.
+     * See GitHub issue #3456.
+     */
     private static InputStream createSurefirePropertiesIfFileExists(String tmpDir, String propFileName)
             throws IOException {
         File surefirePropertiesFile = new File(tmpDir, propFileName);
-        return surefirePropertiesFile.exists() ? Files.newInputStream(surefirePropertiesFile.toPath()) : null;
+        return surefirePropertiesFile.exists() ? new FileInputStream(surefirePropertiesFile) : null;
     }
 
     private static boolean isDebugging() {

--- a/surefire-booter/src/test/java/org/apache/maven/surefire/booter/ForkedBooterMockTest.java
+++ b/surefire-booter/src/test/java/org/apache/maven/surefire/booter/ForkedBooterMockTest.java
@@ -21,7 +21,9 @@ package org.apache.maven.surefire.booter;
 import javax.annotation.Nonnull;
 
 import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
@@ -31,6 +33,8 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
@@ -47,9 +51,11 @@ import org.apache.maven.surefire.booter.spi.SurefireMasterProcessChannelProcesso
 import org.apache.maven.surefire.shared.utils.cli.ShutdownHookUtils;
 import org.apache.maven.surefire.spi.MasterProcessChannelProcessorFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.maven.surefire.api.util.internal.Channels.newBufferedChannel;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -100,6 +106,29 @@ public class ForkedBooterMockTest {
             }
         }
         throw new NoSuchFieldException(fieldName);
+    }
+
+    @Test
+    public void shouldReadSurefirePropertiesWithoutInitializingNio(@TempDir Path tmpDir) throws Exception {
+        // ForkedBooter must not touch java.nio channels before it applies the effective system properties:
+        // sun.nio.ch.IOUtil loads the native "net" library, which freezes java.net.preferIPv4Stack for the whole
+        // JVM. Files.newInputStream() would do exactly that, java.io.FileInputStream does not.
+        // See https://github.com/apache/maven-surefire/issues/3456
+        Path propertiesFile = tmpDir.resolve("surefire.properties");
+        Files.write(propertiesFile, singletonList("key=value"));
+
+        try (InputStream stream = (InputStream) invokeMethod(
+                ForkedBooter.class, "createSurefirePropertiesIfFileExists", tmpDir.toString(), "surefire.properties")) {
+            assertThat(stream).isInstanceOf(FileInputStream.class);
+        }
+    }
+
+    @Test
+    public void shouldNotCreateSurefirePropertiesStreamForMissingFile(@TempDir Path tmpDir) throws Exception {
+        InputStream stream = (InputStream)
+                invokeMethod(ForkedBooter.class, "createSurefirePropertiesIfFileExists", tmpDir.toString(), "absent");
+
+        assertThat(stream).isNull();
     }
 
     @Test

--- a/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3456PreferIPv4StackIT.java
+++ b/surefire-its/src/test/java/org/apache/maven/surefire/its/jiras/Surefire3456PreferIPv4StackIT.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.surefire.its.jiras;
+
+import org.apache.maven.surefire.its.fixture.SurefireJUnit4IntegrationTestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+/**
+ * The fork must apply {@code systemPropertyVariables} before it initializes anything which reads them once and
+ * caches the result. The JDK networking layer is such a case: loading the native "net" library freezes
+ * {@code java.net.preferIPv4Stack}, so a fork which touched {@code java.nio} channels first silently kept the IPv6
+ * stack.
+ * <p>
+ * Not applicable on Windows, where {@code sun.nio.fs.WindowsNativeDispatcher} loads the native "net" library itself
+ * ("nio.dll has dependency on net.dll"). Any jar on the class path is enough to trigger it during JVM start-up, so
+ * no forked JVM can honour {@code java.net.preferIPv4Stack} set from within {@code main}.
+ *
+ * @see <a href="https://github.com/apache/maven-surefire/issues/3456">GitHub issue #3456</a>
+ */
+public class Surefire3456PreferIPv4StackIT extends SurefireJUnit4IntegrationTestCase {
+
+    @Test
+    void preferIPv4StackIsAppliedBeforeNetworkingIsInitialized() {
+        assumeFalse(IS_OS_WINDOWS);
+
+        executeErrorFreeTest("surefire-3456-prefer-ipv4-stack", 1);
+    }
+}

--- a/surefire-its/src/test/resources/surefire-3456-prefer-ipv4-stack/pom.xml
+++ b/surefire-its/src/test/resources/surefire-3456-prefer-ipv4-stack/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.surefire</groupId>
+    <artifactId>surefire-3456-prefer-ipv4-stack</artifactId>
+    <version>1.0</version>
+    <name>Test for: systemPropertyVariables are applied before the fork initializes networking</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/surefire-its/src/test/resources/surefire-3456-prefer-ipv4-stack/src/test/java/issue3456/PreferIPv4StackTest.java
+++ b/surefire-its/src/test/resources/surefire-3456-prefer-ipv4-stack/src/test/java/issue3456/PreferIPv4StackTest.java
@@ -1,0 +1,44 @@
+package issue3456;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that {@code java.net.preferIPv4Stack}, configured through {@code systemPropertyVariables}, is applied
+ * early enough in the fork to actually switch the JVM to the IPv4 stack.
+ * <p>
+ * When the property arrives after the native "net" library has been loaded, the JVM keeps the dual/IPv6 stack and
+ * {@link NetworkInterface} still reports IPv6 addresses. On a host without any IPv6 address the second assertion is
+ * satisfied trivially; the first one still guards the plain propagation of the property.
+ */
+public class PreferIPv4StackTest {
+
+    @Test
+    public void preferIPv4StackIsEffective() throws Exception {
+        assertEquals(
+                "property not propagated to the fork", "true", System.getProperty("java.net.preferIPv4Stack"));
+
+        List<String> ipv6Addresses = new ArrayList<>();
+        for (NetworkInterface ni : Collections.list(NetworkInterface.getNetworkInterfaces())) {
+            for (InetAddress address : Collections.list(ni.getInetAddresses())) {
+                if (address instanceof Inet6Address) {
+                    ipv6Addresses.add(ni.getName() + " -> " + address);
+                }
+            }
+        }
+
+        assertTrue(
+                "the fork still runs on the IPv6 stack, java.net.preferIPv4Stack was applied too late: "
+                        + ipv6Addresses,
+                ipv6Addresses.isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes #3456.

## What

`systemPropertyVariables` were applied too late in the forked JVM, so `java.net.preferIPv4Stack` (and `java.net.preferIPv6Addresses`) were silently ignored and the fork kept running on the IPv6 stack. Reported against 3.6.0, hit by Hadoop in [HADOOP-19964](https://issues.apache.org/jira/browse/HADOOP-19964).

## Why

`ForkedBooter#setupBooter` read the booter properties file *before* applying the effective system properties:

```java
BooterDeserializer booterDeserializer =
        new BooterDeserializer(createSurefirePropertiesIfFileExists(tmpDir, surefirePropsFileName));
setSystemProperties(new File(tmpDir, effectiveSystemPropertiesFileName));
```

That was harmless while the file was read with `FileInputStream`. In 3.6.0, commit 0c24343 (#3179) changed `createSurefirePropertiesIfFileExists` to `java.nio.file.Files.newInputStream`, and that call chain is:

`Files.newInputStream` → `FileChannel` → `sun.nio.ch.UnixFileDispatcherImpl` (`WindowsFileDispatcherImpl`) → `static { IOUtil.load(); }` → `BootLoader.loadLibrary("net")`

libnet's `JNI_OnLoad` calls `Boolean.getBoolean("java.net.preferIPv4Stack")` once and caches the answer in `ipv6_available`. So by the time `setSystemProperties` ran, the networking stack was already fixed, and the property had no effect — silently, and only on machines that actually have IPv6.

Ordinary `java.nio.file` calls are *not* enough to trigger this on Unix — `sun.nio.fs.UnixNativeDispatcher` loads only `"nio"` — which is why the file-reading path specifically is what regressed.

## How

* `setSystemProperties(...)` is now the first statement of `setupBooter`, before anything else in the fork runs.
* `createSurefirePropertiesIfFileExists` uses `FileInputStream` again, so the guarantee does not silently depend on which java.io/java.nio API a future change happens to pick. Both spots carry a comment explaining why.

## Platform caveat

Windows cannot be fixed this way and never worked, including before 3.6.0. `sun.nio.fs.WindowsNativeDispatcher` loads the native library itself:

```java
static {
    // nio.dll has dependency on net.dll
    jdk.internal.loader.BootLoader.loadLibrary("net");
    jdk.internal.loader.BootLoader.loadLibrary("nio");
    initIDs();
}
```

Opening any jar on the class path reaches that (`ZipFile$Source` stats the file through `java.nio.file`), so `java.net.preferIPv4Stack` is already frozen before `main` runs. Users who need it on Windows have to pass `-Djava.net.preferIPv4Stack=true` via `argLine`. The new integration test is skipped on Windows for this reason.

## Tests

* `ForkedBooterMockTest.shouldReadSurefirePropertiesWithoutInitializingNio` — pins the booter properties file to a non-NIO stream. Fails on the 3.6.0 code, passes with this change.
* `Surefire3456PreferIPv4StackIT` — runs a project configured with `<java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>` in `systemPropertyVariables` and asserts the fork really is on the IPv4 stack (no `Inet6Address` reported by `NetworkInterface`). Skipped on Windows per the caveat above.

Verified locally: `mvn clean install` is green, and `ForkedBooterMockTest` fails as expected when the `Files.newInputStream` call is put back. The new IT was exercised on Windows only, where it fails without the fix on the property-propagation path and is skipped by the OS assumption in its final form — I have no Linux box here, so the IT's positive path needs CI to confirm.

## Checklist

- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Run `mvn clean install` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its clean install`). — only the new IT was run locally; the full suite was not.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
