### PR TITLE
[SUREFIRE-3468] Handle non-reflective JUnit Platform method sources

### DIFF
--- a/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
+++ b/surefire-providers/surefire-junit-platform/src/main/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProvider.java
@@ -53,6 +53,7 @@ import org.apache.maven.surefire.api.util.ReflectionUtils;
 import org.apache.maven.surefire.api.util.ScanResult;
 import org.apache.maven.surefire.api.util.TestsToRun;
 import org.apache.maven.surefire.shared.utils.StringUtils;
+import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.FilterResult;
@@ -502,10 +503,7 @@ public class JUnitPlatformProvider extends AbstractProvider {
             boolean hasCategoryClass = false, hasCategoryMethod = false;
             if (methodSource.isPresent()) {
                 if (categoryClass.isPresent()) {
-                    hasCategoryMethod = hasCategoryAnnotationValue(
-                                    methodSource.get().getJavaMethod(), categoryClass.orElse(null), categories)
-                            || hasCategoryAnnotationValue(
-                                    methodSource.get().getJavaClass(), categoryClass.orElse(null), categories);
+                    hasCategoryMethod = hasCategoryAnnotationValue(methodSource.get(), categoryClass.get(), categories);
                 }
             }
 
@@ -536,10 +534,7 @@ public class JUnitPlatformProvider extends AbstractProvider {
             boolean hasCategoryClass = false, hasCategoryMethod = false;
             if (methodSource.isPresent()) {
                 if (categoryClass.isPresent()) {
-                    hasCategoryMethod = hasCategoryAnnotationValue(
-                                    methodSource.get().getJavaMethod(), categoryClass.orElse(null), categories)
-                            || hasCategoryAnnotationValue(
-                                    methodSource.get().getJavaClass(), categoryClass.orElse(null), categories);
+                    hasCategoryMethod = hasCategoryAnnotationValue(methodSource.get(), categoryClass.get(), categories);
                 }
             }
 
@@ -566,6 +561,19 @@ public class JUnitPlatformProvider extends AbstractProvider {
 
     private boolean hasCategoryAnnotationValue(Method method, Class<?> categoryClass, List<String> categories) {
         return hasCategoryAnnotationValue(method.getAnnotations(), categoryClass, categories);
+    }
+
+    private boolean hasCategoryAnnotationValue(
+            MethodSource methodSource, Class<?> categoryClass, List<String> categories) {
+        if (hasCategoryAnnotationValue(methodSource.getJavaClass(), categoryClass, categories)) {
+            return true;
+        }
+        try {
+            return hasCategoryAnnotationValue(methodSource.getJavaMethod(), categoryClass, categories);
+        } catch (PreconditionViolationException e) {
+            // Some engines use display names instead of reflective method names in their MethodSource.
+            return false;
+        }
     }
 
     private boolean hasCategoryAnnotationValue(

--- a/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
+++ b/surefire-providers/surefire-junit-platform/src/test/java/org/apache/maven/surefire/junitplatform/JUnitPlatformProviderTest.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
@@ -47,6 +48,7 @@ import org.apache.maven.surefire.api.testset.TestSetFailedException;
 import org.apache.maven.surefire.api.util.RunOrderCalculator;
 import org.apache.maven.surefire.api.util.ScanResult;
 import org.apache.maven.surefire.api.util.TestsToRun;
+import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -61,6 +63,7 @@ import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.EngineFilter;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.LauncherSession;
@@ -86,6 +89,7 @@ import static org.apache.maven.surefire.api.booter.ProviderParameterNames.EXCLUD
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.GROUPS_PROP;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.INCLUDES_SCAN_LIST;
 import static org.apache.maven.surefire.api.booter.ProviderParameterNames.INCLUDE_JUNIT5_ENGINES_PROP;
+import static org.apache.maven.surefire.api.booter.ProviderParameterNames.JUNIT_VINTAGE_DETECTED;
 import static org.apache.maven.surefire.api.report.RunMode.NORMAL_RUN;
 import static org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.CONFIGURATION_PARAMETERS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1144,6 +1148,38 @@ public class JUnitPlatformProviderTest {
         JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
 
         assertEquals(3, provider.getFilters().length);
+    }
+
+    @Test
+    public void categoryFiltersIgnoreUnresolvableMethodSources() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JUNIT_VINTAGE_DETECTED, "true");
+        properties.put(GROUPS_PROP, "category");
+        properties.put(EXCLUDEDGROUPS_PROP, "category");
+
+        ProviderParameters providerParameters = providerParametersMock(TestClass1.class);
+        when(providerParameters.getProviderProperties()).thenReturn(properties);
+
+        JUnitPlatformProvider provider = new JUnitPlatformProvider(providerParameters);
+        TestDescriptor descriptor =
+                new AbstractTestDescriptor(
+                        UniqueId.forEngine("spock")
+                                .append("spec", "ExampleSpec")
+                                .append("feature", "addition works"),
+                        "addition works",
+                        MethodSource.from(TestClass1.class.getName(), "addition works")) {
+                    @Override
+                    public Type getType() {
+                        return Type.TEST;
+                    }
+                };
+
+        assertFalse(provider.getIncludeCategoryFilter(Arrays.asList("category"), Optional.of(Category.class))
+                .apply(descriptor)
+                .included());
+        assertTrue(provider.getExcludeCategoryFilter(Arrays.asList("category"), Optional.of(Category.class))
+                .apply(descriptor)
+                .included());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Avoid resolving `MethodSource#getJavaMethod()` before checking the declaring class for JUnit 4 categories.
- Treat method sources that only expose a Spock feature display name as having no method-level category, so `<groups>` and `<excludedGroups>` discovery can complete.
- Add a regression test covering both include and exclude category filters with a non-reflective method source.

Fixes #3468

## Verification

- Surefire JUnit Platform provider tests: 114 tests, 0 failures, 0 errors.
- Checkstyle: 0 violations.
- Reproduced the Spock + JUnit 4 + `<excludedGroups>` scenario: fixed build ran 2 tests successfully.