### PR TITLE
Implement getOutputPath() and deprecate getOutputName()

### DIFF
--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/AbstractSurefireReport.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/AbstractSurefireReport.java
@@ -307,7 +307,7 @@ public abstract class AbstractSurefireReport extends AbstractMavenReport {
      * {@inheritDoc}
      */
     @Override
-    public abstract String getOutputName();
+    public abstract String getOutputPath();
 
     protected final ConsoleLogger getConsoleLogger() {
         return new PluginConsoleLogger(getLog());

--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/FailsafeOnlyReport.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/FailsafeOnlyReport.java
@@ -74,8 +74,17 @@ public class FailsafeOnlyReport extends AbstractSurefireReport {
         return new File(buildDir, "failsafe-reports");
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
     @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    @Override
+    public String getOutputPath() {
         return outputName;
     }
 

--- a/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReport.java
+++ b/maven-surefire-report-plugin/src/main/java/org/apache/maven/plugins/surefire/report/SurefireReport.java
@@ -73,8 +73,17 @@ public class SurefireReport extends AbstractSurefireReport {
         return new File(buildDir, "surefire-reports");
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
     @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    @Override
+    public String getOutputPath() {
         return outputName;
     }
 


### PR DESCRIPTION
Adopts the report output method that Maven Reporting API 4.0.0 introduced, following the pattern in the [report plugin guide](https://maven.apache.org/guides/plugin/guide-java-report-plugin-development.html) and already used by maven-javadoc-plugin and maven-pmd-plugin: `getOutputPath()` carries the value, and `getOutputName()` stays as a deprecated delegate because the API still declares it abstract.

Both reports return the configurable `outputName` parameter as before, so the rendered paths do not change. `AbstractSurefireReport` now declares `getOutputPath()` abstract instead of `getOutputName()`.

The `surefire-3.5.x` line is not touched: it is the Doxia 1 line for this plugin and Maven Reporting API 3.x has no `getOutputPath()`.

Verified: `mvn test -pl maven-surefire-report-plugin` → 14 tests, 0 failures.

*This change was created with AI assistance.*
