### PR TITLE
Avoid quadratic XML report writes for ParameterizedClass

### DIFF
--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/RunListenerAdapter.java
@@ -85,6 +85,13 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     private final ConcurrentMap<TestIdentifier, Long> testStartTime = new ConcurrentHashMap<>();
     private final ConcurrentMap<TestIdentifier, TestExecutionResult> failures = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, TestIdentifier> runningTestIdentifiersByUniqueId = new ConcurrentHashMap<>();
+    /** Test sources observed below each report root in the current execution plan. */
+    private final ConcurrentMap<String, Set<String>> classSourcesByRoot = new ConcurrentHashMap<>();
+    /** The latest completion report for each source, used when the top-level container is flushed. */
+    private final ConcurrentMap<String, ConcurrentMap<String, SimpleReportEntry>> classReportsByRoot =
+            new ConcurrentHashMap<>();
+    /** A source gets one test-set-start event per report root. */
+    private final Set<String> startedClassSources = ConcurrentHashMap.newKeySet();
     // Some custom runners execute tests removed by post-discovery filtering. Do not
     // report those executions or associate their output with a targeted rerun.
     private final ThreadLocal<Boolean> suppressOutput = new ThreadLocal<>();
@@ -113,10 +120,14 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {
         this.testPlan = testPlan;
+        classSourcesByRoot.clear();
+        classReportsByRoot.clear();
+        startedClassSources.clear();
     }
 
     @Override
     public void testPlanExecutionFinished(TestPlan testPlan) {
+        flushAllClassRoots();
         this.testPlan = null;
         testStartTime.clear();
         suppressOutput.remove();
@@ -134,7 +145,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
         if (isClassContainer(testIdentifier)) {
             testStartTime.put(testIdentifier, System.currentTimeMillis());
-            runListener.testSetStarting(createReportEntry(testIdentifier));
+            startClassTestSet(testIdentifier);
         } else if (testIdentifier.isTest()) {
             testStartTime.put(testIdentifier, System.currentTimeMillis());
             runListener.testStarting(createReportEntry(testIdentifier));
@@ -188,8 +199,13 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                         runListener.testError(reportEntry);
                     }
                     if (isClass || isRootContainer) {
-                        runListener.testSetCompleted(
-                                createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
+                        SimpleReportEntry completion =
+                                createReportEntry(testIdentifier, null, systemProps(), null, elapsed);
+                        if (isClass) {
+                            completeClassContainer(testIdentifier, completion);
+                        } else {
+                            runListener.testSetCompleted(completion);
+                        }
                     }
                     // Do not record AfterAll/AfterClass container failures for rerun: the test
                     // methods already passed, and re-executing them cannot fix a deterministic
@@ -207,8 +223,13 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                             classesWithSuccessfulTests.add(succeeded.getSourceName());
                         }
                     } else {
-                        runListener.testSetCompleted(
-                                createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
+                        SimpleReportEntry completion =
+                                createReportEntry(testIdentifier, null, systemProps(), null, elapsed);
+                        if (isClass) {
+                            completeClassContainer(testIdentifier, completion);
+                        } else {
+                            runListener.testSetCompleted(completion);
+                        }
                     }
             }
         }
@@ -219,7 +240,8 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
     private void reportAbortedClass(
             TestIdentifier testIdentifier, TestExecutionResult testExecutionResult, Integer elapsed) {
         if (classContainersWithStartedTests.contains(testIdentifier.getUniqueId())) {
-            runListener.testSetCompleted(
+            completeClassContainer(
+                    testIdentifier,
                     createReportEntry(testIdentifier, testExecutionResult, systemProps(), null, elapsed));
             return;
         }
@@ -241,7 +263,7 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
             }
         }
 
-        runListener.testSetCompleted(createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
+        completeClassContainer(testIdentifier, createReportEntry(testIdentifier, null, systemProps(), null, elapsed));
     }
 
     private void recordStartedTest(TestIdentifier testIdentifier) {
@@ -266,6 +288,94 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
                         .getSource()
                         .filter(ClassSource.class::isInstance)
                         .isPresent();
+    }
+
+    private void startClassTestSet(TestIdentifier testIdentifier) {
+        String sourceName = getClassSourceName(testIdentifier);
+        if (sourceName == null) {
+            return;
+        }
+        String rootId = getClassRootId(testIdentifier);
+        classSourcesByRoot.computeIfAbsent(rootId, ignored -> ConcurrentHashMap.newKeySet()).add(sourceName);
+        classReportsByRoot
+                .computeIfAbsent(rootId, ignored -> new ConcurrentHashMap<>())
+                .putIfAbsent(sourceName, createReportEntry(testIdentifier));
+        if (startedClassSources.add(classSourceKey(rootId, sourceName))) {
+            runListener.testSetStarting(createReportEntry(testIdentifier));
+        }
+    }
+
+    private void completeClassContainer(TestIdentifier testIdentifier, SimpleReportEntry completion) {
+        String sourceName = getClassSourceName(testIdentifier);
+        if (sourceName == null) {
+            runListener.testSetCompleted(completion);
+            return;
+        }
+        String rootId = getClassRootId(testIdentifier);
+        classSourcesByRoot.computeIfAbsent(rootId, ignored -> ConcurrentHashMap.newKeySet()).add(sourceName);
+        classReportsByRoot
+                .computeIfAbsent(rootId, ignored -> new ConcurrentHashMap<>())
+                .put(sourceName, completion);
+        if (rootId.equals(testIdentifier.getUniqueId())) {
+            flushClassRoot(rootId);
+        }
+    }
+
+    private void flushAllClassRoots() {
+        for (String rootId : new LinkedHashSet<>(classSourcesByRoot.keySet())) {
+            flushClassRoot(rootId);
+        }
+    }
+
+    private void flushClassRoot(String rootId) {
+        Set<String> sourceNames = classSourcesByRoot.remove(rootId);
+        Map<String, SimpleReportEntry> reports = classReportsByRoot.remove(rootId);
+        if (sourceNames == null || reports == null) {
+            return;
+        }
+        for (String sourceName : sourceNames) {
+            SimpleReportEntry report = reports.get(sourceName);
+            if (report != null) {
+                runListener.testSetCompleted(report);
+            }
+            startedClassSources.remove(classSourceKey(rootId, sourceName));
+        }
+    }
+
+    private String getClassRootId(TestIdentifier testIdentifier) {
+        if (!hasClassTemplateInvocation(testIdentifier.getUniqueId())) {
+            return testIdentifier.getUniqueId();
+        }
+        TestIdentifier root = testIdentifier;
+        Optional<TestIdentifier> parent = resolveParent(root);
+        while (parent.isPresent()) {
+            if (isClassContainer(parent.get())) {
+                root = parent.get();
+            }
+            parent = resolveParent(parent.get());
+        }
+        return root.getUniqueId();
+    }
+
+    private static String classSourceKey(String rootId, String sourceName) {
+        return rootId + '\n' + sourceName;
+    }
+
+    private static boolean hasClassTemplateInvocation(String uniqueId) {
+        try {
+            return UniqueId.parse(uniqueId).getSegments().stream()
+                    .anyMatch(segment -> "class-template-invocation".equals(segment.getType()));
+        } catch (RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    private static String getClassSourceName(TestIdentifier testIdentifier) {
+        return testIdentifier.getSource()
+                .filter(ClassSource.class::isInstance)
+                .map(ClassSource.class::cast)
+                .map(ClassSource::getClassName)
+                .orElse(null);
     }
 
     private Integer computeElapsedTime(TestIdentifier testIdentifier) {
@@ -337,11 +447,11 @@ final class RunListenerAdapter implements TestExecutionListener, TestOutputRecei
 
         if (isClass) {
             SimpleReportEntry report = createReportEntry(testIdentifier);
-            runListener.testSetStarting(report);
+            startClassTestSet(testIdentifier);
             for (TestIdentifier child : testPlan.getChildren(testIdentifier)) {
                 runListener.testSkipped(createReportEntry(child, null, emptyMap(), reason, null));
             }
-            runListener.testSetCompleted(report);
+            completeClassContainer(testIdentifier, report);
         } else {
             runListener.testSkipped(createReportEntry(testIdentifier, null, emptyMap(), reason, null));
         }

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/RunListenerAdapterTest.java
@@ -287,6 +287,71 @@ public class RunListenerAdapterTest {
     }
 
     @Test
+    public void completesParameterizedClassReportOnceAfterAllInvocations() throws Exception {
+        EngineDescriptor engine = new EngineDescriptor(UniqueId.forEngine("junit-jupiter"), "JUnit Jupiter");
+        TestDescriptor classTemplate = newParameterizedClassTemplateDescriptor(engine.getUniqueId());
+        engine.addChild(classTemplate);
+
+        TestDescriptor invocation1 = newParameterizedClassInvocationDescriptor(classTemplate.getUniqueId(), 1);
+        TestDescriptor method1 = newUnparameterizedMethodDescriptor(invocation1.getUniqueId());
+        classTemplate.addChild(invocation1);
+        invocation1.addChild(method1);
+
+        TestDescriptor invocation2 = newParameterizedClassInvocationDescriptor(classTemplate.getUniqueId(), 2);
+        TestDescriptor method2 = newUnparameterizedMethodDescriptor(invocation2.getUniqueId());
+        classTemplate.addChild(invocation2);
+        invocation2.addChild(method2);
+
+        TestPlan plan = TestPlan.from(false, singletonList(engine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(engine));
+        adapter.executionStarted(TestIdentifier.from(classTemplate));
+        adapter.executionStarted(TestIdentifier.from(invocation1));
+        adapter.executionStarted(TestIdentifier.from(method1));
+        adapter.executionFinished(TestIdentifier.from(method1), successful());
+        adapter.executionFinished(TestIdentifier.from(invocation1), successful());
+        adapter.executionStarted(TestIdentifier.from(invocation2));
+        adapter.executionStarted(TestIdentifier.from(method2));
+        adapter.executionFinished(TestIdentifier.from(method2), successful());
+        adapter.executionFinished(TestIdentifier.from(invocation2), successful());
+
+        verify(listener, times(1)).testSetStarting(any());
+        verify(listener, never()).testSetCompleted(any());
+
+        adapter.executionFinished(TestIdentifier.from(classTemplate), successful());
+
+        verify(listener, times(1)).testSetCompleted(any());
+    }
+
+    @Test
+    public void completesNestedClassReportBeforeOuterClass() {
+        EngineDescriptor engine = new EngineDescriptor(UniqueId.forEngine("junit-jupiter"), "JUnit Jupiter");
+        TestDescriptor outerClass = newClassDescriptor();
+        TestDescriptor nestedClass = new ClassTestDescriptor(
+                outerClass.getUniqueId().append("nested-class", MySuiteClass.class.getName()),
+                MySuiteClass.class,
+                new DefaultJupiterConfiguration(CONFIG_PARAMS, OUTPUT_DIRECTORY));
+        engine.addChild(outerClass);
+        outerClass.addChild(nestedClass);
+
+        TestPlan plan = TestPlan.from(false, singletonList(engine), CONFIG_PARAMS, OUTPUT_DIRECTORY);
+        adapter.testPlanExecutionStarted(plan);
+
+        adapter.executionStarted(TestIdentifier.from(engine));
+        adapter.executionStarted(TestIdentifier.from(outerClass));
+        adapter.executionStarted(TestIdentifier.from(nestedClass));
+        adapter.executionFinished(TestIdentifier.from(nestedClass), successful());
+
+        verify(listener, times(2)).testSetStarting(any());
+        verify(listener, times(1)).testSetCompleted(any());
+
+        adapter.executionFinished(TestIdentifier.from(outerClass), successful());
+
+        verify(listener, times(2)).testSetCompleted(any());
+    }
+
+    @Test
     public void distinguishedNestedJUnit6ParameterizedClassInvocations() throws Exception {
         EngineDescriptor engine = new EngineDescriptor(UniqueId.forEngine("junit-jupiter"), "JUnit Jupiter");
         TestDescriptor outerTemplate = newParameterizedClassTemplateDescriptor(engine.getUniqueId());


### PR DESCRIPTION
Following the Maven Surefire contribution checklist:

- [x] The commit has a meaningful subject and body.
- [x] The pull request description explains the behavior, cause, and fix.
- [x] Module verification and focused tests were run locally.
- [ ] The full integration-test profile was not run locally.

Fixes #3439.

JUnit 5.14 ParameterizedClass emits one ClassSource across multiple class-template-invocation containers. RunListenerAdapter previously opened and closed the same test set for every invocation. StatelessXmlReporter then rewrote the accumulated report after each invocation, making the write cost quadratic in the number of invocations.

This keeps the report lifecycle open for a parameterized class branch and flushes the collected source reports once the class template completes. Ordinary nested class containers retain their independent lifecycles.

Validation:
- mvn -Denforcer.skip=true -DskipTests -pl surefire-providers/surefire-junit-platform -am verify
- RunListenerAdapterTest: 40 tests passed via the JUnit Platform launcher
- StatelessXmlReporterTest: 14 tests passed via the JUnit Platform launcher
- JUnit 5.14.4 sample with three @ParameterizedClass values: one XML report with tests="3" and all three invocation testcases